### PR TITLE
Fixed the OoT exporter

### DIFF
--- a/fast64_internal/oot/c_writer/oot_scene_table_c.py
+++ b/fast64_internal/oot/c_writer/oot_scene_table_c.py
@@ -24,7 +24,7 @@ def getSceneTableEntryBySceneName(sceneTable, sceneName):
 def readSceneTable(exportPath):
 	fileData = readFile(os.path.join(exportPath, 'src/code/z_scene_table.c'))
 
-	matchResult = re.search('Scene\s*gSceneTable\[\]\s*=\s*\{([^\}]*)\}', fileData, re.DOTALL)
+	matchResult = re.search('SceneTableEntry\s*gSceneTable\[\]\s*=\s*\{([^\}]*)\}', fileData, re.DOTALL)
 	if matchResult is None:
 		raise PluginError("z_scene_table.c does not have gSceneTable in it.")
 	sceneTable = parseSceneTableData(matchResult.group(1))


### PR DESCRIPTION
The OoT exporter broke with the [latest ](https://github.com/zeldaret/oot/commit/7551dc2b71f7c6587f96c498cbd62cfd05aa292c) commit of decomp that changed "Scene gSceneTable" to "SceneTableEntry gSceneTable"