### PR TITLE
Extend max/min of STS Scrolling amount

### DIFF
--- a/fast64_internal/f3d/f3d_material.py
+++ b/fast64_internal/f3d/f3d_material.py
@@ -2033,8 +2033,9 @@ class TextureFieldProperty(bpy.types.PropertyGroup):
 		update = update_tex_values)
 
 class SetTileSizeScrollProperty(bpy.types.PropertyGroup):
-	s : bpy.props.IntProperty(min = -100, max = 100, default = 0)
-	t : bpy.props.IntProperty(min = -100, max = 100, default = 0)
+	# min/max match max of TextureFieldProperty.low
+	s : bpy.props.IntProperty(min = -1023, soft_min = -100, soft_max = 100, max = 1023, default = 0)
+	t : bpy.props.IntProperty(min = -1023, soft_min = -100, soft_max = 100, max = 1023, default = 0)
 	interval : bpy.props.IntProperty(min = 1, soft_max = 1000, default = 1)
 
 class TextureProperty(bpy.types.PropertyGroup):

--- a/fast64_internal/f3d/f3d_material.py
+++ b/fast64_internal/f3d/f3d_material.py
@@ -2033,9 +2033,8 @@ class TextureFieldProperty(bpy.types.PropertyGroup):
 		update = update_tex_values)
 
 class SetTileSizeScrollProperty(bpy.types.PropertyGroup):
-	# min/max match max of TextureFieldProperty.low
-	s : bpy.props.IntProperty(min = -1023, soft_min = -100, soft_max = 100, max = 1023, default = 0)
-	t : bpy.props.IntProperty(min = -1023, soft_min = -100, soft_max = 100, max = 1023, default = 0)
+	s : bpy.props.IntProperty(min = -4095, max = 4095, default = 0)
+	t : bpy.props.IntProperty(min = -4095, max = 4095, default = 0)
 	interval : bpy.props.IntProperty(min = 1, soft_max = 1000, default = 1)
 
 class TextureProperty(bpy.types.PropertyGroup):


### PR DESCRIPTION
Set min and max to be the highest possible min/max values. Kept the soft_min and soft_max into normal usage bounds.