### PR TITLE
Fixed cutscene editing only for primary scene header

### DIFF
--- a/fast64_internal/oot/oot_scene_room.py
+++ b/fast64_internal/oot/oot_scene_room.py
@@ -677,7 +677,7 @@ def drawSceneHeaderProperty(layout, sceneProp, dropdownLabel, headerIndex, objNa
 			r.prop(sceneProp, "csTermIdx", text = "Index")
 			r.prop(sceneProp, "csTermStart", text = "Start Frm")
 			r.prop(sceneProp, "csTermEnd", text = "End Frm")
-		tempHeaderIndex = headerIndex - 4 if headerIndex is not None and headerIndex >= 4 else -1
+		tempHeaderIndex = 0 if headerIndex is None else headerIndex
 		for i, p in enumerate(sceneProp.csLists):
 			drawCSListProperty(cutscene, p, i, objName, tempHeaderIndex)
 		drawCSAddButtons(cutscene, objName, tempHeaderIndex)

--- a/fast64_internal/oot/oot_scene_room.py
+++ b/fast64_internal/oot/oot_scene_room.py
@@ -289,12 +289,13 @@ class OOTCSProperty():
 	def filterName(self, name, listProp):
 		return name
 	
-	def draw(self, layout, listProp, listIndex, cmdIndex, objName):
+	def draw(self, layout, listProp, listIndex, cmdIndex, objName, headerIndex):
 		layout.prop(self, 'expandTab', text = self.getName() + " " + str(cmdIndex),
 			icon = 'TRIA_DOWN' if self.expandTab else 'TRIA_RIGHT')
 		if not self.expandTab: return
 		box = layout.box().column()
-		drawCollectionOps(box, cmdIndex, "CS." + self.attrName, listIndex, objName)
+		drawCollectionOps(box, cmdIndex, 
+			"CSHdr." + str(headerIndex) + "." + self.attrName, listIndex, objName)
 		for p in self.subprops:
 			if self.filterProp(p, listProp):
 				prop_split(box, self, p, self.filterName(p, listProp))
@@ -330,12 +331,13 @@ class OOTCSTextboxAdd(bpy.types.Operator):
 	bl_label = 'Add CS Textbox'
 	bl_options = {'REGISTER', 'UNDO'} 
 
+	collectionType : bpy.props.StringProperty()
 	textboxType : bpy.props.EnumProperty(items = ootEnumCSTextboxType)
 	listIndex : bpy.props.IntProperty()
 	objName : bpy.props.StringProperty()
 
 	def execute(self, context):
-		collection = bpy.data.objects[self.objName].ootSceneHeader.csLists[self.listIndex].textbox
+		collection = getCollection(self.objName, self.collectionType, self.listIndex)
 		collection.add()
 		collection[len(collection)-1].textboxType = self.textboxType
 		#self.report({'INFO'}, 'Success!')
@@ -466,13 +468,13 @@ class OOTCSListProperty(bpy.types.PropertyGroup):
 	fxStartFrame : bpy.props.IntProperty(name = '', default = 0, min = 0)
 	fxEndFrame : bpy.props.IntProperty(name = '', default = 1, min = 0)
 
-def drawCSListProperty(layout, listProp, listIndex, objName):
+def drawCSListProperty(layout, listProp, listIndex, objName, headerIndex):
 	layout.prop(listProp, 'expandTab', 
 		text = listProp.listType + ' List' if listProp.listType != 'FX' else 'Scene Trans FX',
 		icon = 'TRIA_DOWN' if listProp.expandTab else 'TRIA_RIGHT')
 	if not listProp.expandTab: return
 	box = layout.box().column()
-	drawCollectionOps(box, listIndex, "CS", None, objName, False)
+	drawCollectionOps(box, listIndex, "CSHdr." + str(headerIndex), None, objName, False)
 	
 	if listProp.listType == "Textbox":
 		attrName = "textbox"
@@ -499,20 +501,21 @@ def drawCSListProperty(layout, listProp, listIndex, objName):
 		
 	dat = getattr(listProp, attrName)
 	for i, p in enumerate(dat):
-		p.draw(box, listProp, listIndex, i, objName)
+		p.draw(box, listProp, listIndex, i, objName, headerIndex)
 	if len(dat) == 0:
 		box.label(text = "No items in " + listProp.listType + " List.")
 	if listProp.listType == "Textbox":
 		row = box.row(align=True)
 		for l in range(3):
 			addOp = row.operator(OOTCSTextboxAdd.bl_idname, text = 'Add ' + ootEnumCSTextboxType[l][1], icon = ootEnumCSTextboxTypeIcons[l])
+			addOp.collectionType = "CSHdr." + str(headerIndex) + '.textbox'
 			addOp.textboxType = ootEnumCSTextboxType[l][0]
 			addOp.listIndex = listIndex
 			addOp.objName = objName
 	else:
 		addOp = box.operator(OOTCollectionAdd.bl_idname, text = 'Add item to ' + listProp.listType + ' List')
 		addOp.option = len(dat)
-		addOp.collectionType = "CS." + attrName
+		addOp.collectionType = "CSHdr." + str(headerIndex) + '.' + attrName
 		addOp.subIndex = listIndex
 		addOp.objName = objName
 
@@ -522,20 +525,22 @@ class OOTCSListAdd(bpy.types.Operator):
 	bl_label = 'Add CS List'
 	bl_options = {'REGISTER', 'UNDO'} 
 
+	collectionType : bpy.props.StringProperty()
 	listType : bpy.props.EnumProperty(items = ootEnumCSListType)
 	objName : bpy.props.StringProperty()
 
 	def execute(self, context):
-		collection = bpy.data.objects[self.objName].ootSceneHeader.csLists
+		collection = getCollection(self.objName, self.collectionType, None)
 		collection.add()
 		collection[len(collection)-1].listType = self.listType
 		#self.report({'INFO'}, 'Success!')
 		return {'FINISHED'} 
 
-def drawCSAddButtons(layout, objName):
+def drawCSAddButtons(layout, objName, headerIndex):
 	def addButton(row):
 		nonlocal l
 		op = row.operator(OOTCSListAdd.bl_idname, text = ootEnumCSListType[l][1], icon = ootEnumCSListTypeIcons[l])
+		op.collectionType = "CSHdr." + str(headerIndex)
 		op.listType = ootEnumCSListType[l][0]
 		op.objName = objName
 		l += 1
@@ -672,9 +677,10 @@ def drawSceneHeaderProperty(layout, sceneProp, dropdownLabel, headerIndex, objNa
 			r.prop(sceneProp, "csTermIdx", text = "Index")
 			r.prop(sceneProp, "csTermStart", text = "Start Frm")
 			r.prop(sceneProp, "csTermEnd", text = "End Frm")
+		tempHeaderIndex = headerIndex - 4 if headerIndex is not None and headerIndex >= 4 else -1
 		for i, p in enumerate(sceneProp.csLists):
-			drawCSListProperty(cutscene, p, i, objName)
-		drawCSAddButtons(cutscene, objName)
+			drawCSListProperty(cutscene, p, i, objName, tempHeaderIndex)
+		drawCSAddButtons(cutscene, objName, tempHeaderIndex)
 
 	elif menuTab == 'Exits':
 		if headerIndex is None or headerIndex == 0:

--- a/fast64_internal/oot/oot_utility.py
+++ b/fast64_internal/oot/oot_utility.py
@@ -418,8 +418,8 @@ def getCollectionFromIndex(obj, prop, subIndex, isRoom):
 # Operators cannot store mutable references (?), so to reuse PropertyCollection modification code we do this.
 # Save a string identifier in the operator, then choose the member variable based on that.
 # subIndex is for a collection within a collection element
-def getCollection(obj, collectionType, subIndex):
-
+def getCollection(objName, collectionType, subIndex):
+	obj = bpy.data.objects[objName]
 	if collectionType == "Actor":	
 		collection = obj.ootActorProperty.headerSettings.cutsceneHeaders
 	elif collectionType == "Transition Actor":	
@@ -436,10 +436,18 @@ def getCollection(obj, collectionType, subIndex):
 		collection = getCollectionFromIndex(obj, 'exitList', subIndex, False)
 	elif collectionType == "Object":
 		collection = getCollectionFromIndex(obj, 'objectList', subIndex, True)
-	elif collectionType == "CS":
-		collection = obj.ootSceneHeader.csLists
-	elif collectionType.startswith("CS."):
-		collection = getattr(obj.ootSceneHeader.csLists[subIndex], collectionType[3:])
+	elif collectionType.startswith("CSHdr."):
+		# CSHdr.HeaderNumber[.ListType]
+		# Specifying ListType means uses subIndex
+		toks = collectionType.split('.')
+		assert len(toks) in [2, 3]
+		hdrnum = int(toks[1])
+		if hdrnum < 0:
+			collection = obj.ootSceneHeader.csLists
+		else:
+			collection = obj.ootAlternateSceneHeaders.cutsceneHeaders[hdrnum].csLists
+		if len(toks) == 3:
+			collection = getattr(collection[subIndex], toks[2])
 	else:
 		raise PluginError("Invalid collection type: " + collectionType)
 
@@ -498,7 +506,7 @@ class OOTCollectionAdd(bpy.types.Operator):
 	objName : bpy.props.StringProperty()
 
 	def execute(self, context):
-		collection = getCollection(bpy.data.objects[self.objName], self.collectionType, self.subIndex)
+		collection = getCollection(self.objName, self.collectionType, self.subIndex)
 
 		collection.add()
 		collection.move(len(collection)-1, self.option)
@@ -516,7 +524,7 @@ class OOTCollectionRemove(bpy.types.Operator):
 	objName : bpy.props.StringProperty()
 
 	def execute(self, context):
-		collection = getCollection(bpy.data.objects[self.objName], self.collectionType, self.subIndex)
+		collection = getCollection(self.objName, self.collectionType, self.subIndex)
 		collection.remove(self.option)
 		#self.report({'INFO'}, 'Success!')
 		return {'FINISHED'} 
@@ -533,7 +541,7 @@ class OOTCollectionMove(bpy.types.Operator):
 
 	collectionType : bpy.props.StringProperty(default = "Actor")
 	def execute(self, context):
-		collection = getCollection(bpy.data.objects[self.objName], self.collectionType, self.subIndex)
+		collection = getCollection(self.objName, self.collectionType, self.subIndex)
 		collection.move(self.option, self.option + self.offset)
 		#self.report({'INFO'}, 'Success!')
 		return {'FINISHED'} 

--- a/fast64_internal/oot/oot_utility.py
+++ b/fast64_internal/oot/oot_utility.py
@@ -442,10 +442,18 @@ def getCollection(objName, collectionType, subIndex):
 		toks = collectionType.split('.')
 		assert len(toks) in [2, 3]
 		hdrnum = int(toks[1])
-		if hdrnum < 0:
-			collection = obj.ootSceneHeader.csLists
+		if hdrnum == 0:
+			hdr = obj.ootSceneHeader.csLists
+		elif hdrnum == 1:
+			hdr = obj.ootAlternateSceneHeaders.childNightHeader
+		elif hdrnum == 2:
+			hdr = obj.ootAlternateSceneHeaders.adultDayHeader
+		elif hdrnum == 3:
+			hdr = obj.ootAlternateSceneHeaders.adultNightHeader
 		else:
-			collection = obj.ootAlternateSceneHeaders.cutsceneHeaders[hdrnum].csLists
+			assert hdrnum >= 4
+			hdr = obj.ootAlternateSceneHeaders.cutsceneHeaders[hdrnum-4]
+		collection = hdr.csLists
 		if len(toks) == 3:
 			collection = getattr(collection[subIndex], toks[2])
 	else:


### PR DESCRIPTION
Most operators / GUI code for cutscene editing was hard-coded to use only the main scene header. Adding commands to cutscenes in other headers would actually add them to the cutscene in the main header, and there was no way to add or edit commands in other headers. This has been fixed. Basic cases of editing and exporting multiple cutscenes in one scene have been tested and work.