### PR TITLE
fixed bug where not having a point selected would prevent splines from being exported

### DIFF
--- a/fast64_internal/oot/oot_level_writer.py
+++ b/fast64_internal/oot/oot_level_writer.py
@@ -358,7 +358,7 @@ def ootConvertScene(originalSceneObj, transformMatrix,
 			elif isinstance(obj.data, bpy.types.Camera):
 				camPosProp = obj.ootCameraPositionProperty
 				readCamPos(camPosProp, obj, scene, sceneObj, transformMatrix)
-			elif isinstance(obj.data, bpy.types.Curve) and isCurveValid(obj):
+			elif isinstance(obj.data, bpy.types.Curve) and assertCurveValid(obj):
 				readPathProp(obj.ootSplineProperty, obj, scene, sceneObj, sceneName, transformMatrix)
 		
 		scene.validateIndices()
@@ -481,7 +481,7 @@ def ootProcessEmpties(scene, room, sceneObj, obj, transformMatrix):
 	elif isinstance(obj.data, bpy.types.Camera):
 		camPosProp = obj.ootCameraPositionProperty
 		readCamPos(camPosProp, obj, scene, sceneObj, transformMatrix)
-	elif isinstance(obj.data, bpy.types.Curve) and isCurveValid(obj):
+	elif isinstance(obj.data, bpy.types.Curve) and assertCurveValid(obj):
 		readPathProp(obj.ootSplineProperty, obj, scene, sceneObj, scene.name, transformMatrix)
 	
 	for childObj in obj.children:

--- a/fast64_internal/sm64/sm64_objects.py
+++ b/fast64_internal/sm64/sm64_objects.py
@@ -665,7 +665,7 @@ def process_sm64_objects(obj, area, rootMatrix, transformMatrix, specialsOnly):
 				puppycamProp.puppycamVolumePermaswap, puppycamProp.puppycamVolumeFunction, translation, scale, obj.empty_display_size, puppycamCamPosCoords, puppycamCamFocusCoords, puppycamModeString))
 
 
-	elif not specialsOnly and isCurveValid(obj):
+	elif not specialsOnly and assertCurveValid(obj):
 		area.splines.append(convertSplineObject(area.name + '_spline_' + obj.name , obj, finalTransform))
 			
 


### PR DESCRIPTION
As the title says. Somebody reached out to me about this bug. If they deleted a point they couldn't export splines and would get a `NoneType has no attribute points` error. This error could be bypassed by making sure to select any random point after deleting a point. So my fix is just using the first spline instead of the active spline, and the export has the same output as before (tested against multiple splines in the same export).