### PR TITLE
Added interval for STS Scrolling

### DIFF
--- a/fast64_internal/f3d/f3d_gbi.py
+++ b/fast64_internal/f3d/f3d_gbi.py
@@ -1461,7 +1461,7 @@ def get_tex_sts_code(tex: FSetTileSizeScrollField, tex_num: int, cmd_num: int):
 		# get interval and variable for tracking interval
 		interval, cur_interval = get_sts_interval_vars(tex_num)
 		# pass each var and its value to variables
-		variables.extend([(interval, tex.interval), (cur_interval, 0)])
+		variables.extend([(interval, tex.interval), (cur_interval, tex.interval)])
 
 		# indent again for if statement
 		lines = [('\t' + func) for func in lines]

--- a/fast64_internal/f3d/f3d_material.py
+++ b/fast64_internal/f3d/f3d_material.py
@@ -1064,6 +1064,7 @@ def ui_tileScroll(tex, name, layout):
 	row = layout.row(heading = name)
 	row.prop(tex.tile_scroll, 's', text = 'S:')
 	row.prop(tex.tile_scroll, 't', text = 'T:')
+	row.prop(tex.tile_scroll, 'interval', text = 'Interval:')
 
 def ui_procAnimVecEnum(material, procAnimVec, layout, name, vecType, useDropdown, useTex0, useTex1):
 	layout = layout.box()
@@ -2034,6 +2035,7 @@ class TextureFieldProperty(bpy.types.PropertyGroup):
 class SetTileSizeScrollProperty(bpy.types.PropertyGroup):
 	s : bpy.props.IntProperty(min = -100, max = 100, default = 0)
 	t : bpy.props.IntProperty(min = -100, max = 100, default = 0)
+	interval : bpy.props.IntProperty(min = 1, max = 0xFFFF, default = 1)
 
 class TextureProperty(bpy.types.PropertyGroup):
 	tex : bpy.props.PointerProperty(type = bpy.types.Image, name = 'Texture', update = update_tex_values_and_formats)
@@ -2445,6 +2447,7 @@ class AddPresetF3D(AddPresetBase, Operator):
 		"f3d_mat.tex0.tile_scroll",
 		"f3d_mat.tex0.tile_scroll.s",
 		"f3d_mat.tex0.tile_scroll.t",
+		"f3d_mat.tex0.tile_scroll.interval",
 		"f3d_mat.tex1.tex",
 		"f3d_mat.tex1.tex_format",
 		"f3d_mat.tex1.ci_format",
@@ -2461,6 +2464,7 @@ class AddPresetF3D(AddPresetBase, Operator):
 		"f3d_mat.tex1.tile_scroll",
 		"f3d_mat.tex1.tile_scroll.s",
 		"f3d_mat.tex1.tile_scroll.t",
+		"f3d_mat.tex1.tile_scroll.interval",
 		"f3d_mat.tex_scale",
 		"f3d_mat.scale_autoprop",
 		"f3d_mat.uv_basis",

--- a/fast64_internal/f3d/f3d_material.py
+++ b/fast64_internal/f3d/f3d_material.py
@@ -2035,7 +2035,7 @@ class TextureFieldProperty(bpy.types.PropertyGroup):
 class SetTileSizeScrollProperty(bpy.types.PropertyGroup):
 	s : bpy.props.IntProperty(min = -100, max = 100, default = 0)
 	t : bpy.props.IntProperty(min = -100, max = 100, default = 0)
-	interval : bpy.props.IntProperty(min = 1, max = 0xFFFF, default = 1)
+	interval : bpy.props.IntProperty(min = 1, soft_max = 1000, default = 1)
 
 class TextureProperty(bpy.types.PropertyGroup):
 	tex : bpy.props.PointerProperty(type = bpy.types.Image, name = 'Texture', update = update_tex_values_and_formats)


### PR DESCRIPTION
This change allows SetTileSize scrolling to go at different intervals. One benefit of this would be having a 32x64 sized texture UV mapped to half of it (32x32), and every so often scroll S by 32, and you'd have yourself a simple animation! Or if you have scroll set to 1, this could allow you to have slower scrolling although it'd be choppier the longer the interval.


https://user-images.githubusercontent.com/79979276/128582153-0adea55a-bf18-45b5-b577-88fc79f0d3e3.mp4

