### PR TITLE
Custom geo commands and object instancing in SM64 Object exporting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __pycache__/
+.vscode

--- a/README.md
+++ b/README.md
@@ -46,3 +46,6 @@ There may occur cases where code is formatted differently based on the code use 
 ### Converting To F3D v4 Materials
 A new optimized shader graph was introduced to decrease processing times for material creation and exporting. If you have a project that still uses old materials, you may want to convert them to v4. To convert an old project, click the "Recreate F3D Materials As V4" operator near the top of the Fast64 tab in 3D view. This may take a while depending on the number of materials in the project. Then go to the outliner, change the display mode to "Orphan Data" (broken heart icon), then click "Purge" in the top right corner. Purge multiple times until all of the old node groups are gone.
 
+### Fast64 Development
+If you'd like to develop in VSCode, follow this tutorial to get proper autocomplete. Skip the linter for now, we'll need to make sure the entire project gets linted before enabling autosave linting because the changes will be massive.
+https://b3d.interplanety.org/en/using-microsoft-visual-studio-code-as-external-ide-for-writing-blender-scripts-add-ons/

--- a/fast64_internal/f3d/f3d_material.py
+++ b/fast64_internal/f3d/f3d_material.py
@@ -1103,10 +1103,10 @@ def ui_procAnimVecEnum(material, procAnimVec, layout, name, vecType, useDropdown
 		layout.box().label(text = 'SM64 SetTileSize Texture Scroll')
 
 		if useTex0:
-			ui_tileScroll(material.tex0, 'Texture 0 Speed', layout)
+			ui_tileScroll(material.tex0, 'Tex 0 Speed', layout)
 
 		if useTex1:
-			ui_tileScroll(material.tex1, 'Texture 1 Speed', layout)
+			ui_tileScroll(material.tex1, 'Tex 1 Speed', layout)
 
 def ui_procAnimFieldEnum(procAnimField, layout, name, overrideName):
 	box = layout

--- a/fast64_internal/f3d/f3d_material.py
+++ b/fast64_internal/f3d/f3d_material.py
@@ -145,7 +145,7 @@ def update_draw_layer(self, context):
 		material = context.material_slot.material # Handles case of texture property groups
 		if not material.is_f3d or material.f3d_update_flag:
 			return
-		
+
 		material.f3d_update_flag = True
 		if material.mat_ver > 3:
 			drawLayer = material.f3d_mat.draw_layer
@@ -223,7 +223,7 @@ def combiner_uses(material, checkList, is2Cycle):
 		else:
 			value1 = value
 			value2 = value
-			
+
 		display |= material.combiner1.A == value1
 		if is2Cycle:
 			display |= material.combiner2.A == value2
@@ -239,7 +239,7 @@ def combiner_uses(material, checkList, is2Cycle):
 		display |= material.combiner1.D == value1
 		if is2Cycle:
 			display |= material.combiner2.D  == value2
-	
+
 
 		display |= material.combiner1.A_alpha == value1
 		if is2Cycle:
@@ -289,41 +289,41 @@ def combiner_uses_alpha(material, checkList, is2Cycle):
 
 def all_combiner_uses(material):
 	useDict = {
-		'Texture' : combiner_uses(material, 
-			['TEXEL0', 'TEXEL0_ALPHA', 'TEXEL1', 'TEXEL1_ALPHA'], 
+		'Texture' : combiner_uses(material,
+			['TEXEL0', 'TEXEL0_ALPHA', 'TEXEL1', 'TEXEL1_ALPHA'],
 			material.rdp_settings.g_mdsft_cycletype == 'G_CYC_2CYCLE'),
 
-		'Texture 0' : combiner_uses(material, 
-			['TEXEL0', 'TEXEL0_ALPHA'], 
+		'Texture 0' : combiner_uses(material,
+			['TEXEL0', 'TEXEL0_ALPHA'],
 			material.rdp_settings.g_mdsft_cycletype == 'G_CYC_2CYCLE'),
 
-		'Texture 1' : combiner_uses(material, 
-			['TEXEL1', 'TEXEL1_ALPHA'], 
+		'Texture 1' : combiner_uses(material,
+			['TEXEL1', 'TEXEL1_ALPHA'],
 			material.rdp_settings.g_mdsft_cycletype == 'G_CYC_2CYCLE'),
 
-		'Primitive' : combiner_uses(material, 
-			['PRIMITIVE', 'PRIMITIVE_ALPHA', 'PRIM_LOD_FRAC'], 
+		'Primitive' : combiner_uses(material,
+			['PRIMITIVE', 'PRIMITIVE_ALPHA', 'PRIM_LOD_FRAC'],
 			material.rdp_settings.g_mdsft_cycletype == 'G_CYC_2CYCLE'),
 
-		'Environment' : combiner_uses(material, 
-			['ENVIRONMENT', 'ENV_ALPHA'], 
+		'Environment' : combiner_uses(material,
+			['ENVIRONMENT', 'ENV_ALPHA'],
 			material.rdp_settings.g_mdsft_cycletype == 'G_CYC_2CYCLE'),
 
-		'Shade' : combiner_uses(material, 
-			['SHADE', 'SHADE_ALPHA'], 
+		'Shade' : combiner_uses(material,
+			['SHADE', 'SHADE_ALPHA'],
 			material.rdp_settings.g_mdsft_cycletype == 'G_CYC_2CYCLE'),
-		
+
 		'Shade Alpha' : combiner_uses_alpha(material,
 			['SHADE'],
 			material.rdp_settings.g_mdsft_cycletype == 'G_CYC_2CYCLE'),
 
-		'Key' : combiner_uses(material, ['CENTER', 'SCALE'], 
+		'Key' : combiner_uses(material, ['CENTER', 'SCALE'],
 			material.rdp_settings.g_mdsft_cycletype == 'G_CYC_2CYCLE'),
 
-		'LOD Fraction' : combiner_uses(material, ['LOD_FRACTION'], 
+		'LOD Fraction' : combiner_uses(material, ['LOD_FRACTION'],
 			material.rdp_settings.g_mdsft_cycletype == 'G_CYC_2CYCLE'),
 
-		'Convert' : combiner_uses(material, ['K4', 'K5'], 
+		'Convert' : combiner_uses(material, ['K4', 'K5'],
 			material.rdp_settings.g_mdsft_cycletype == 'G_CYC_2CYCLE'),
 	}
 	return useDict
@@ -331,7 +331,7 @@ def all_combiner_uses(material):
 def ui_geo_mode(settings, dataHolder, layout, useDropdown):
 	inputGroup = layout.column()
 	if useDropdown:
-		inputGroup.prop(dataHolder, 'menu_geo', 
+		inputGroup.prop(dataHolder, 'menu_geo',
 			text = 'Geometry Mode Settings',
 			icon = 'TRIA_DOWN' if dataHolder.menu_geo else 'TRIA_RIGHT')
 	if not useDropdown or dataHolder.menu_geo:
@@ -351,27 +351,27 @@ def ui_geo_mode(settings, dataHolder, layout, useDropdown):
 		#	fogInfoBox.label(text = 'In Render Settings, check "Set Render Mode".')
 		#	fogInfoBox.label(text = 'Set the first field to "Fog Shade".')
 		#	fogInfoBox.label(text = 'Set the second to the material\'s draw layer, usually "Opaque".')
-			
+
 		inputGroup.prop(settings, 'g_lighting', text = 'Lighting')
 		inputGroup.prop(settings, 'g_tex_gen', text = 'Texture UV Generate')
-		inputGroup.prop(settings, 'g_tex_gen_linear', 
+		inputGroup.prop(settings, 'g_tex_gen_linear',
 			text = 'Texture UV Generate Linear')
 		inputGroup.prop(settings, 'g_shade_smooth', text = 'Smooth Shading')
 		if bpy.context.scene.f3d_type == 'F3DEX_GBI_2' or \
 			bpy.context.scene.f3d_type == 'F3DEX_GBI':
 			inputGroup.prop(settings, 'g_clipping', text = 'Clipping')
-	
+
 def ui_upper_mode(settings, dataHolder, layout, useDropdown):
 	inputGroup = layout.column()
 	if useDropdown:
-		inputGroup.prop(dataHolder, 'menu_upper', 
-			text = 'Other Mode Upper Settings', 
+		inputGroup.prop(dataHolder, 'menu_upper',
+			text = 'Other Mode Upper Settings',
 			icon = 'TRIA_DOWN' if dataHolder.menu_upper else 'TRIA_RIGHT')
 	if not useDropdown or dataHolder.menu_upper:
 		if not bpy.context.scene.isHWv1:
 			prop_split(inputGroup, settings, 'g_mdsft_alpha_dither',
 				'Alpha Dither')
-			prop_split(inputGroup, settings, 'g_mdsft_rgb_dither', 
+			prop_split(inputGroup, settings, 'g_mdsft_rgb_dither',
 				'RGB Dither')
 		else:
 			prop_split(inputGroup, settings, 'g_mdsft_color_dither',
@@ -384,14 +384,14 @@ def ui_upper_mode(settings, dataHolder, layout, useDropdown):
 		prop_split(inputGroup, settings, 'g_mdsft_textdetail', 'Texture Detail')
 		prop_split(inputGroup, settings, 'g_mdsft_textpersp', 'Texture Perspective Correction')
 		prop_split(inputGroup, settings, 'g_mdsft_cycletype', 'Cycle Type')
-		
+
 		prop_split(inputGroup, settings, 'g_mdsft_pipeline', 'Pipeline Span Buffer Coherency')
 
 def ui_lower_mode(settings, dataHolder, layout, useDropdown):
 	inputGroup = layout.column()
 	if useDropdown:
-		inputGroup.prop(dataHolder, 'menu_lower', 
-			text = 'Other Mode Lower Settings', 
+		inputGroup.prop(dataHolder, 'menu_lower',
+			text = 'Other Mode Lower Settings',
 			icon = 'TRIA_DOWN' if dataHolder.menu_lower else 'TRIA_RIGHT')
 	if not useDropdown or dataHolder.menu_lower:
 		prop_split(inputGroup, settings, 'g_mdsft_alpha_compare', 'Alpha Compare')
@@ -400,8 +400,8 @@ def ui_lower_mode(settings, dataHolder, layout, useDropdown):
 def ui_other(settings, dataHolder, layout, useDropdown):
 	inputGroup = layout.column()
 	if useDropdown:
-		inputGroup.prop(dataHolder, 'menu_other', 
-			text = 'Other Settings', 
+		inputGroup.prop(dataHolder, 'menu_other',
+			text = 'Other Settings',
 			icon = 'TRIA_DOWN' if dataHolder.menu_other else 'TRIA_RIGHT')
 	if not useDropdown or dataHolder.menu_other:
 		clipRatioGroup = inputGroup.column()
@@ -437,7 +437,7 @@ class F3DPanel(bpy.types.Panel):
 	bl_space_type = 'PROPERTIES'
 	bl_region_type = 'WINDOW'
 	bl_context = "material"
-	bl_options = {'HIDE_HEADER'} 
+	bl_options = {'HIDE_HEADER'}
 
 	#def hasNecessaryNodes(self, nodes):
 	#	result = True
@@ -460,7 +460,7 @@ class F3DPanel(bpy.types.Panel):
 				prop_input_name.prop(textureProp, 'tex_set', text = "Set Texture")
 			else:
 				prop_input_name.label(text = name)
-			#prop_input.template_image(textureProp, 'tex', 
+			#prop_input.template_image(textureProp, 'tex',
 			#	nodes[name].image_user)
 			texIndex = name[-1]
 
@@ -471,15 +471,15 @@ class F3DPanel(bpy.types.Panel):
 				if textureProp.tex_format[:2] == 'CI':
 					prop_split(prop_input, textureProp, "pal_reference", "Palette Reference")
 					prop_split(prop_input, textureProp, "pal_reference_size", "Palette Size")
-			
+
 			else:
-				prop_input.template_ID(textureProp, 'tex', new='image.new', open='image.open', 
+				prop_input.template_ID(textureProp, 'tex', new='image.new', open='image.open',
 					unlink='image.tex' + texIndex + "_unlink")
 				prop_input.enabled = textureProp.tex_set
 
 				if tex is not None:
 					prop_input.label(text = "Size: " + str(tex.size[0]) + " x " + str(tex.size[1]))
-					
+
 			if material.mat_ver > 3 and material.f3d_mat.use_large_textures:
 				prop_input.label(text = "Large texture mode enabled.")
 				prop_input.label(text = "Each triangle must fit in a single tile load.")
@@ -504,7 +504,7 @@ class F3DPanel(bpy.types.Panel):
 				mirrorSettings.prop(textureProp.S, "mirror", text = 'Mirror S')
 				mirrorSettings.prop(textureProp.T, "mirror", text = 'Mirror T')
 
-				prop_input.prop(textureProp, 'autoprop', 
+				prop_input.prop(textureProp, 'autoprop',
 					text = 'Auto Set Other Properties')
 
 				if not textureProp.autoprop:
@@ -530,8 +530,8 @@ class F3DPanel(bpy.types.Panel):
 					warnBox = layout.box()
 					warnBox.label(
 						text = 'Warning: Texture dimensions are not power of 2.')
-					warnBox.label(text = 'Wrapping only occurs on power of 2 bounds.')	
-	
+					warnBox.label(text = 'Wrapping only occurs on power of 2 bounds.')
+
 	def ui_prop(self, material, layout, name, setName, setProp, showCheckBox):
 		nodes = material.node_tree.nodes
 		inputGroup = layout.row()
@@ -595,7 +595,7 @@ class F3DPanel(bpy.types.Panel):
 		inputGroup = layout.row()
 		prop_input_name = inputGroup.column()
 		prop_input = inputGroup.column()
-		
+
 		if material.mat_ver > 3:
 			if showCheckBox:
 				prop_input_name.prop(material.f3d_mat, 'set_env', text = 'Environment Color')
@@ -629,10 +629,10 @@ class F3DPanel(bpy.types.Panel):
 		if material.key_width[0] > 1 or material.key_width[1] > 1 or \
 			material.key_width[2] > 1:
 			layout.box().label(text = \
-				"NOTE: Keying is disabled for channels with width > 1.") 
+				"NOTE: Keying is disabled for channels with width > 1.")
 		prop_input.enabled = setProp
 		return inputGroup
-	
+
 	def ui_lights(self, material, layout, name, showCheckBox):
 		inputGroup = layout.row()
 		prop_input_name = inputGroup.column()
@@ -650,25 +650,25 @@ class F3DPanel(bpy.types.Panel):
 			else:
 				lightSettings.prop(material, 'ambient_light_color', text = 'Ambient Color')
 
-				lightSettings.prop_search(material, 'f3d_light1', 
+				lightSettings.prop_search(material, 'f3d_light1',
 					bpy.data, 'lights', text = '')
 				if material.f3d_light1 is not None:
-					lightSettings.prop_search(material, 'f3d_light2', 
+					lightSettings.prop_search(material, 'f3d_light2',
 						bpy.data, 'lights', text = '')
 				if material.f3d_light2 is not None:
-					lightSettings.prop_search(material, 'f3d_light3', 
+					lightSettings.prop_search(material, 'f3d_light3',
 						bpy.data, 'lights', text = '')
 				if material.f3d_light3 is not None:
-					lightSettings.prop_search(material, 'f3d_light4', 
+					lightSettings.prop_search(material, 'f3d_light4',
 						bpy.data, 'lights', text = '')
 				if material.f3d_light4 is not None:
-					lightSettings.prop_search(material, 'f3d_light5', 
+					lightSettings.prop_search(material, 'f3d_light5',
 						bpy.data, 'lights', text = '')
 				if material.f3d_light5 is not None:
-					lightSettings.prop_search(material, 'f3d_light6', 
+					lightSettings.prop_search(material, 'f3d_light6',
 						bpy.data, 'lights', text = '')
 				if material.f3d_light6 is not None:
-					lightSettings.prop_search(material, 'f3d_light7', 
+					lightSettings.prop_search(material, 'f3d_light7',
 						bpy.data, 'lights', text = '')
 			prop_input.prop(material, 'use_default_lighting', text = 'Use Custom Lighting', invert_checkbox = True)
 			#layout.box().label(text = "Note: Lighting preview is not 100% accurate.")
@@ -687,7 +687,7 @@ class F3DPanel(bpy.types.Panel):
 			prop_input_name.prop(material, 'set_k0_5', text = 'YUV Convert')
 		else:
 			prop_input_name.label(text = 'YUV Convert')
-		
+
 		prop_k0 = prop_input.row()
 		prop_k0.prop(material, 'k0', text='K0')
 		prop_k0.label(text = str(int(material.k0 * 255)))
@@ -719,39 +719,39 @@ class F3DPanel(bpy.types.Panel):
 		# cycle independent
 		inputGroup = layout.column()
 		if useDropdown:
-			inputGroup.prop(material, 'menu_lower_render', 
-				text = 'Render Settings', 
+			inputGroup.prop(material, 'menu_lower_render',
+				text = 'Render Settings',
 				icon = 'TRIA_DOWN' if material.menu_lower_render else 'TRIA_RIGHT')
 		if not useDropdown or material.menu_lower_render:
-			inputGroup.prop(material.rdp_settings, 'set_rendermode', 
+			inputGroup.prop(material.rdp_settings, 'set_rendermode',
 				text ='Set Render Mode?')
 
 			renderGroup = inputGroup.column()
 			renderGroup.prop(material.rdp_settings, 'rendermode_advanced_enabled',
 				text = 'Show Advanced Settings')
 			if not material.rdp_settings.rendermode_advanced_enabled:
-				prop_split(renderGroup, material.rdp_settings, 
+				prop_split(renderGroup, material.rdp_settings,
 					'rendermode_preset_cycle_1', "Render Mode")
 				if material.rdp_settings.g_mdsft_cycletype == 'G_CYC_2CYCLE':
-					prop_split(renderGroup, material.rdp_settings, 
+					prop_split(renderGroup, material.rdp_settings,
 						'rendermode_preset_cycle_2', "Render Mode Cycle 2")
 			else:
 				prop_split(renderGroup, material.rdp_settings, 'aa_en', 'Antialiasing')
 				prop_split(renderGroup, material.rdp_settings, 'z_cmp', 'Z Testing')
 				prop_split(renderGroup, material.rdp_settings, 'z_upd', 'Z Writing')
 				prop_split(renderGroup, material.rdp_settings, 'im_rd', 'IM_RD (?)')
-				prop_split(renderGroup, material.rdp_settings, 'clr_on_cvg', 
+				prop_split(renderGroup, material.rdp_settings, 'clr_on_cvg',
 					'Clear On Coverage')
-				prop_split(renderGroup, material.rdp_settings, 'cvg_dst', 
+				prop_split(renderGroup, material.rdp_settings, 'cvg_dst',
 					'Coverage Destination')
 				prop_split(renderGroup, material.rdp_settings, 'zmode', 'Z Mode')
-				prop_split(renderGroup, material.rdp_settings, 'cvg_x_alpha', 
+				prop_split(renderGroup, material.rdp_settings, 'cvg_x_alpha',
 					'Multiply Coverage And Alpha')
 				prop_split(renderGroup, material.rdp_settings, 'alpha_cvg_sel',
 					'Use Coverage For Alpha')
 				prop_split(renderGroup, material.rdp_settings, 'force_bl', 'Force Blending')
 
-				# cycle dependent - (P * A + M - B) / (A + B) 
+				# cycle dependent - (P * A + M - B) / (A + B)
 				combinerBox = renderGroup.box()
 				combinerBox.label(text='Blender (Color = (P * A + M * B) / (A + B)')
 				combinerCol = combinerBox.row()
@@ -774,7 +774,7 @@ class F3DPanel(bpy.types.Panel):
 					rowAlpha2.prop(material.rdp_settings, 'blend_b2', text = 'B')
 
 			renderGroup.enabled = material.rdp_settings.set_rendermode
-	
+
 	def ui_uvCheck(self, layout, context):
 		if hasattr(context, 'object') and context.object is not None and \
 			isinstance(context.object.data, bpy.types.Mesh):
@@ -837,7 +837,7 @@ class F3DPanel(bpy.types.Panel):
 
 	def drawShadeAlphaNotice(self, layout):
 		layout.box().column().label(text = "There must be a vertex color layer called \"Alpha\".", icon = "ERROR")
-	
+
 	def drawCIMultitextureNotice(self, layout):
 		layout.label(text = 'CI textures will break with multitexturing.', icon = "ERROR")
 
@@ -870,11 +870,11 @@ class F3DPanel(bpy.types.Panel):
 			if material.mat_ver > 3:
 				inputCol.prop(f3dMat, 'use_large_textures')
 			self.ui_scale(f3dMat, inputCol)
-		
+
 		if useDict['Primitive'] and f3dMat.set_prim:
 			self.ui_prim(material, inputCol, 'set_prim', f3dMat.set_prim, False)
 
-		if useDict['Environment'] and f3dMat.set_env:	
+		if useDict['Environment'] and f3dMat.set_env:
 			if material.mat_ver >= 3:
 				self.ui_env(material, inputCol, False)
 			else:
@@ -889,7 +889,7 @@ class F3DPanel(bpy.types.Panel):
 		if useDict['Key'] and f3dMat.set_key:
 			self.ui_chroma(material, inputCol, 'Chroma Key Center',
 				'set_key', f3dMat.set_key, False)
-		
+
 		if useDict['Convert'] and f3dMat.set_k0_5:
 			self.ui_convert(f3dMat, inputCol, False)
 
@@ -912,7 +912,7 @@ class F3DPanel(bpy.types.Panel):
 				self.drawShadeAlphaNotice(layout)
 
 			combinerBox = layout.box()
-			combinerBox.prop(f3dMat, 'set_combiner', 
+			combinerBox.prop(f3dMat, 'set_combiner',
 				text = 'Color Combiner (Color = (A - B) * C + D)')
 			combinerCol = combinerBox.row()
 			combinerCol.enabled = f3dMat.set_combiner
@@ -978,7 +978,7 @@ class F3DPanel(bpy.types.Panel):
 			if useDict['Primitive']:
 				self.ui_prim(material, inputCol, 'set_prim', f3dMat.set_prim, True)
 
-			if useDict['Environment']:	
+			if useDict['Environment']:
 				if material.mat_ver >= 3:
 					self.ui_env(material, inputCol, True)
 				else:
@@ -995,7 +995,7 @@ class F3DPanel(bpy.types.Panel):
 				self.ui_convert(f3dMat, inputCol, True)
 
 			self.ui_fog(f3dMat, inputCol, True)
-		
+
 		if menuTab == "Geo":
 			ui_geo_mode(f3dMat.rdp_settings, f3dMat, layout, False)
 		if menuTab == "Upper":
@@ -1051,7 +1051,7 @@ class F3DPanel(bpy.types.Panel):
 			self.draw_full(f3dMat, material, layout, context)
 
 #def ui_procAnimVec(self, procAnimVec, layout, name, vecType):
-#	layout.prop(procAnimVec, 'menu', text = name, 
+#	layout.prop(procAnimVec, 'menu', text = name,
 #		icon = 'TRIA_DOWN' if procAnimVec.menu else 'TRIA_RIGHT')
 #	if procAnimVec.menu:
 #		box = layout.box()
@@ -1061,7 +1061,8 @@ class F3DPanel(bpy.types.Panel):
 #			self.ui_procAnimField(procAnimVec.z, box, vecType[2])
 
 def ui_tileScroll(tex, name, layout):
-	row = layout.row(heading = name)
+	row = layout.row()
+	row.label(text = name)
 	row.prop(tex.tile_scroll, 's', text = 'S:')
 	row.prop(tex.tile_scroll, 't', text = 'T:')
 	row.prop(tex.tile_scroll, 'interval', text = 'Interval:')
@@ -1070,11 +1071,11 @@ def ui_procAnimVecEnum(material, procAnimVec, layout, name, vecType, useDropdown
 	layout = layout.box()
 	box = layout.column()
 	if useDropdown:
-		layout.prop(procAnimVec, 'menu', text = name, 
+		layout.prop(procAnimVec, 'menu', text = name,
 			icon = 'TRIA_DOWN' if procAnimVec.menu else 'TRIA_RIGHT')
 	else:
 		layout.box().label(text = name)
-		
+
 	if not useDropdown or procAnimVec.menu:
 		box = layout.column()
 		#box.box().label(text = 'Scrolling not visible in preview.')
@@ -1097,7 +1098,7 @@ def ui_procAnimVecEnum(material, procAnimVec, layout, name, vecType, useDropdown
 			box.row().prop(procAnimVec, 'angularSpeed')
 			if combinedOption == "Rotation":
 				pass
-	
+
 	if useTex0 or useTex1:
 		layout.box().label(text = 'SM64 SetTileSize Texture Scroll')
 
@@ -1106,7 +1107,7 @@ def ui_procAnimVecEnum(material, procAnimVec, layout, name, vecType, useDropdown
 
 		if useTex1:
 			ui_tileScroll(material.tex1, 'Texture 1 Speed', layout)
-	
+
 def ui_procAnimFieldEnum(procAnimField, layout, name, overrideName):
 	box = layout
 	box.prop(procAnimField, 'animType', text = name if overrideName is None else overrideName)
@@ -1144,16 +1145,16 @@ def ui_procAnim(material, layout, useTex0, useTex1, title, useDropdown):
 		ui_procAnimVecEnum(material.f3d_mat, material.f3d_mat.UVanim0, layout, title, 'UV', useDropdown, useTex0, useTex1)
 	else:
 		ui_procAnimVecEnum(material, material.UVanim, layout, title, 'UV', useDropdown, useTex0, useTex1)
-	#layout.prop(material, 'menu_procAnim', 
-	#	text = 'Procedural Animation', 
+	#layout.prop(material, 'menu_procAnim',
+	#	text = 'Procedural Animation',
 	#	icon = 'TRIA_DOWN' if material.menu_procAnim else 'TRIA_RIGHT')
 	#if material.menu_procAnim:
 	#	procAnimBox = layout.box()
 	#	if useTex0:
-	#		ui_procAnimVec(material.UVanim_tex0, procAnimBox, 
+	#		ui_procAnimVec(material.UVanim_tex0, procAnimBox,
 	#		"UV Texture 0", 'UV')
 	#	if useTex1:
-	#		ui_procAnimVec(material.UVanim_tex1, procAnimBox, 
+	#		ui_procAnimVec(material.UVanim_tex1, procAnimBox,
 	#		"UV Texture 1", 'UV')
 	#	ui_procAnimVec(material.positionAnim, procAnimBox,
 	#		"Position", 'XYZ')
@@ -1169,7 +1170,7 @@ def update_node_values(self, context):
 		material = context.material_slot.material # Handles case of texture property groups
 		if not material.is_f3d or material.f3d_update_flag:
 			return
-		
+
 		material.f3d_update_flag = True
 		update_node_values_of_material(material, context)
 		if material.mat_ver > 3:
@@ -1186,7 +1187,7 @@ def update_node_values_without_preset(self, context):
 		material = context.material_slot.material # Handles case of texture property groups
 		if not material.is_f3d or material.f3d_update_flag:
 			return
-		
+
 		material.f3d_update_flag = True
 		update_node_values_of_material(material, context)
 		material.f3d_update_flag = False
@@ -1194,14 +1195,14 @@ def update_node_values_without_preset(self, context):
 		material = context.material
 		if not material.is_f3d or material.f3d_update_flag:
 			return
-		
+
 		material.f3d_update_flag = True
 		update_node_values_of_material(material, context)
 		material.f3d_update_flag = False
 	else:
 		#print('No material in context.')
 		pass
-		
+
 def update_node_values_directly(material, context):
 	if not material.is_f3d or material.f3d_update_flag:
 		return
@@ -1229,7 +1230,7 @@ def update_node_combiner(material, combinerInputs, f3dVer, cycleIndex):
 				if cycleIndex == 2:
 					combiner1 = nodes['Color Combiner Cycle 1 F3D v3']
 					combiner2 = nodes['Color Combiner Cycle 2 F3D v3']
-					material.node_tree.links.new(combiner2.inputs[i], 
+					material.node_tree.links.new(combiner2.inputs[i],
 						combiner1.outputs[0 if combinerInputs[i] == 'COMBINED' else 1])
 			else:
 				if cycleIndex == 2 and combinerInputs[i][:5] == "TEXEL":
@@ -1257,7 +1258,7 @@ def update_node_values_of_material(material, context):
 	if material.mat_ver > 3:
 		update_blend_method(material, context)
 		if not hasNodeGraph(material):
-			return 
+			return
 
 	if material.mat_ver > 3:
 		f3dMat = material.f3d_mat
@@ -1346,7 +1347,7 @@ def update_node_values_of_material(material, context):
 			not f3dMat.rdp_settings.g_shade else 1
 		nodes['Shade Color'].inputs[1].default_value = 0 if \
 			not f3dMat.rdp_settings.g_lighting else 1
-		
+
 		if f3dMat.use_default_lighting:
 			nodes['Shade Color'].inputs[2].default_value = \
 				(f3dMat.default_light_color[0],
@@ -1448,7 +1449,7 @@ def update_tex_values_field(self, fieldProperty, texCoordNode, pixelLength,
 		fieldProperty.mask =  math.ceil(math.log(pixelLength, 2) - 0.001)
 		#fieldProperty.mask = 0
 		fieldProperty.shift = 0
-	
+
 	L = fieldProperty.low
 	H = fieldProperty.high
 	mask = fieldProperty.mask
@@ -1461,7 +1462,7 @@ def update_tex_values_field(self, fieldProperty, texCoordNode, pixelLength,
 	normHNode.outputs[0].default_value = (H + 1)/pixelLength
 	normMaskNode.outputs[0].default_value = \
 		(2 ** mask) / pixelLength if mask > 0 else 0
-	
+
 	shiftNode.outputs[0].default_value = shift
 	scaleNode.outputs[0].default_value = scale * uvBasisScale
 
@@ -1490,7 +1491,7 @@ def update_tex_values_field_v2(self, fieldProperty, pixelLength,
 
 	clampNode.inputs[fieldIndex].default_value = 1 if fieldProperty.clamp else 0
 	mirrorNode.inputs[fieldIndex].default_value = 1 if fieldProperty.mirror else 0
-	normHalfPixelNode.inputs[fieldIndex].default_value = 1 / (2 * pixelLengthAxis)	
+	normHalfPixelNode.inputs[fieldIndex].default_value = 1 / (2 * pixelLengthAxis)
 
 	if autoprop:
 		setAutoProp(fieldProperty, pixelLengthAxis)
@@ -1501,7 +1502,7 @@ def update_tex_values_field_v2(self, fieldProperty, pixelLength,
 	shiftNode.inputs[fieldIndex].default_value = fieldProperty.shift
 	scaleNode.inputs[fieldIndex].default_value = scale[fieldIndex] * uvBasisScale[fieldIndex]
 
-def update_tex_values_field_v3(self, texProperty, tex_size, 
+def update_tex_values_field_v3(self, texProperty, tex_size,
 	uvBasisScale, scale, texIndex):
 	nodes = self.node_tree.nodes
 	if texProperty.autoprop:
@@ -1518,23 +1519,23 @@ def update_tex_values_field_v3(self, texProperty, tex_size,
 	nodes['Get UV ' + str(texIndex) + ' F3D v3'].inputs[3].default_value = (
 		texProperty.S.low / tex_size[0],
 		texProperty.T.low / tex_size[1], 0)
-	
+
 	# Normalized H
 	nodes['Get UV ' + str(texIndex) + ' F3D v3'].inputs[4].default_value = (
 		(texProperty.S.high + 1) / tex_size[0],
 		(texProperty.T.high + 1) / tex_size[1], 0)
 
 	# Clamp
-	isTexGen = self.f3d_mat.rdp_settings.g_tex_gen or self.f3d_mat.rdp_settings.g_tex_gen_linear 
+	isTexGen = self.f3d_mat.rdp_settings.g_tex_gen or self.f3d_mat.rdp_settings.g_tex_gen_linear
 	nodes['Get UV ' + str(texIndex) + ' F3D v3'].inputs[5].default_value = (
 		1 if texProperty.S.clamp and not isTexGen else 0,
 		1 if texProperty.T.clamp and not isTexGen else 0, 0)
-		
+
 	# Normalized Mask
 	nodes['Get UV ' + str(texIndex) + ' F3D v3'].inputs[6].default_value = (
 		(2 ** texProperty.S.mask) / tex_size[0] if texProperty.S.mask > 0 else 0,
 		(2 ** texProperty.T.mask) / tex_size[1] if texProperty.T.mask > 0 else 0, 0)
-	
+
 	# Mirror
 	nodes['Get UV ' + str(texIndex) + ' F3D v3'].inputs[7].default_value = (
 		1 if texProperty.S.mirror else 0,
@@ -1554,8 +1555,8 @@ def update_tex_values_field_v3(self, texProperty, tex_size,
 	nodes['Get UV ' + str(texIndex) + ' F3D v3'].inputs[10].default_value = (
 		1 / (2 * tex_size[0]),
 		1 / (2 * tex_size[1]), 0)
-	
-def update_tex_values_index(self, context, texProperty, texNodeName, 
+
+def update_tex_values_index(self, context, texProperty, texNodeName,
 	uvNodeName, isTexGen, uvBasisScale, scale, texIndex):
 	nodes = self.node_tree.nodes
 
@@ -1587,7 +1588,7 @@ def update_tex_values_index(self, context, texProperty, texNodeName,
 				tex_x = nodes
 				tex_y = nodes
 				imageFactorNode = nodes['Tex ' + str(texIndex) + ' Image Factor']
-				imageFactorNode.inputs[0].default_value = 1024 / tex_size[0] 
+				imageFactorNode.inputs[0].default_value = 1024 / tex_size[0]
 				imageFactorNode.inputs[1].default_value = 1024 / tex_size[1]
 
 				update_tex_values_field_v2(self, texProperty.S, tex_size,
@@ -1598,9 +1599,9 @@ def update_tex_values_index(self, context, texProperty, texNodeName,
 				if self.mat_ver > 3:
 					f3dMat = self.f3d_mat
 				else:
-					f3dMat = self 
+					f3dMat = self
 				if self.mat_ver == 3 or hasNodeGraph(self):
-					update_tex_values_field_v3(self, texProperty, tex_size, 
+					update_tex_values_field_v3(self, texProperty, tex_size,
 						uvBasisScale, scale, texIndex)
 					#nodes[texNodeName].interpolation = "Closest"
 					nodes[texNodeName].interpolation = "Closest" if \
@@ -1608,7 +1609,7 @@ def update_tex_values_index(self, context, texProperty, texNodeName,
 				else:
 					if texProperty.autoprop:
 						setAutoProp(texProperty.S, tex_size[0])
-						setAutoProp(texProperty.T, tex_size[1])		
+						setAutoProp(texProperty.T, tex_size[1])
 			else:
 				print("Error: Unhandled material version " + str(self.mat_ver) + ' for texture properties.')
 
@@ -1655,7 +1656,7 @@ def update_tex_values_and_formats(self, context):
 			material = context.material
 			useLargeTextures = False
 			isMultiTexture = False
-			
+
 		if context.material.f3d_update_flag:
 			return
 		context.material.f3d_update_flag = True
@@ -1670,7 +1671,7 @@ def update_tex_values_and_formats(self, context):
 			else:
 				material.tex1.tex_format = getOptimalFormat(material.tex1.tex, useLargeTextures)
 		context.material.f3d_update_flag = False
-		
+
 		update_tex_values(context.material, context)
 	else:
 		if self.tex is not None:
@@ -1703,14 +1704,14 @@ def update_tex_values_manual(self, context):
 			tex_size = material.tex1.tex.size
 
 		if isTexGen and tex_size is not None:
-			material.tex_scale = ((tex_size[0] - 1) / 1024, 
+			material.tex_scale = ((tex_size[0] - 1) / 1024,
 				(tex_size[1] - 1) / 1024)
 		else:
 			material.tex_scale = (1,1)
-	
+
 
 	useDict = all_combiner_uses(material)
-		
+
 	if useDict['Texture 0'] and material.tex0.tex is not None and \
 		useDict['Texture 1'] and material.tex1.tex is not None and\
 		material.tex0.tex.size[0] > 0 and material.tex0.tex.size[1] > 0 and\
@@ -1726,15 +1727,15 @@ def update_tex_values_manual(self, context):
 	else:
 		uvBasisScale0 = (1,1)
 		uvBasisScale1 = (1,1)
-			
-	update_tex_values_index(self, context, material.tex0, 'Texture 0', 
+
+	update_tex_values_index(self, context, material.tex0, 'Texture 0',
 		'Get UV', isTexGen, uvBasisScale0, material.tex_scale, 0)
-	update_tex_values_index(self, context, material.tex1, 'Texture 1', 
+	update_tex_values_index(self, context, material.tex1, 'Texture 1',
 		'Get UV.001', isTexGen, uvBasisScale1, material.tex_scale, 1)
 
 def getMaterialScrollDimensions(material):
 	useDict = all_combiner_uses(material)
-		
+
 	if useDict['Texture 0'] and material.tex0.tex is not None and \
 		useDict['Texture 1'] and material.tex1.tex is not None and\
 		material.tex0.tex.size[0] > 0 and material.tex0.tex.size[1] > 0 and\
@@ -1779,7 +1780,7 @@ def update_preset_manual_v4(material, preset):
 	if preset.lower() != "custom":
 		material.f3d_update_flag = True
 		bpy.ops.script.execute_preset(override,
-			filepath=findF3DPresetPath(preset), 
+			filepath=findF3DPresetPath(preset),
 			menu_idname='MATERIAL_MT_f3d_presets')
 		material.f3d_update_flag = False
 
@@ -1806,7 +1807,7 @@ def createF3DMat(obj, preset = 'Shaded Solid', index = None):
 		material.blend_method = 'BLEND'
 		material.show_transparent_back = False
 
-		# Remove default shader 
+		# Remove default shader
 		node_tree = material.node_tree
 		nodes = material.node_tree.nodes
 		links = material.node_tree.links
@@ -1825,7 +1826,7 @@ def createF3DMat(obj, preset = 'Shaded Solid', index = None):
 		links.new(bsdf.inputs["Base Color"], tex0Node.outputs["Color"])
 		links.new(bsdf.inputs["Subsurface Color"], tex1Node.outputs["Color"])
 		bsdf.inputs['Specular'].default_value = 0
-		
+
 		update_preset_manual_v4(material, preset)
 
 		return material
@@ -1834,7 +1835,7 @@ def createF3DMat(obj, preset = 'Shaded Solid', index = None):
 	material.blend_method = 'HASHED'
 	material.show_transparent_back = False
 
-	# Remove default shader 
+	# Remove default shader
 	node_tree = material.node_tree
 	nodes = material.node_tree.nodes
 	links = material.node_tree.links
@@ -1845,9 +1846,9 @@ def createF3DMat(obj, preset = 'Shaded Solid', index = None):
 	y = 0
 
 	uvDict = {}
-	#texGenNode, x, y = addNodeAt(node_tree, 'ShaderNodeValue', 
+	#texGenNode, x, y = addNodeAt(node_tree, 'ShaderNodeValue',
 	#	'Texture Gen', x, y, 'Texture Gen', uvDict)
-	#texGenLinearNode, x, y = addNodeAt(node_tree, 'ShaderNodeValue', 
+	#texGenLinearNode, x, y = addNodeAt(node_tree, 'ShaderNodeValue',
 	#	'Texture Gen Linear', x, y, 'Texture Gen Linear', uvDict)
 
 	# Create UV nodes
@@ -1868,27 +1869,27 @@ def createF3DMat(obj, preset = 'Shaded Solid', index = None):
 		'Chroma Key Scale': 'ShaderNodeRGB',
 		#'Primitive Alpha': 'ShaderNodeValue',
 		#'Shade Alpha': 'ShaderNodeValue',
-		#'Environment Alpha' : 'ShaderNodeValue', 
-		'LOD Fraction' : 'ShaderNodeValue', 
-		'Primitive LOD Fraction' : 'ShaderNodeValue', 
-		'Noise' : 'ShaderNodeTexNoise', 
-		'YUV Convert K4' : 'ShaderNodeValue', 
-		'YUV Convert K5' : 'ShaderNodeValue', 
-		'1' : 'ShaderNodeValue', 
-		'0' : 'ShaderNodeValue', 
+		#'Environment Alpha' : 'ShaderNodeValue',
+		'LOD Fraction' : 'ShaderNodeValue',
+		'Primitive LOD Fraction' : 'ShaderNodeValue',
+		'Noise' : 'ShaderNodeTexNoise',
+		'YUV Convert K4' : 'ShaderNodeValue',
+		'YUV Convert K5' : 'ShaderNodeValue',
+		'1' : 'ShaderNodeValue',
+		'0' : 'ShaderNodeValue',
 		}, x, y)
 
 	# Set noise scale
 	nodeDict["Noise"].inputs[2].default_value = 10
 
-	createGroupLink(node_tree, nodeDict['Texture 0'].inputs[0], 
+	createGroupLink(node_tree, nodeDict['Texture 0'].inputs[0],
 		uvNode0.outputs[0], 'NodeSocketVector', 'UV0Output')
-	createGroupLink(node_tree, nodeDict['Texture 1'].inputs[0], 
+	createGroupLink(node_tree, nodeDict['Texture 1'].inputs[0],
 		uvNode1.outputs[0], 'NodeSocketVector', 'UV1Output')
 
 
 	# Note: Because of modulo operations on UVs, aliasing occurs
-	# due to mipmapping when 'Linear' filtering is used. 
+	# due to mipmapping when 'Linear' filtering is used.
 	# When using 'Cubic', clamping doesn't work correctly either.
 	# Thus 'Closest' is used instead.
 	nodes['Texture 0'].interpolation = 'Linear'
@@ -1914,14 +1915,14 @@ def createF3DMat(obj, preset = 'Shaded Solid', index = None):
 	# create shade node
 	x += 300
 	y = 0
-	#lightingNode, x, y = addNodeAt(node_tree, 'ShaderNodeValue', 
+	#lightingNode, x, y = addNodeAt(node_tree, 'ShaderNodeValue',
 	#	'Lighting', x, y)
-	#shadingNode, x, y = addNodeAt(node_tree, 'ShaderNodeValue', 
+	#shadingNode, x, y = addNodeAt(node_tree, 'ShaderNodeValue',
 	#	'Shading', x, y)
-	#ambientNode, x, y = addNodeAt(node_tree, 'ShaderNodeRGB', 
+	#ambientNode, x, y = addNodeAt(node_tree, 'ShaderNodeRGB',
 	#	'Ambient Color', x, y)
 	nodeDict['Shade Color'] = createShadeNode(node_tree, [x, y])
-	
+
 	#x += 300
 	#y = 0
 	#otherDict = {}
@@ -1985,7 +1986,7 @@ def reloadDefaultF3DPresets():
 			presetNameToFilename[bpy.path.display_name(presetName)] = presetName
 	for material in bpy.data.materials:
 		if material.mat_ver > 3 and material.f3d_mat.presetName in presetNameToFilename:
-			update_preset_manual_v4(material, presetNameToFilename[material.f3d_mat.presetName])	
+			update_preset_manual_v4(material, presetNameToFilename[material.f3d_mat.presetName])
 
 class CreateFast3DMaterial(bpy.types.Operator):
 	# set bl_ properties
@@ -2019,9 +2020,9 @@ class ReloadDefaultF3DPresets(bpy.types.Operator):
 		return {'FINISHED'} # must return a set
 
 class TextureFieldProperty(bpy.types.PropertyGroup):
-	clamp : bpy.props.BoolProperty(name = 'Clamp', 
+	clamp : bpy.props.BoolProperty(name = 'Clamp',
 		update = update_tex_values)
-	mirror : bpy.props.BoolProperty(name = 'Mirror', 
+	mirror : bpy.props.BoolProperty(name = 'Mirror',
 		update = update_tex_values)
 	low : bpy.props.FloatProperty(name = 'Low', min = 0, max = 1023.75,
 		update = update_tex_values)
@@ -2067,39 +2068,39 @@ def on_tex_autoprop(texProperty, context):
 
 class CombinerProperty(bpy.types.PropertyGroup):
 	A : bpy.props.EnumProperty(
-		name = "A", description = "A", items = combiner_enums['Case A'], 
+		name = "A", description = "A", items = combiner_enums['Case A'],
 		default = 'TEXEL0', update = update_node_values)
 
 	B : bpy.props.EnumProperty(
-		name = "B", description = "B", items = combiner_enums['Case B'], 
+		name = "B", description = "B", items = combiner_enums['Case B'],
 		default = '0', update = update_node_values)
 
 	C : bpy.props.EnumProperty(
-		name = "C", description = "C", items = combiner_enums['Case C'], 
+		name = "C", description = "C", items = combiner_enums['Case C'],
 		default = 'SHADE', update = update_node_values)
 
 	D : bpy.props.EnumProperty(
-		name = "D", description = "D", items = combiner_enums['Case D'], 
+		name = "D", description = "D", items = combiner_enums['Case D'],
 		default = '0', update = update_node_values)
 
 	A_alpha : bpy.props.EnumProperty(
-		name = "A Alpha", description = "A Alpha", 
-		items = combiner_enums['Case A Alpha'], 
+		name = "A Alpha", description = "A Alpha",
+		items = combiner_enums['Case A Alpha'],
 		default = '0', update = update_node_values)
 
 	B_alpha : bpy.props.EnumProperty(
-		name = "B Alpha", description = "B Alpha", 
-		items = combiner_enums['Case B Alpha'], 
+		name = "B Alpha", description = "B Alpha",
+		items = combiner_enums['Case B Alpha'],
 		default = '0', update = update_node_values)
 
 	C_alpha : bpy.props.EnumProperty(
-		name = "C Alpha", description = "C Alpha", 
-		items = combiner_enums['Case C Alpha'], 
+		name = "C Alpha", description = "C Alpha",
+		items = combiner_enums['Case C Alpha'],
 		default = '0', update = update_node_values)
 
 	D_alpha : bpy.props.EnumProperty(
-		name = "D Alpha", description = "D Alpha", 
-		items = combiner_enums['Case D Alpha'], 
+		name = "D Alpha", description = "D Alpha",
+		items = combiner_enums['Case D Alpha'],
 		default = 'ENVIRONMENT', update = update_node_values)
 
 class ProceduralAnimProperty(bpy.types.PropertyGroup):
@@ -2144,12 +2145,12 @@ class RDPSettings(bpy.types.PropertyGroup):
 		name = 'Texture UV Generate Linear',
 		update = update_node_values)
 	#v1/2 difference
-	g_shade_smooth : bpy.props.BoolProperty(name = 'Smooth Shading', 
+	g_shade_smooth : bpy.props.BoolProperty(name = 'Smooth Shading',
 		default = True,	update = update_node_values)
 	# f3dlx2 only
 	g_clipping : bpy.props.BoolProperty(name = 'Clipping',
 		update = update_node_values)
-	
+
 	# upper half mode
 	# v2 only
 	g_mdsft_alpha_dither : bpy.props.EnumProperty(
@@ -2171,7 +2172,7 @@ class RDPSettings(bpy.types.PropertyGroup):
 	g_mdsft_textdetail : bpy.props.EnumProperty(
 		name = 'Texture Detail', items = enumTextDetail, default = 'G_TD_CLAMP', update = update_node_values)
 	g_mdsft_textpersp : bpy.props.EnumProperty(
-		name = 'Texture Perspective Correction', items = enumTextPersp, 
+		name = 'Texture Perspective Correction', items = enumTextPersp,
 		default = 'G_TP_PERSP', update = update_node_values)
 	g_mdsft_cycletype : bpy.props.EnumProperty(
 		name = 'Cycle Type', items = enumCycleType, default = 'G_CYC_1CYCLE',
@@ -2182,13 +2183,13 @@ class RDPSettings(bpy.types.PropertyGroup):
 	g_mdsft_pipeline : bpy.props.EnumProperty(
 		name = 'Pipeline Span Buffer Coherency', items = enumPipelineMode,
 		default = 'G_PM_1PRIMITIVE', update = update_node_values)
-	
+
 	# lower half mode
 	g_mdsft_alpha_compare : bpy.props.EnumProperty(
-		name = 'Alpha Compare', items = enumAlphaCompare, 
+		name = 'Alpha Compare', items = enumAlphaCompare,
 		default = 'G_AC_NONE', update = update_node_values)
 	g_mdsft_zsrcsel : bpy.props.EnumProperty(
-		name = 'Z Source Selection', items = enumDepthSource, 
+		name = 'Z Source Selection', items = enumDepthSource,
 		default = 'G_ZS_PIXEL', update = update_node_values)
 
 	clip_ratio : bpy.props.IntProperty(default = 1,
@@ -2215,7 +2216,7 @@ class RDPSettings(bpy.types.PropertyGroup):
 	alpha_cvg_sel : bpy.props.BoolProperty(update = update_node_values)
 	force_bl : bpy.props.BoolProperty(update = update_node_values)
 
-	# cycle dependent - (P * A + M - B) / (A + B) 
+	# cycle dependent - (P * A + M - B) / (A + B)
 	blend_p1 : bpy.props.EnumProperty(
 		name = 'Color Source 1', items = enumBlendColor, update = update_node_values)
 	blend_p2 : bpy.props.EnumProperty(
@@ -2239,7 +2240,7 @@ class DefaultRDPSettingsPanel(bpy.types.Panel):
 	bl_space_type = 'PROPERTIES'
 	bl_region_type = 'WINDOW'
 	bl_context = "world"
-	bl_options = {'HIDE_HEADER'} 
+	bl_options = {'HIDE_HEADER'}
 
 	@classmethod
 	def poll(cls, context):
@@ -2286,13 +2287,13 @@ node_categories = [
 			"my_float_prop": repr(2.0),
 		}),
 		NodeItem("Fast3D_NodeType", label="Shaded Texture", settings={
-			"inA": repr('1'), "inB": repr('8'), "inC": repr('4'), 
-			"inD": repr('7'), "inA_alpha": repr('7'), "inB_alpha": repr('7'), 
-			"inC_alpha": repr('7'), "inD_alpha": repr('5'), 
+			"inA": repr('1'), "inB": repr('8'), "inC": repr('4'),
+			"inD": repr('7'), "inA_alpha": repr('7'), "inB_alpha": repr('7'),
+			"inC_alpha": repr('7'), "inD_alpha": repr('5'),
 		}),
 		NodeItem("Fast3DSplitter_NodeType", label="Splitter", settings={
 		}),
-		'''    
+		'''
 	]),
 ]
 
@@ -2303,7 +2304,7 @@ def getOptimalFormat(tex, useLargeTextures):
 	if bpy.context.scene.ignoreTextureRestrictions or \
 		tex.size[0] * tex.size[1] > 8192: # Image too big
 		return 'RGBA32'
-	
+
 	isGreyscale = True
 	hasAlpha4bit = False
 	hasAlpha1bit = False
@@ -2325,7 +2326,7 @@ def getOptimalFormat(tex, useLargeTextures):
 			pixelColor = getRGBA16Tuple(color)
 			if pixelColor not in pixelValues:
 				pixelValues.append(pixelColor)
-	
+
 	if isGreyscale:
 		if tex.size[0] * tex.size[1] > 4096:
 			if not hasAlpha1bit:
@@ -2344,17 +2345,17 @@ def getOptimalFormat(tex, useLargeTextures):
 			texFormat = 'CI8'
 		else:
 			texFormat = 'RGBA16'
-	
+
 	return texFormat
 
 def getCurrentPresetDir():
 	return "f3d/" + bpy.context.scene.gameEditorMode.lower()
-	
+
 # modules/bpy_types.py -> Menu
 class MATERIAL_MT_f3d_presets(Menu):
 	bl_label = "F3D Material Presets"
 	preset_operator = "script.execute_preset"
-	
+
 	def draw(self, _context):
 		"""
 		Define these on the subclass:
@@ -2499,11 +2500,11 @@ class AddPresetF3D(AddPresetBase, Operator):
 			ext = ".py"
 
 		name = self.name.strip() if is_preset_add else self.name
-			
+
 		if is_preset_add:
 			if not name:
 				return {'FINISHED'}
-			
+
 			filename = self.as_filename(name)
 			if filename in material_presets or filename == "custom":
 				self.report({'WARNING'}, "Unable to delete/overwrite default presets.")
@@ -2587,7 +2588,7 @@ class AddPresetF3D(AddPresetBase, Operator):
 
 			presetName = bpy.path.display_name(filename)
 			preset_menu_class.bl_label = presetName
-			
+
 			for otherMat in bpy.data.materials:
 				if otherMat.f3d_mat.presetName == presetName and otherMat != context.material:
 					update_preset_manual_v4(otherMat, filename)
@@ -2696,7 +2697,7 @@ def convertToNewMat(material, oldMat):
 	# Chroma
 	material.f3d_mat.key_scale = oldMat.key_scale
 	material.f3d_mat.key_width = oldMat.key_width
-	
+
 	# Convert
 	material.f3d_mat.k0 = oldMat.k0
 	material.f3d_mat.k1 = oldMat.k1
@@ -2704,7 +2705,7 @@ def convertToNewMat(material, oldMat):
 	material.f3d_mat.k3 = oldMat.k3
 	material.f3d_mat.k4 = oldMat.k4
 	material.f3d_mat.k5 = oldMat.k5
-	
+
 	# Prim
 	material.f3d_mat.prim_lod_frac = oldMat.prim_lod_frac
 	material.f3d_mat.prim_lod_min = oldMat.prim_lod_min
@@ -2783,15 +2784,15 @@ class F3DMaterialProperty(bpy.types.PropertyGroup):
 	# Chroma
 	key_scale : bpy.props.FloatVectorProperty(name = 'Key Scale', min = 0, max = 1, step = 1, update = update_node_values)
 	key_width : bpy.props.FloatVectorProperty(name = 'Key Width', min = 0, max = 16, update = update_node_values)
-	
+
 	# Convert
 	k0 : bpy.props.FloatProperty(min = -1, max = 1, default = 175/255, step = 1, update = update_node_values)
 	k1 : bpy.props.FloatProperty(min = -1, max = 1, default = -43/255, step = 1, update = update_node_values)
-	k2 : bpy.props.FloatProperty(min = -1, max = 1, default = -89/255, step = 1, update = update_node_values)	
+	k2 : bpy.props.FloatProperty(min = -1, max = 1, default = -89/255, step = 1, update = update_node_values)
 	k3 : bpy.props.FloatProperty(min = -1, max = 1, default = 222/255, step = 1, update = update_node_values)
 	k4 : bpy.props.FloatProperty(min = -1, max = 1, default = 114/255, step = 1, update = update_node_values)
 	k5 : bpy.props.FloatProperty(min = -1, max = 1, default = 42/255, step = 1, update = update_node_values)
-	
+
 	# Prim
 	prim_lod_frac : bpy.props.FloatProperty(name = 'Prim LOD Frac', min = 0, max = 1, step = 1, update = update_node_values)
 	prim_lod_min : bpy.props.FloatProperty(name = 'Min LOD Ratio', min = 0, max = 1, step = 1, update = update_node_values)
@@ -2873,7 +2874,7 @@ class UpdateF3DNodes(bpy.types.Operator):
 			self.report({"ERROR"}, "Material is not F3D.")
 			return {"CANCELLED"}
 		material = context.material
-		
+
 		material.f3d_update_flag = True
 		update_node_values_of_material(material, context)
 		if material.mat_ver > 3:
@@ -2951,7 +2952,7 @@ def mat_unregister_old():
 	# Chroma
 	del bpy.types.Material.key_scale
 	del bpy.types.Material.key_width
-	
+
 	# Convert
 	del bpy.types.Material.k0
 	del bpy.types.Material.k1
@@ -2959,7 +2960,7 @@ def mat_unregister_old():
 	del bpy.types.Material.k3
 	del bpy.types.Material.k4
 	del bpy.types.Material.k5
-	
+
 	# Prim
 	del bpy.types.Material.prim_lod_frac
 	del bpy.types.Material.prim_lod_min
@@ -2991,7 +2992,7 @@ def mat_unregister_old():
 
 def mat_register_old():
 	bpy.types.Material.f3d_preset = bpy.props.EnumProperty(name = 'F3D Preset',
-		items = enumMaterialPresets, default = 'Custom', 
+		items = enumMaterialPresets, default = 'Custom',
 		update = update_preset)
 
 	bpy.types.Material.scale_autoprop = bpy.props.BoolProperty(
@@ -3025,7 +3026,7 @@ def mat_register_old():
 
 	# material textures
 	bpy.types.Material.tex_scale = bpy.props.FloatVectorProperty(
-		min = 0, max = 1, size = 2, default = (1,1), step = 1, 
+		min = 0, max = 1, size = 2, default = (1,1), step = 1,
 		update = update_tex_values)
 	bpy.types.Material.tex0 = bpy.props.PointerProperty(type = TextureProperty)
 	bpy.types.Material.tex1 = bpy.props.PointerProperty(type = TextureProperty)
@@ -3059,21 +3060,21 @@ def mat_register_old():
 	bpy.types.Material.key_width = bpy.props.FloatVectorProperty(
 		name = 'Key Width', min = 0, max = 16,
 		update = update_node_values)
-	
+
 	# Convert
 	bpy.types.Material.k0 = bpy.props.FloatProperty(min = -1, max = 1,
 		default = 175/255, step = 1, update = update_node_values)
 	bpy.types.Material.k1 = bpy.props.FloatProperty(min = -1, max = 1,
 		default = -43/255, step = 1, update = update_node_values)
 	bpy.types.Material.k2 = bpy.props.FloatProperty(min = -1, max = 1,
-		default = -89/255, step = 1, update = update_node_values)	
+		default = -89/255, step = 1, update = update_node_values)
 	bpy.types.Material.k3 = bpy.props.FloatProperty(min = -1, max = 1,
 		default = 222/255, step = 1, update = update_node_values)
 	bpy.types.Material.k4 = bpy.props.FloatProperty(min = -1, max = 1,
 		default = 114/255, step = 1, update = update_node_values)
 	bpy.types.Material.k5 = bpy.props.FloatProperty(min = -1, max = 1,
 		default = 42/255, step = 1, update = update_node_values)
-	
+
 	# Prim
 	bpy.types.Material.prim_lod_frac = bpy.props.FloatProperty(
 		name = 'Prim LOD Frac', min = 0, max = 1, step = 1,
@@ -3149,7 +3150,7 @@ def mat_register():
 	#bpy.app.handlers.load_post.append(loadTimer)
 	for cls in mat_classes:
 		register_class(cls)
-	
+
 	#presetDict = addMaterialPresets()
 	#for presetName, presetItem in presetDict.items():
 	#	enumMaterialPresets.append((presetName, presetName, presetName))
@@ -3162,7 +3163,7 @@ def mat_register():
 	bpy.types.Scene.f3d_type = bpy.props.EnumProperty(
 		name = 'F3D Microcode', items = enumF3D, default = 'F3D')
 	bpy.types.Scene.isHWv1 = bpy.props.BoolProperty(name = 'Is Hardware v1?')
-	
+
 	# RDP Defaults
 	bpy.types.World.rdp_defaults = bpy.props.PointerProperty(
 		type = RDPSettings)
@@ -3178,7 +3179,7 @@ def mat_register():
 	bpy.types.Material.f3d_update_flag = bpy.props.BoolProperty()
 	bpy.types.Material.f3d_mat = bpy.props.PointerProperty(type = F3DMaterialProperty)
 	bpy.types.Material.menu_tab = bpy.props.EnumProperty(items = enumF3DMenu)
-	
+
 	bpy.types.Scene.f3dUserPresetsOnly = bpy.props.BoolProperty(name = "User Presets Only")
 	bpy.types.Scene.f3d_simple = bpy.props.BoolProperty(name = "Display Simple", default = True)
 

--- a/fast64_internal/f3d/f3d_writer.py
+++ b/fast64_internal/f3d/f3d_writer.py
@@ -422,7 +422,8 @@ def saveStaticModel(triConverterInfo, fModel, obj, transformMatrix, ownerName, c
 
 def addCullCommand(obj, fMesh, transformMatrix, matWriteMethod):
 	fMesh.add_cull_vtx()
-	for vertexPos in obj.bound_box:
+	# if the object has a specifically set culling bounds, use that instead
+	for vertexPos in obj.get('culling_bounds', obj.bound_box):
 		# Most other fields of convertVertexData are unnecessary for bounding box verts
 		fMesh.cullVertexList.vertices.append(
 			convertVertexData(obj.data, 

--- a/fast64_internal/f3d/f3d_writer.py
+++ b/fast64_internal/f3d/f3d_writer.py
@@ -79,7 +79,7 @@ def getInfoDict(obj):
 			raise PluginError("Object \'" + obj.name + "\' does not have a UV layer named \'UVMap.\'")
 	for face in mesh.loop_triangles:
 		validNeighborDict[face] = []
-		material = obj.material_slots[face.material_index].material 
+		material = obj.material_slots[face.material_index].material
 		if material is None:
 			raise PluginError("There are some faces on your mesh that are assigned to an empty material slot.")
 		for vertIndex in face.vertices:
@@ -94,10 +94,10 @@ def getInfoDict(obj):
 				edgeDict[edgeKey].append(face)
 
 		for loopIndex in face.loops:
-			convertInfo = LoopConvertInfo(uv_data, obj, 
+			convertInfo = LoopConvertInfo(uv_data, obj,
 				isLightingDisabled(obj.material_slots[face.material_index].material))
 			f3dVertDict[loopIndex] = getF3DVert(mesh.loops[loopIndex], face, convertInfo, mesh)
-	for face in mesh.loop_triangles:	
+	for face in mesh.loop_triangles:
 		for edgeKey in face.edge_keys:
 			for otherFace in edgeDict[edgeKey]:
 				if otherFace == face:
@@ -166,16 +166,16 @@ def fixLargeUVs(obj):
 			minDiff = (-cellSize[i]+2) - minUV[i]
 			if minDiff > 0:
 				applyOffset(minUV, maxUV, uvOffset, ceil(minDiff / UVinterval[i]) * UVinterval[i], i)
-			
+
 			maxDiff = maxUV[i] - (cellSize[i] - 1)
 			if maxDiff > 0:
 				applyOffset(minUV, maxUV, uvOffset, -ceil(maxDiff / UVinterval[i]) * UVinterval[i], i)
 
 		for loopIndex in polygon.loop_indices:
 			newUV = (uv_data[loopIndex].uv[0] + uvOffset[0],
-				uv_data[loopIndex].uv[1] + uvOffset[1]) 
+				uv_data[loopIndex].uv[1] + uvOffset[1])
 			uv_data[loopIndex].uv = newUV
-				
+
 			#if newUV[0] > cellSize[0] or \
 			#	newUV[1] > cellSize[1] or \
 			#	newUV[0] < -cellSize[0] or \
@@ -229,7 +229,7 @@ class TileLoad:
 		new_th = max(th, self.th)
 		newWidth = abs(new_sl - new_sh) + 1
 		newHeight = abs(new_tl - new_th) + 1
-		
+
 		tmemUsage = getTmemWordUsage(self.texFormat, newWidth, newHeight) * 8 *\
 			(2 if self.twoTextures else 1)
 
@@ -245,7 +245,7 @@ class TileLoad:
 	def tryAdd(self, points):
 		if len(points) == 0:
 			return True
-		
+
 		sl = self.getLow(points[0][0])
 		sh = self.getHigh(points[0][0], 0)
 		tl = self.getLow(points[0][1])
@@ -262,14 +262,14 @@ class TileLoad:
 			sh = max(self.getHigh(point[0], 0), sh)
 			tl = min(self.getLow(point[1]), tl)
 			th = max(self.getHigh(point[1], 1), th)
-		
+
 		return self.appendTile(sl, sh, tl, th)
 
 	def getDimensions(self):
 		return [abs(self.sl - self.sh) + 1,
 			abs(self.tl - self.th) + 1]
-		
-def saveMeshWithLargeTexturesByFaces(material, faces, fModel, fMesh, obj, drawLayer, 
+
+def saveMeshWithLargeTexturesByFaces(material, faces, fModel, fMesh, obj, drawLayer,
 	convertTextureData, currentGroupIndex, triConverterInfo, existingVertData, matRegionDict):
 	if len(faces) == 0:
 		print('0 Faces Provided.')
@@ -305,7 +305,7 @@ def saveMeshWithLargeTexturesByFaces(material, faces, fModel, fMesh, obj, drawLa
 		faceTileLoads[face] = faceTileLoad
 		if not faceTileLoad.tryAdd(uvs):
 			raise PluginError("Large texture material " + str(material.name) + " has a triangle that is too large to fit in a single tile load.")
-		
+
 		added = False
 		for tileLoad, sortedFaces in tileLoads.items():
 			if tileLoad.tryAppend(faceTileLoad):
@@ -331,10 +331,10 @@ def saveMeshWithLargeTexturesByFaces(material, faces, fModel, fMesh, obj, drawLa
 			#nextTmem = 0
 			#revertCommands = GfxList("temp", GfxListTag.Draw, fModel.DLFormat) # Unhandled?
 			#texDimensions, nextTmem = \
-			#	saveTextureIndex(material.name, fModel, fMaterial, triGroup.triList, revertCommands, otherTex, 0, nextTmem, 
+			#	saveTextureIndex(material.name, fModel, fMaterial, triGroup.triList, revertCommands, otherTex, 0, nextTmem,
 			#		None, False, None, True, True)
 
-	#saveGeometry(obj, triList, fMesh.vertexList, bFaces, 
+	#saveGeometry(obj, triList, fMesh.vertexList, bFaces,
 	#	bMesh, texDimensions, transformMatrix, isPointSampled, isFlatShaded,
 	#	exportVertexColors, fModel.f3d)
 	currentGroupIndex = None
@@ -344,22 +344,22 @@ def saveMeshWithLargeTexturesByFaces(material, faces, fModel, fMesh, obj, drawLa
 		triGroup.triList.commands.append(DPPipeSync())
 		if fMaterial.texturesLoaded[0] and not (otherTextureIndex == 0 and otherTexSingleLoad):
 			texDimensions0, nextTmem = \
-				saveTextureIndex(material.name, fModel, fMaterial, triGroup.triList, revertCommands, f3dMat.tex0, 0, nextTmem, 
+				saveTextureIndex(material.name, fModel, fMaterial, triGroup.triList, revertCommands, f3dMat.tex0, 0, nextTmem,
 				None, False, [tileLoad, None], True, False)
 		if fMaterial.texturesLoaded[1] and not (otherTextureIndex == 1 and otherTexSingleLoad):
-			texDimensions1, nextTmem = saveTextureIndex(material.name, fModel, 
+			texDimensions1, nextTmem = saveTextureIndex(material.name, fModel,
 				fMaterial, triGroup.triList, revertCommands, f3dMat.tex1, 1, nextTmem, None, False,
 				[None, tileLoad], True, False)
 
-		triConverter = TriangleConverter(triConverterInfo, texDimensions, material, currentGroupIndex, 
-			triGroup.triList, triGroup.vertexList, 
+		triConverter = TriangleConverter(triConverterInfo, texDimensions, material, currentGroupIndex,
+			triGroup.triList, triGroup.vertexList,
 			copy.deepcopy(existingVertData), copy.deepcopy(matRegionDict))
 
 		currentGroupIndex = saveTriangleStrip(triConverter, tileFaces, obj.data, False)
 
 		if len(revertCommands.commands) > 0:
 			fMesh.draw.commands.extend(revertCommands.commands)
-	
+
 	triGroup.triList.commands.append(SPEndDisplayList())
 
 	if fMaterial.revert is not None:
@@ -372,7 +372,7 @@ def saveMeshWithLargeTexturesByFaces(material, faces, fModel, fMesh, obj, drawLa
 def saveStaticModel(triConverterInfo, fModel, obj, transformMatrix, ownerName, convertTextureData, revertMatAtEnd, drawLayerField):
 	if len(obj.data.polygons) == 0:
 		return None
-	
+
 	#checkForF3DMaterial(obj)
 
 	facesByMat = {}
@@ -384,7 +384,7 @@ def saveStaticModel(triConverterInfo, fModel, obj, transformMatrix, ownerName, c
 	fMeshes = {}
 	for material_index, faces in facesByMat.items():
 		material = obj.material_slots[material_index].material
-		
+
 		if drawLayerField is not None and material.mat_ver > 3:
 			drawLayer = getattr(material.f3d_mat.draw_layer, drawLayerField)
 			drawLayerName = drawLayer
@@ -406,12 +406,12 @@ def saveStaticModel(triConverterInfo, fModel, obj, transformMatrix, ownerName, c
 			saveOrGetF3DMaterial(material, fModel, obj, drawLayer, convertTextureData)
 
 		if fMaterial.useLargeTextures:
-			saveMeshWithLargeTexturesByFaces(material, faces, fModel, fMesh, obj, drawLayer, convertTextureData, None, 
+			saveMeshWithLargeTexturesByFaces(material, faces, fModel, fMesh, obj, drawLayer, convertTextureData, None,
 				triConverterInfo, None, None)
 		else:
-			saveMeshByFaces(material, faces,  
+			saveMeshByFaces(material, faces,
 				fModel, fMesh, obj, drawLayer, convertTextureData, None, triConverterInfo, None, None)
-	
+
 	for drawLayer, fMesh in fMeshes.items():
 		if revertMatAtEnd:
 			fModel.onEndDraw(fMesh, obj)
@@ -426,8 +426,8 @@ def addCullCommand(obj, fMesh, transformMatrix, matWriteMethod):
 	for vertexPos in obj.get('culling_bounds', obj.bound_box):
 		# Most other fields of convertVertexData are unnecessary for bounding box verts
 		fMesh.cullVertexList.vertices.append(
-			convertVertexData(obj.data, 
-				mathutils.Vector(vertexPos), [0,0], 
+			convertVertexData(obj.data,
+				mathutils.Vector(vertexPos), [0,0],
 				mathutils.Vector([0,0,0,0]), [32, 32],
 				transformMatrix, False, False))
 
@@ -461,7 +461,7 @@ def exportF3DCommon(obj, fModel, transformMatrix, includeChildren, name, DLForma
 		drawLayer = fModel.getDrawLayerV3(tempObj)
 		infoDict = getInfoDict(tempObj)
 		triConverterInfo = TriangleConverterInfo(tempObj, None, fModel.f3d, transformMatrix, infoDict)
-		fMesh = saveStaticModel(triConverterInfo, fModel, tempObj, 
+		fMesh = saveStaticModel(triConverterInfo, fModel, tempObj,
 			transformMatrix, name, convertTextureData, True, None)[drawLayer]
 		cleanupCombineObj(tempObj, meshList)
 		obj.select_set(True)
@@ -471,7 +471,7 @@ def exportF3DCommon(obj, fModel, transformMatrix, includeChildren, name, DLForma
 		obj.select_set(True)
 		bpy.context.view_layer.objects.active = obj
 		raise Exception(str(e))
-	
+
 	return fMesh
 
 
@@ -527,7 +527,7 @@ def getLowestUnvisitedNeighborCountFace(unvisitedFaces, infoDict):
 
 def getNextNeighborFace(faces, face, lastEdgeKey, visitedFaces, possibleFaces,
 	infoDict):
-	
+
 	if lastEdgeKey is not None:
 		handledEdgeKeys = [lastEdgeKey]
 		nextEdgeKey = face.edge_keys[
@@ -577,7 +577,7 @@ def saveTriangleStrip(triConverter, faces, mesh, terminateDL):
 				neighborFace =  getLowestUnvisitedNeighborCountFace(
 					unvisitedFaces, infoDict)
 				lastEdgeKey = None
-		
+
 		triConverter.addFace(neighborFace)
 		if neighborFace in visitedFaces:
 			raise PluginError("Repeated face")
@@ -588,9 +588,9 @@ def saveTriangleStrip(triConverter, faces, mesh, terminateDL):
 		for otherFace in infoDict.validNeighbors[neighborFace]:
 			infoDict.validNeighbors[otherFace].remove(neighborFace)
 
-		neighborFace, lastEdgeKey = getNextNeighborFace(faces, 
+		neighborFace, lastEdgeKey = getNextNeighborFace(faces,
 			neighborFace, lastEdgeKey, visitedFaces, possibleFaces, infoDict)
-	
+
 	triConverter.finish(terminateDL)
 	return triConverter.currentGroupIndex
 
@@ -617,7 +617,7 @@ def checkIfFlatShaded(material):
 		f3dMat = material
 	return not f3dMat.rdp_settings.g_shade_smooth
 
-def saveMeshByFaces(material, faces, fModel, fMesh, obj, drawLayer, 
+def saveMeshByFaces(material, faces, fModel, fMesh, obj, drawLayer,
 	convertTextureData, currentGroupIndex, triConverterInfo,
 	existingVertData, matRegionDict):
 	if len(faces) == 0:
@@ -634,12 +634,12 @@ def saveMeshByFaces(material, faces, fModel, fMesh, obj, drawLayer,
 	triGroup = fMesh.tri_group_new(fMaterial)
 	fMesh.draw.commands.append(SPDisplayList(triGroup.triList))
 
-	triConverter = TriangleConverter(triConverterInfo, texDimensions, material, 
-		currentGroupIndex, triGroup.triList, triGroup.vertexList, 
+	triConverter = TriangleConverter(triConverterInfo, texDimensions, material,
+		currentGroupIndex, triGroup.triList, triGroup.vertexList,
 		copy.deepcopy(existingVertData), copy.deepcopy(matRegionDict))
 
 	currentGroupIndex = saveTriangleStrip(triConverter, faces, obj.data, True)
-	
+
 	if fMaterial.revert is not None:
 		fMesh.draw.commands.append(SPDisplayList(fMaterial.revert))
 
@@ -648,13 +648,13 @@ def saveMeshByFaces(material, faces, fModel, fMesh, obj, drawLayer,
 def get8bitRoundedNormal(loop, mesh):
 	alpha_layer = mesh.vertex_colors['Alpha'].data if 'Alpha' in \
 		mesh.vertex_colors else None
-	
+
 	if alpha_layer is not None:
 		normalizedAColor = alpha_layer[loop.index].color
 		normalizedA = mathutils.Color(normalizedAColor[0:3]).v
 	else:
 		normalizedA = 1
-	
+
 	# Don't round, as this may move UV toward UV bounds.
 	return mathutils.Vector(
 		(int(loop.normal[0] * 128) / 128,
@@ -704,7 +704,7 @@ class TriangleConverterInfo:
 
 		# Caching names
 		self.groupNames = {}
-	
+
 	def getMatrixAddrFromGroup(self, groupIndex):
 		raise PluginError("TriangleConverterInfo must be extended with getMatrixAddrFromGroup implemented for game specific uses.")
 
@@ -716,16 +716,16 @@ class TriangleConverterInfo:
 				self.groupNames[groupIndex] = getGroupNameFromIndex(self.obj, groupIndex)
 			name = self.groupNames[groupIndex]
 			if name not in self.armature.bones:
-				print("Vertex group " + name + " not found in bones.")	
+				print("Vertex group " + name + " not found in bones.")
 				groupMatrix = mathutils.Matrix.Identity(4)
 			else:
 				groupMatrix = self.armature.bones[name].matrix_local.inverted()
 		return self.transformMatrix @ groupMatrix
-		
+
 # existingVertexData is used for cases where we want to assume the presence of vertex data
 # loaded in from a previous matrix transform (ex. sm64 skinning)
 class TriangleConverter:
-	def __init__(self, triConverterInfo, texDimensions, material, currentGroupIndex, 
+	def __init__(self, triConverterInfo, texDimensions, material, currentGroupIndex,
 		triList, vtxList, existingVertexData, existingVertexMaterialRegions):
 		self.triConverterInfo = triConverterInfo
 		self.currentGroupIndex = currentGroupIndex
@@ -734,7 +734,7 @@ class TriangleConverter:
 		# Existing data assumed to be already loaded in.
 		if existingVertexData is not None:
 			# [(position, uv, colorOrNormal)]
-			self.vertBuffer = existingVertexData 
+			self.vertBuffer = existingVertexData
 		else:
 			self.vertBuffer = []
 		self.existingVertexMaterialRegions = existingVertexMaterialRegions
@@ -752,7 +752,7 @@ class TriangleConverter:
 		self.isPointSampled = isPointSampled
 		self.exportVertexColors = exportVertexColors
 
-		
+
 
 	def vertInBuffer(self, bufferVert, material_index):
 		if self.existingVertexMaterialRegions is None:
@@ -784,18 +784,18 @@ class TriangleConverter:
 			currentLimbVerts = limbVerts[self.currentGroupIndex]
 			self.vertBuffer = self.vertBuffer[:self.bufferStart] + currentLimbVerts
 			self.triList.commands.append(
-				SPVertex(self.vtxList, len(self.vtxList.vertices), 
+				SPVertex(self.vtxList, len(self.vtxList.vertices),
 				len(currentLimbVerts), self.bufferStart))
 			bufferEnd += len(currentLimbVerts)
 			del limbVerts[self.currentGroupIndex]
-		
+
 			# Save vertices
 			for bufferVert in self.vertBuffer[bufferStart : bufferEnd]:
-				self.vtxList.vertices.append(convertVertexData(self.triConverterInfo.mesh, 
+				self.vtxList.vertices.append(convertVertexData(self.triConverterInfo.mesh,
 					bufferVert.f3dVert[0], bufferVert.f3dVert[1], bufferVert.f3dVert[2], self.texDimensions,
 					self.triConverterInfo.getTransformMatrix(bufferVert.groupIndex), self.isPointSampled,
 					self.exportVertexColors))
-			
+
 			bufferStart = bufferEnd
 		else:
 			self.vertBuffer = self.vertBuffer[:self.bufferStart]
@@ -806,15 +806,15 @@ class TriangleConverter:
 				self.triList.commands.append(SPMatrix(self.triConverterInfo.getMatrixAddrFromGroup(groupIndex), "G_MTX_LOAD"))
 				self.currentGroupIndex = groupIndex
 			self.triList.commands.append(
-				SPVertex(self.vtxList, len(self.vtxList.vertices), 
+				SPVertex(self.vtxList, len(self.vtxList.vertices),
 				len(bufferVerts), bufferStart))
-			
+
 			self.vertBuffer += bufferVerts
 			bufferEnd += len(bufferVerts)
 
 			# Save vertices
 			for bufferVert in self.vertBuffer[bufferStart : bufferEnd]:
-				self.vtxList.vertices.append(convertVertexData(self.triConverterInfo.mesh, 
+				self.vtxList.vertices.append(convertVertexData(self.triConverterInfo.mesh,
 					bufferVert.f3dVert[0], bufferVert.f3dVert[1], bufferVert.f3dVert[2], self.texDimensions,
 					self.triConverterInfo.getTransformMatrix(bufferVert.groupIndex), self.isPointSampled,
 					self.exportVertexColors))
@@ -834,7 +834,7 @@ class TriangleConverter:
 		for loopIndex in face.loops:
 			loop = self.triConverterInfo.mesh.loops[loopIndex]
 			vertexGroup = self.triConverterInfo.vertexGroupInfo.vertexGroups[loop.vertex_index] if self.triConverterInfo.vertexGroupInfo is not None else None
-			bufferVert = BufferVertex(getF3DVert(loop, face, self.convertInfo, self.triConverterInfo.mesh), 
+			bufferVert = BufferVertex(getF3DVert(loop, face, self.convertInfo, self.triConverterInfo.mesh),
 				vertexGroup, face.material_index)
 			triIndices.append(bufferVert)
 			if not self.vertInBuffer(bufferVert, face.material_index):
@@ -845,7 +845,7 @@ class TriangleConverter:
 			else:
 				allVerts.append(bufferVert)
 				existingVerts.append(None)
-		
+
 		# We care only about load size, since loading is what takes up time.
 		# Even if vert_buffer is larger, its still another load to fill it.
 		if len(self.vertBuffer) + len(addedVerts) > self.triConverterInfo.f3d.vert_load_size:
@@ -855,16 +855,16 @@ class TriangleConverter:
 		else:
 			self.vertBuffer.extend(addedVerts)
 			self.vertexBufferTriangles.append(triIndices)
-	
+
 	def finish(self, terminateDL):
 		if len(self.vertexBufferTriangles) > 0:
 			self.processGeometry()
-		
+
 		#if self.originalGroupIndex != self.currentGroupIndex:
 		#	self.triList.commands.append(SPMatrix(getMatrixAddrFromGroup(self.originalGroupIndex), "G_MTX_LOAD"))
 		if terminateDL:
 			self.triList.commands.append(SPEndDisplayList())
-	
+
 def getF3DVert(loop, face, convertInfo, mesh):
 	position = mesh.vertices[loop.vertex_index].co.copy().freeze()
 	# N64 is -Y, Blender is +Y
@@ -872,9 +872,9 @@ def getF3DVert(loop, face, convertInfo, mesh):
 	uv[:] = [field if not math.isnan(field) else 0 for field in uv]
 	uv[1] = 1 - uv[1]
 	uv = uv.freeze()
-	colorOrNormal = getLoopColorOrNormal(loop, face, 
+	colorOrNormal = getLoopColorOrNormal(loop, face,
 		convertInfo.obj.data, convertInfo.obj, convertInfo.exportVertexColors)
-	
+
 	return (position, uv, colorOrNormal)
 
 def getLoopNormal(loop, face, mesh, isFlatShaded):
@@ -906,7 +906,7 @@ def getLoopNormalCreased(bLoop, obj):
 		nextFaceWeight = getHighestFaceWeight(availableFaces)
 		curNormal += getWeightedNormalAndMoveToNextFace(
 			nextFaceWeight, visitedFaces, availableFaces, centerVert, edges)
-	
+
 	return curNormal.normalized()
 
 def getConnectedFaces(bFace, bVert):
@@ -936,10 +936,10 @@ def getNextFace(faceWeight, bVert, visitedFaces, availableFaces):
 		else:
 			availableFaces.append(FaceWeight(face, nextPrevFace,
 				faceWeight.weight))
-	
+
 	if not newFaceFound:
 		availableFaces.remove(faceWeight)
-	
+
 	removedFaceWeights = []
 	for otherFaceWeight in availableFaces:
 		if otherFaceWeight.face in visitedFaces:
@@ -968,7 +968,7 @@ class FaceWeight:
 		self.prevFace = prevFace
 		self.weight = weight
 
-def getWeightedNormalAndMoveToNextFace(selectFaceWeight, visitedFaces, 
+def getWeightedNormalAndMoveToNextFace(selectFaceWeight, visitedFaces,
 	availableFaces, centerVert, edges):
 	selectLoop = getLoopFromFaceVert(selectFaceWeight.face, centerVert)
 	edgeIndex = getEdgeBetweenFaces(selectFaceWeight).index
@@ -1001,7 +1001,7 @@ def UVtoST(obj, loopIndex, uv_data, texDimensions, isPointSampled):
 	]
 
 
-def convertVertexData(mesh, loopPos, loopUV, loopColorOrNormal, 
+def convertVertexData(mesh, loopPos, loopUV, loopColorOrNormal,
 	texDimensions, transformMatrix, isPointSampled, exportVertexColors):
 	#uv_layer = mesh.uv_layers.active
 	#color_layer = mesh.vertex_colors['Col']
@@ -1077,27 +1077,27 @@ def createTriangleCommands(triangles, vertexBuffer, useSP2Triangle):
 		while len(triangles) > 0:
 			if len(triangles) >= 2:
 				commands.append(SP2Triangles(
-					vertexBuffer.index(triangles[0][0]), 
-					vertexBuffer.index(triangles[0][1]), 
+					vertexBuffer.index(triangles[0][0]),
+					vertexBuffer.index(triangles[0][1]),
 					vertexBuffer.index(triangles[0][2]), 0,
-					vertexBuffer.index(triangles[1][0]), 
-					vertexBuffer.index(triangles[1][1]), 
+					vertexBuffer.index(triangles[1][0]),
+					vertexBuffer.index(triangles[1][1]),
 					vertexBuffer.index(triangles[1][2]), 0))
 				triangles = triangles[2:]
 			else:
 				commands.append(SP1Triangle(
-					vertexBuffer.index(triangles[0][0]), 
-					vertexBuffer.index(triangles[0][1]), 
+					vertexBuffer.index(triangles[0][0]),
+					vertexBuffer.index(triangles[0][1]),
 					vertexBuffer.index(triangles[0][2]), 0))
 				triangles = []
 	else:
 		while len(triangles) > 0:
 			commands.append(SP1Triangle(
-				vertexBuffer.index(triangles[0][0]), 
-				vertexBuffer.index(triangles[0][1]), 
+				vertexBuffer.index(triangles[0][0]),
+				vertexBuffer.index(triangles[0][1]),
 				vertexBuffer.index(triangles[0][2]), 0))
 			triangles = triangles[1:]
-		
+
 	return commands
 
 # white diffuse, grey ambient, normal = (1,1,1)
@@ -1152,11 +1152,11 @@ def saveOrGetF3DMaterial(material, fModel, obj, drawLayer, convertTextureData):
 		materialKey = (material, drawLayer, areaKey)
 	else:
 		materialKey = (material, None, areaKey)
-	
+
 	materialItem = fModel.getMaterialAndHandleShared(materialKey)
 	if materialItem is not None:
 		return materialItem
-	
+
 	if len(obj.data.materials) == 0:
 		raise PluginError("Mesh must have at least one material.")
 	materialName = fModel.name + "_" + toAlnum(material.name) + (('_layer' + str(drawLayer)) \
@@ -1166,7 +1166,7 @@ def saveOrGetF3DMaterial(material, fModel, obj, drawLayer, convertTextureData):
 	fMaterial = FMaterial(materialName, fModel.DLFormat)
 	fMaterial.material.commands.append(DPPipeSync())
 	fMaterial.revert.commands.append(DPPipeSync())
-	
+
 	if not material.is_f3d:
 		raise PluginError("Material named " +  material.name + \
 			' is not an F3D material.')
@@ -1259,28 +1259,28 @@ def saveOrGetF3DMaterial(material, fModel, obj, drawLayer, convertTextureData):
 	if useDict['Texture 0'] and f3dMat.tex0.tex_set:
 		if f3dMat.tex0.tex is None and not f3dMat.tex0.use_tex_reference:
 			raise PluginError('In material \"' + material.name + '\", a texture has not been set.')
-		
+
 		fMaterial.useLargeTextures = not loadTextures
 		fMaterial.texturesLoaded[0] = True
 		fMaterial.saveLargeTextures[0] = f3dMat.tex0.save_large_texture
-		texDimensions0, nextTmem = saveTextureIndex(material.name, fModel, 
+		texDimensions0, nextTmem = saveTextureIndex(material.name, fModel,
 			fMaterial, fMaterial.material, fMaterial.revert, f3dMat.tex0, 0, nextTmem, None, convertTextureData,
 			None, loadTextures, True)
 	if useDict['Texture 1'] and f3dMat.tex1.tex_set:
 		if f3dMat.tex1.tex is None and not f3dMat.tex1.use_tex_reference:
 			raise PluginError('In material \"' + material.name + '\", a texture has not been set.')
-		
+
 		fMaterial.useLargeTextures = not loadTextures
 		fMaterial.texturesLoaded[1] = True
 		fMaterial.saveLargeTextures[1] = f3dMat.tex1.save_large_texture
-		texDimensions1, nextTmem = saveTextureIndex(material.name, fModel, 
+		texDimensions1, nextTmem = saveTextureIndex(material.name, fModel,
 			fMaterial, fMaterial.material, fMaterial.revert, f3dMat.tex1, 1, nextTmem, None, convertTextureData,
 			None, loadTextures, True)
 
 	# Used so we know how to convert normalized UVs when saving verts.
 	if texDimensions0 is not None and texDimensions1 is not None:
 		if f3dMat.uv_basis == 'TEXEL0':
-			texDimensions = texDimensions0 
+			texDimensions = texDimensions0
 			fMaterial.largeTextureIndex = 0
 		else:
 			texDimensions = texDimensions1
@@ -1308,12 +1308,12 @@ def saveOrGetF3DMaterial(material, fModel, obj, drawLayer, convertTextureData):
 			DPSetPrimColor(
 			int(f3dMat.prim_lod_min * 255),
 			int(f3dMat.prim_lod_frac * 255),
-			int(color[0] * 255), 
-			int(color[1] * 255), 
+			int(color[0] * 255),
+			int(color[1] * 255),
 			int(color[2] * 255),
 			int(color[3] * 255)))
 
-	if useDict['Environment'] and f3dMat.set_env:	
+	if useDict['Environment'] and f3dMat.set_env:
 		if material.mat_ver > 3:
 			color = f3dMat.env_color
 		elif material.mat_ver == 3:
@@ -1323,18 +1323,18 @@ def saveOrGetF3DMaterial(material, fModel, obj, drawLayer, convertTextureData):
 		color = gammaCorrect(color[0:3]) + [color[3]]
 		fMaterial.material.commands.append(
 			DPSetEnvColor(
-			int(color[0] * 255), 
-			int(color[1] * 255), 
+			int(color[0] * 255),
+			int(color[1] * 255),
 			int(color[2] * 255),
 			int(color[3] * 255)))
-	
+
 	if useDict['Shade'] and f3dMat.set_lights:
-		fLights = saveLightsDefinition(fModel, fMaterial, f3dMat, 
+		fLights = saveLightsDefinition(fModel, fMaterial, f3dMat,
 			materialName + '_lights')
 		fMaterial.material.commands.extend([
 			SPSetLights(fLights) # TODO: handle synching: NO NEED?
 		])
-	
+
 	if useDict['Key'] and f3dMat.set_key:
 		if material.mat_ver == 4:
 			center = f3dMat.key_center
@@ -1345,12 +1345,12 @@ def saveOrGetF3DMaterial(material, fModel, obj, drawLayer, convertTextureData):
 		fMaterial.material.commands.extend([
 			DPSetCombineKey('G_CK_KEY'),
 			# TODO: Add UI handling width
-			DPSetKeyR(int(center[0] * 255), int(scale[0] * 255), 
+			DPSetKeyR(int(center[0] * 255), int(scale[0] * 255),
 				int(width[0] * 2**8)),
-			DPSetKeyGB(int(center[1] * 255), int(scale[1] * 255), 
-				int(width[1] * 2**8), 
-				int(center[2] * 255), int(scale[2] * 255), 
-				int(width[2] * 2**8))	
+			DPSetKeyGB(int(center[1] * 255), int(scale[1] * 255),
+				int(width[1] * 2**8),
+				int(center[2] * 255), int(scale[2] * 255),
+				int(width[2] * 2**8))
 		])
 
 	# all k0-5 set at once
@@ -1369,7 +1369,7 @@ def saveOrGetF3DMaterial(material, fModel, obj, drawLayer, convertTextureData):
 		])
 
 	fModel.onMaterialCommandsBuilt(fMaterial.material, fMaterial.revert, material, drawLayer)
-		
+
 	# End Display List
 	# For dynamic calls, materials will be called as functions and should not end the DL.
 	if fModel.DLFormat == DLFormat.Static:
@@ -1381,14 +1381,14 @@ def saveOrGetF3DMaterial(material, fModel, obj, drawLayer, convertTextureData):
 			fMaterial.revert.commands.append(SPEndDisplayList())
 	else:
 		fMaterial.revert = None
-	
+
 	materialKey = material, (drawLayer if f3dMat.rdp_settings.set_rendermode else None), \
 		fModel.global_data.getCurrentAreaKey(f3dMat)
 	fModel.materials[materialKey] = (fMaterial, texDimensions)
 
 	return fMaterial, texDimensions
 
-def saveTextureIndex(propName, fModel, fMaterial, loadTexGfx, revertTexGfx, texProp, index, tmem, 
+def saveTextureIndex(propName, fModel, fMaterial, loadTexGfx, revertTexGfx, texProp, index, tmem,
 	overrideName, convertTextureData, tileSettingsOverride, loadTextures, loadPalettes):
 	tex = texProp.tex
 
@@ -1400,7 +1400,7 @@ def saveTextureIndex(propName, fModel, fMaterial, loadTexGfx, revertTexGfx, texP
 			raise PluginError('In ' + propName + ", no texture is selected.")
 		elif len(tex.pixels) == 0:
 			raise PluginError("Could not load missing texture: " + tex.name + ". Make sure this texture has not been deleted or moved on disk.")
-	
+
 	texFormat = texProp.tex_format
 	isCITexture = texFormat[:2] == 'CI'
 	palFormat = texProp.ci_format if isCITexture else ''
@@ -1414,7 +1414,7 @@ def saveTextureIndex(propName, fModel, fMaterial, loadTexGfx, revertTexGfx, texP
 		name = texProp.tex_reference
 	texName = fModel.name + '_' + \
 		(getNameFromPath(name, True) + '_' + texFormat.lower() if overrideName is None else overrideName)
-		
+
 
 	if tileSettingsOverride is not None:
 		tileSettings = tileSettingsOverride[index]
@@ -1429,7 +1429,7 @@ def saveTextureIndex(propName, fModel, fMaterial, loadTexGfx, revertTexGfx, texP
 		setTLUTMode = fModel.matWriteMethod == GfxMatWriteMethod.WriteAll
 
 	nextTmem = tmem + getTmemWordUsage(texFormat, width, height)
-	
+
 	if not bpy.context.scene.ignoreTextureRestrictions and loadTextures:
 		if nextTmem > (512 if texFormat[:2] != 'CI' else 256):
 			raise PluginError("Error in \"" + propName + "\": Textures are too big. Max TMEM size is 4k " + \
@@ -1445,7 +1445,7 @@ def saveTextureIndex(propName, fModel, fMaterial, loadTexGfx, revertTexGfx, texP
 		tex_SH = texProp.S.high
 		mask_S = texProp.S.mask
 		shift_S = texProp.S.shift
-	
+
 		clamp_T = texProp.T.clamp
 		mirror_T = texProp.T.mirror
 		tex_TL = texProp.T.low
@@ -1460,7 +1460,7 @@ def saveTextureIndex(propName, fModel, fMaterial, loadTexGfx, revertTexGfx, texP
 		tex_SH = tileSettings.sh
 		mask_S = 0
 		shift_S = 0
-	
+
 		clamp_T = True
 		mirror_T = False
 		tex_TL = tileSettings.tl
@@ -1476,29 +1476,29 @@ def saveTextureIndex(propName, fModel, fMaterial, loadTexGfx, revertTexGfx, texP
 		else:
 			fImage, fPalette = saveOrGetPaletteDefinition(
 				fMaterial, fModel, tex, texName, texFormat, palFormat, convertTextureData)
-		
+
 		if loadPalettes:
-			savePaletteLoading(loadTexGfx, revertTexGfx, fPalette, 
+			savePaletteLoading(loadTexGfx, revertTexGfx, fPalette,
 				palFormat, 0, fPalette.height, fModel.f3d, fModel.matWriteMethod)
 	else:
 		if texProp.use_tex_reference:
 			fImage = FImage(texProp.tex_reference, None, None, width, height, None, False)
 		else:
-			fImage = saveOrGetTextureDefinition(fMaterial, fModel, tex, texName, 
+			fImage = saveOrGetTextureDefinition(fMaterial, fModel, tex, texName,
 				texFormat, convertTextureData)
-	
+
 	if setTLUTMode and not isCITexture:
 		loadTexGfx.commands.append(DPSetTextureLUT('G_TT_NONE'))
 	if loadTextures:
 		saveTextureLoading(fMaterial, fImage, loadTexGfx, clamp_S,
 		 	mirror_S, clamp_T, mirror_T,
-			mask_S, mask_T, shift_S, 
-			shift_T, tex_SL, tex_TL, tex_SH, 
+			mask_S, mask_T, shift_S,
+			shift_T, tex_SL, tex_TL, tex_SH,
 			tex_TH, texFormat, index, fModel.f3d, tmem)
 	texDimensions = fImage.width, fImage.height
-	#fImage = saveTextureDefinition(fModel, tex, texName, 
+	#fImage = saveTextureDefinition(fModel, tex, texName,
 	#	texFormatOf[texFormat], texBitSizeOf[texFormat])
-	#fModel.textures[texName] = fImage	
+	#fModel.textures[texName] = fImage
 
 	return texDimensions, nextTmem
 
@@ -1520,7 +1520,7 @@ def saveTextureLoading(fMaterial, fImage, loadTexGfx, clamp_S, mirror_S, clamp_T
 	tl = int(TL * (2 ** f3d.G_TEXTURE_IMAGE_FRAC))
 	sh = int(SH * (2 ** f3d.G_TEXTURE_IMAGE_FRAC))
 	th = int(TH * (2 ** f3d.G_TEXTURE_IMAGE_FRAC))
-	
+
 	fmt = texFormatOf[tex_format]
 	siz = texBitSizeOf[tex_format]
 	pal = 0 if fmt[:2] != 'CI' else 0 # handle palettes
@@ -1532,7 +1532,7 @@ def saveTextureLoading(fMaterial, fImage, loadTexGfx, clamp_S, mirror_S, clamp_T
 	# LoadTile will pad rows to 64 bit word alignment, while
 	# LoadBlock assumes this is already done.
 
-	# These commands are basically DPLoadMultiBlock/Tile, 
+	# These commands are basically DPLoadMultiBlock/Tile,
 	# except for the load tile index which will be 6 instead of 7 for render tile = 1.
 	# This may be unnecessary, but at this point DPLoadMultiBlock/Tile is not implemented yet
 	# so it would be extra work for the same outcome.
@@ -1550,13 +1550,13 @@ def saveTextureLoading(fMaterial, fImage, loadTexGfx, clamp_S, mirror_S, clamp_T
 				DPSetTile(fmt, 'G_IM_SIZ_16b', 0, tmem, f3d.G_TX_LOADTILE - texIndex, 0,
 					cmt, maskt, shiftt, cms, masks, shifts),
 				DPLoadSync(),
-				DPLoadBlock(f3d.G_TX_LOADTILE - texIndex, 0, 0, (((fImage.width)*(fImage.height)+3)>>2)-1, dxt)])				
+				DPLoadBlock(f3d.G_TX_LOADTILE - texIndex, 0, 0, (((fImage.width)*(fImage.height)+3)>>2)-1, dxt)])
 		else:
 			loadTexGfx.commands.extend([
 				DPTileSync(), # added in
 				DPSetTextureImage(fmt, 'G_IM_SIZ_8b', fImage.width >> 1, fImage),
-				DPSetTile(fmt, 'G_IM_SIZ_8b', line, tmem, 
-					f3d.G_TX_LOADTILE - texIndex, 0, cmt, maskt, shiftt, 
+				DPSetTile(fmt, 'G_IM_SIZ_8b', line, tmem,
+					f3d.G_TX_LOADTILE - texIndex, 0, cmt, maskt, shiftt,
 				 	cms, masks, shifts),
 				DPLoadSync(),
 				DPLoadTile(f3d.G_TX_LOADTILE - texIndex, sl2, tl, sh2, th),])
@@ -1573,8 +1573,8 @@ def saveTextureLoading(fMaterial, fImage, loadTexGfx, clamp_S, mirror_S, clamp_T
 
 				# Load Block version
 				DPSetTextureImage(fmt, siz + '_LOAD_BLOCK', 1, fImage),
-				DPSetTile(fmt, siz + '_LOAD_BLOCK', 0, tmem, 
-					f3d.G_TX_LOADTILE - texIndex, 0, cmt, maskt, shiftt, 
+				DPSetTile(fmt, siz + '_LOAD_BLOCK', 0, tmem,
+					f3d.G_TX_LOADTILE - texIndex, 0, cmt, maskt, shiftt,
 				 	cms, masks, shifts),
 				DPLoadSync(),
 				DPLoadBlock(f3d.G_TX_LOADTILE - texIndex, 0, 0, \
@@ -1588,12 +1588,12 @@ def saveTextureLoading(fMaterial, fImage, loadTexGfx, clamp_S, mirror_S, clamp_T
 
 				# Load Tile version
 				DPSetTextureImage(fmt, siz, fImage.width, fImage),
-				DPSetTile(fmt, siz, line, tmem, 
-					f3d.G_TX_LOADTILE - texIndex, 0, cmt, maskt, shiftt, 
+				DPSetTile(fmt, siz, line, tmem,
+					f3d.G_TX_LOADTILE - texIndex, 0, cmt, maskt, shiftt,
 				 	cms, masks, shifts),
 				DPLoadSync(),
 				DPLoadTile(f3d.G_TX_LOADTILE - texIndex, sl, tl, sh, th),]) # added in
-	
+
 	tileSizeCommand = DPSetTileSize(f3d.G_TX_RENDERTILE + texIndex, sl, tl, sh, th)
 	loadTexGfx.commands.extend([
 		DPPipeSync(),
@@ -1609,7 +1609,7 @@ def saveTextureLoading(fMaterial, fImage, loadTexGfx, clamp_S, mirror_S, clamp_T
 
 # palette stored in upper half of TMEM (words 256-511)
 # pal is palette number (0-16), for CI8 always set to 0
-def savePaletteLoading(loadTexGfx, revertTexGfx, fPalette, palFormat, pal, 
+def savePaletteLoading(loadTexGfx, revertTexGfx, fPalette, palFormat, pal,
 	colorCount, f3d, matWriteMethod):
 	palFmt = texFormatOf[palFormat]
 	cms = ['G_TX_WRAP', 'G_TX_NOMIRROR']
@@ -1635,7 +1635,7 @@ def savePaletteLoading(loadTexGfx, revertTexGfx, fPalette, palFormat, pal,
 				(256+(((pal)&0xf)*16)), \
             	palFmt, 'G_IM_SIZ_16b', 4*colorCount, 1,
             	pal, cms, cmt, 0, 0, 0, 0)])
-	
+
 def saveOrGetPaletteDefinition(fMaterial, fModelOrTexRect, image, imageName, texFmt, palFmt, convertTextureData):
 	texFormat = texFormatOf[texFmt]
 	palFormat = texFormatOf[palFmt]
@@ -1665,14 +1665,14 @@ def saveOrGetPaletteDefinition(fMaterial, fModelOrTexRect, image, imageName, tex
 					pixelColor = getIA16Tuple(color)
 				else:
 					raise PluginError("Invalid combo: " + palFormat + ', ' + bitSize)
-				
+
 				if pixelColor not in palette:
 					palette.append(pixelColor)
 					if len(palette) > maxColors:
 						raise PluginError('Texture ' + imageName + ' has more than ' + \
 							str(maxColors) + ' colors.')
 				texture.append(palette.index(pixelColor))
-	
+
 	if image.filepath == "":
 		name = image.name
 	else:
@@ -1683,29 +1683,29 @@ def saveOrGetPaletteDefinition(fMaterial, fModelOrTexRect, image, imageName, tex
 		fModelOrTexRect.getTextureSuffixFromFormat(texFmt) + '.pal'
 	#paletteFilename = getNameFromPath(name, True) + '.' + \
 	#	fModelOrTexRect.getTextureSuffixFromFormat(palFmt) + '.inc.c'
-	fImage = FImage(checkDuplicateTextureName(fModelOrTexRect, toAlnum(imageName)), texFormat, bitSize, 
+	fImage = FImage(checkDuplicateTextureName(fModelOrTexRect, toAlnum(imageName)), texFormat, bitSize,
 		image.size[0], image.size[1], filename, convertTextureData)
 
-	fPalette = FImage(checkDuplicateTextureName(fModelOrTexRect, paletteName), palFormat, 'G_IM_SIZ_16b', 1, 
+	fPalette = FImage(checkDuplicateTextureName(fModelOrTexRect, paletteName), palFormat, 'G_IM_SIZ_16b', 1,
 		len(palette), paletteFilename, convertTextureData)
 	if fMaterial.useLargeTextures:
 		fImage.isLargeTexture = True
 		fPalette.isLargeTexture = True
 	fImage.paletteKey = paletteKey
-	
+
 	#paletteImage = bpy.data.images.new(paletteName, 1, len(palette))
 	#paletteImage.pixels = palette
 	#paletteImage.filepath = paletteFilename
 
 	if convertTextureData:
 		for color in palette:
-			fPalette.data.extend(color.to_bytes(2, 'big')) 
+			fPalette.data.extend(color.to_bytes(2, 'big'))
 
 		if bitSize == 'G_IM_SIZ_4b':
 			fImage.data = compactNibbleArray(texture, image.size[0], image.size[1])
-		else:	
+		else:
 			fImage.data = bytearray(texture)
-	
+
 	fModelOrTexRect.addTexture((image, (texFmt, palFmt)), fImage, fMaterial)
 	fModelOrTexRect.addTexture((image, (palFmt, 'PAL')), fPalette, fMaterial)
 
@@ -1722,7 +1722,7 @@ def compactNibbleArray(texture, width, height):
 
 	if (width * height) % 2 == 1:
 		nibbleData.append((texture[-1] & 0xF) << 4)
-	
+
 	return bytearray(nibbleData)
 
 def checkDuplicateTextureName(fModelOrTexRect, name):
@@ -1750,7 +1750,7 @@ def saveOrGetTextureDefinition(fMaterial, fModel, image, imageName, texFormat, c
 	filename = getNameFromPath(name, True) + '.' + \
 		fModel.getTextureSuffixFromFormat(texFormat) + '.inc.c'
 
-	fImage = FImage(checkDuplicateTextureName(fModel, toAlnum(imageName)), fmt, bitSize, 
+	fImage = FImage(checkDuplicateTextureName(fModel, toAlnum(imageName)), fmt, bitSize,
 		image.size[0], image.size[1], filename, convertTextureData)
 	if fMaterial.useLargeTextures:
 		fImage.isLargeTexture = True
@@ -1782,7 +1782,7 @@ def saveOrGetTextureDefinition(fMaterial, fModel, image, imageName, texFormat, c
 					for j in reversed(range(image.size[1])) for i in range(image.size[0]) for field in range(image.channels)])
 			else:
 				raise PluginError("Invalid combo: " + fmt + ', ' + bitSize)
-		
+
 		elif fmt == 'G_IM_FMT_YUV':
 			raise PluginError("YUV not yet implemented.")
 			if bitSize == 'G_IM_SIZ_16b':
@@ -1819,7 +1819,7 @@ def saveOrGetTextureDefinition(fMaterial, fModel, image, imageName, texFormat, c
 								(j * image.size[0] + i) * image.channels :
 								(j * image.size[0] + i) * image.channels + 3
 							]).v * 0xFF)) & 0xFF,
-						int(round(image.pixels[(j * image.size[0] + i) * image.channels + 3] * 0xFF)) & 0xFF) 
+						int(round(image.pixels[(j * image.size[0] + i) * image.channels + 3] * 0xFF)) & 0xFF)
 					for j in reversed(range(image.size[1])) for i in range(image.size[0])] for byteVal in doubleByte])
 			else:
 				raise PluginError("Invalid combo: " + fmt + ', ' + bitSize)
@@ -1830,7 +1830,7 @@ def saveOrGetTextureDefinition(fMaterial, fModel, image, imageName, texFormat, c
 						image.pixels[
 							(j * image.size[0] + i) * image.channels :
 							(j * image.size[0] + i) * image.channels + 3
-						]).v * 0xF)) & 0xF 
+						]).v * 0xF)) & 0xF
 				for j in reversed(range(image.size[1])) for i in range(image.size[0])])
 			elif bitSize == 'G_IM_SIZ_8b':
 				fImage.data = bytearray([
@@ -1838,7 +1838,7 @@ def saveOrGetTextureDefinition(fMaterial, fModel, image, imageName, texFormat, c
 						image.pixels[
 							(j * image.size[0] + i) * image.channels :
 							(j * image.size[0] + i) * image.channels + 3
-						]).v * 0xFF)) & 0xFF 
+						]).v * 0xFF)) & 0xFF
 				for j in reversed(range(image.size[1])) for i in range(image.size[0])])
 			else:
 				raise PluginError("Invalid combo: " + fmt + ', ' + bitSize)
@@ -1849,7 +1849,7 @@ def saveOrGetTextureDefinition(fMaterial, fModel, image, imageName, texFormat, c
 		if bitSize == 'G_IM_SIZ_4b':
 			fImage.data = \
 				compactNibbleArray(fImage.data, image.size[0], image.size[1])
-	
+
 	print("Finished converting.")
 	fModel.addTexture((image, (texFormat, 'NONE')), fImage, fMaterial)
 
@@ -1915,7 +1915,7 @@ def saveOrGetTextureDefinition(fMaterial, fModel, image, imageName, texFormat, c
 	#					raise PluginError("Invalid combo: " + fmt + ', ' + bitSize)
 	#			else:
 	#				raise PluginError("Invalid image format " + fmt)
-	#		
+	#
 	#	# We stored 4bit values in byte arrays, now to convert
 	#	if bitSize == 'G_IM_SIZ_4b':
 	#		fImage.data = \
@@ -1929,7 +1929,7 @@ def saveLightsDefinition(fModel, fMaterial, material, lightsName):
 	lights = fModel.getLightAndHandleShared(lightsName)
 	if lights is not None:
 		return lights
-		
+
 	lights = Lights(toAlnum(lightsName))
 
 	if material.use_default_lighting:
@@ -1941,7 +1941,7 @@ def saveLightsDefinition(fModel, fMaterial, material, lightsName):
 		lights.l.append(Light(
 			[int(color[0] * 255),
 			int(color[1] * 255),
-			int(color[2] * 255)], 
+			int(color[2] * 255)],
 			[0x28, 0x28, 0x28]))
 	else:
 		ambientColor = gammaCorrect(material.ambient_light_color)
@@ -1980,7 +1980,7 @@ def addLightDefinition(mat, f3d_light, fLights):
 	#if lightObj is None:
 	#	raise PluginError(
 	#		"The material \"" + mat.name + "\" is referencing a light that is no longer in the scene (i.e. has been deleted).")
-	
+
 	fLights.l.append(Light(
 		getLightColor(f3d_light.color),
 		getLightRotation(f3d_light),
@@ -2007,7 +2007,7 @@ def getObjDirection(obj):
 	return normToSigned8Vector(normal)
 
 def normToSigned8Vector(normal):
-	return [int.from_bytes(int(value * 127).to_bytes(1, 'big', 
+	return [int.from_bytes(int(value * 127).to_bytes(1, 'big',
 		signed = True), 'big') for value in normal]
 
 def saveBitGeo(value, defaultValue, flagName, setGeo, clearGeo, matWriteMethod):
@@ -2034,7 +2034,7 @@ def saveGeoModeDefinition(fMaterial, settings, defaults, matWriteMethod):
 		setGeo, clearGeo, matWriteMethod)
 
 	# make sure normals are saved correctly.
-	saveBitGeo(settings.g_tex_gen, defaults.g_tex_gen, 'G_TEXTURE_GEN', 
+	saveBitGeo(settings.g_tex_gen, defaults.g_tex_gen, 'G_TEXTURE_GEN',
 		setGeo, clearGeo, matWriteMethod)
 	saveBitGeo(settings.g_tex_gen_linear, defaults.g_tex_gen_linear,
 		'G_TEXTURE_GEN_LINEAR', setGeo, clearGeo, matWriteMethod)
@@ -2042,7 +2042,7 @@ def saveGeoModeDefinition(fMaterial, settings, defaults, matWriteMethod):
 		'G_SHADING_SMOOTH', setGeo, clearGeo, matWriteMethod)
 	if bpy.context.scene.f3d_type == 'F3DEX_GBI_2' or \
 		bpy.context.scene.f3d_type == 'F3DEX_GBI':
-		saveBitGeo(settings.g_clipping, defaults.g_clipping, 'G_CLIPPING', 
+		saveBitGeo(settings.g_clipping, defaults.g_clipping, 'G_CLIPPING',
 			setGeo, clearGeo, matWriteMethod)
 
 	if len(setGeo.flagList) > 0:
@@ -2084,7 +2084,7 @@ def saveOtherModeHDefinitionAll(fMaterial, settings, defaults, isHWv1):
 	cmd.flagList.append(settings.g_mdsft_pipeline)
 
 	fMaterial.material.commands.append(cmd)
-		
+
 def saveOtherModeHDefinitionIndividual(fMaterial, settings, defaults, isHWv1):
 	saveModeSetting(fMaterial, settings.g_mdsft_alpha_dither,
 		defaults.g_mdsft_alpha_dither, DPSetAlphaDither)
@@ -2095,7 +2095,7 @@ def saveOtherModeHDefinitionIndividual(fMaterial, settings, defaults, isHWv1):
 
 		saveModeSetting(fMaterial, settings.g_mdsft_combkey,
 			defaults.g_mdsft_combkey, DPSetCombineKey)
-	
+
 	saveModeSetting(fMaterial, settings.g_mdsft_textconv,
 		defaults.g_mdsft_textconv, DPSetTextureConvert)
 
@@ -2113,14 +2113,14 @@ def saveOtherModeHDefinitionIndividual(fMaterial, settings, defaults, isHWv1):
 
 	saveModeSetting(fMaterial, settings.g_mdsft_textpersp,
 		defaults.g_mdsft_textpersp, DPSetTexturePersp)
-	
+
 	saveModeSetting(fMaterial, settings.g_mdsft_cycletype,
 		defaults.g_mdsft_cycletype, DPSetCycleType)
 
 	if isHWv1:
 		saveModeSetting(fMaterial, settings.g_mdsft_color_dither,
 			defaults.g_mdsft_color_dither, DPSetColorDither)
-	
+
 	saveModeSetting(fMaterial, settings.g_mdsft_pipeline,
 		defaults.g_mdsft_pipeline, DPPipelineMode)
 
@@ -2137,7 +2137,7 @@ def saveOtherModeLDefinitionAll(fMaterial, settings, defaults, defaultRenderMode
 		cmd = SPSetOtherMode("G_SETOTHERMODE_L", 0, 3, [])
 		cmd.flagList.append(settings.g_mdsft_alpha_compare)
 		cmd.flagList.append(settings.g_mdsft_zsrcsel)
-	
+
 	else:
 		cmd = SPSetOtherMode("G_SETOTHERMODE_L", 0, 32, [])
 		cmd.flagList.append(settings.g_mdsft_alpha_compare)
@@ -2175,7 +2175,7 @@ def getRenderModeFlagList(settings, fMaterial):
 	flagList = []
 	blendList = None
 	# cycle independent
-	
+
 	if not settings.rendermode_advanced_enabled:
 		fMaterial.renderModeUseDrawLayer = [
 			settings.rendermode_preset_cycle_1 == 'Use Draw Layer',
@@ -2183,7 +2183,7 @@ def getRenderModeFlagList(settings, fMaterial):
 
 		if settings.g_mdsft_cycletype == 'G_CYC_2CYCLE':
 			flagList = [
-				settings.rendermode_preset_cycle_1, 
+				settings.rendermode_preset_cycle_1,
 				settings.rendermode_preset_cycle_2]
 		else:
 			cycle2 = settings.rendermode_preset_cycle_1 + '2'
@@ -2194,15 +2194,15 @@ def getRenderModeFlagList(settings, fMaterial):
 	else:
 		if settings.g_mdsft_cycletype == 'G_CYC_2CYCLE':
 			blendList = \
-				[settings.blend_p1, settings.blend_a1, 
+				[settings.blend_p1, settings.blend_a1,
 				settings.blend_m1, settings.blend_b1,
-				settings.blend_p2, settings.blend_a2, 
+				settings.blend_p2, settings.blend_a2,
 				settings.blend_m2, settings.blend_b2]
 		else:
 			blendList = \
-				[settings.blend_p1, settings.blend_a1, 
+				[settings.blend_p1, settings.blend_a1,
 				settings.blend_m1, settings.blend_b1,
-				settings.blend_p1, settings.blend_a1, 
+				settings.blend_p1, settings.blend_a1,
 				settings.blend_m1, settings.blend_b1]
 
 		if settings.aa_en:
@@ -2233,12 +2233,12 @@ def saveOtherDefinition(fMaterial, material, defaults):
 	if settings.clip_ratio != defaults.clip_ratio:
 		fMaterial.material.commands.append(SPClipRatio(settings.clip_ratio))
 		fMaterial.revert.commands.append(SPClipRatio(defaults.clip_ratio))
-	
+
 	if material.set_blend:
 		fMaterial.material.commands.append(
 			DPSetBlendColor(
-			int(material.blend_color[0] * 255), 
-			int(material.blend_color[1] * 255), 
+			int(material.blend_color[0] * 255),
+			int(material.blend_color[1] * 255),
 			int(material.blend_color[2] * 255),
 			int(material.blend_color[3] * 255)))
 
@@ -2259,11 +2259,11 @@ def getWriteMethodFromEnum(enumVal):
 	else:
 		return matWriteMethodEnumDict[enumVal]
 
-def exportF3DtoC(dirPath, obj, DLFormat, transformMatrix, 
+def exportF3DtoC(dirPath, obj, DLFormat, transformMatrix,
 	f3dType, isHWv1, texDir, savePNG, texSeparate, name, matWriteMethod):
 
 	fModel = FModel(f3dType, isHWv1, name, DLFormat, matWriteMethod)
-	fMesh = exportF3DCommon(obj, fModel, transformMatrix, 
+	fMesh = exportF3DCommon(obj, fModel, transformMatrix,
 		True, name, DLFormat, not savePNG)
 
 	modelDirPath = os.path.join(dirPath, toAlnum(name))
@@ -2280,8 +2280,8 @@ def exportF3DtoC(dirPath, obj, DLFormat, transformMatrix,
 	if DLFormat == DLFormat.Static:
 		staticData.append(dynamicData)
 	else:
-		geoString = writeMaterialFiles(dirPath, modelDirPath, 
-			'#include "actors/' + toAlnum(name) + '/header.h"', 
+		geoString = writeMaterialFiles(dirPath, modelDirPath,
+			'#include "actors/' + toAlnum(name) + '/header.h"',
 			'#include "actors/' + toAlnum(name) + '/material.inc.h"',
 			dynamicData.header, dynamicData.source, '', True)
 
@@ -2306,7 +2306,7 @@ def removeDL(sourcePath, headerPath, DLName):
 
 	headerMatch = getDeclaration(DLDataH, DLName)
 	if headerMatch is not None:
-		DLDataH = DLDataH[:headerMatch.start(0)] + DLDataH[headerMatch.end(0):] 
+		DLDataH = DLDataH[:headerMatch.start(0)] + DLDataH[headerMatch.end(0):]
 
 	if DLDataC != originalDataC:
 		writeFile(sourcePath, DLDataC)
@@ -2340,7 +2340,7 @@ class F3D_ExportDL(bpy.types.Operator):
 		except Exception as e:
 			raisePluginError(self, e)
 			return {"CANCELLED"}
-		
+
 		try:
 			applyRotation([obj], math.radians(90), 'X')
 
@@ -2354,7 +2354,7 @@ class F3D_ExportDL(bpy.types.Operator):
 			DLName = bpy.context.scene.DLName
 			matWriteMethod = getWriteMethodFromEnum(context.scene.matWriteMethod)
 
-			exportF3DtoC(exportPath, obj, dlFormat, finalTransform, 
+			exportF3DtoC(exportPath, obj, dlFormat, finalTransform,
 				f3dType, isHWv1, texDir, savePNG, separateTexDef, DLName, matWriteMethod)
 
 			self.report({'INFO'}, 'Success!')
@@ -2391,11 +2391,11 @@ class F3D_ExportDLPanel(bpy.types.Panel):
 		prop_split(col, context.scene, "blenderF3DScale", "Scale")
 		prop_split(col, context.scene, 'matWriteMethod', "Material Write Method")
 		col.prop(context.scene, 'DLExportisStatic')
-		
+
 		if not bpy.context.scene.ignoreTextureRestrictions:
 			if context.scene.saveTextures:
 				prop_split(col, context.scene, 'DLTexDir',
-					'Texture Include Path') 
+					'Texture Include Path')
 				col.prop(context.scene, 'DLSeparateTextureDef')
 
 f3d_writer_classes = (

--- a/fast64_internal/operators.py
+++ b/fast64_internal/operators.py
@@ -27,7 +27,7 @@ class AddWaterBox(bpy.types.Operator):
 	def execute(self, context):
 		if context.mode != "OBJECT":
 			bpy.ops.object.mode_set(mode = "OBJECT")
-		
+
 		bpy.ops.object.select_all(action = "DESELECT")
 
 		location = mathutils.Vector(bpy.context.scene.cursor.location)
@@ -37,7 +37,7 @@ class AddWaterBox(bpy.types.Operator):
 		planeObj.name = "Water Box Mesh"
 
 		addMaterialByName(planeObj, self.matName, self.preset)
-		
+
 		location += mathutils.Vector([0,0,-self.scale])
 		bpy.ops.object.empty_add(type='CUBE', radius = self.scale, align='WORLD', location=location[:])
 		emptyObj = context.view_layer.objects.active
@@ -57,20 +57,20 @@ class WarningOperator(bpy.types.Operator):
 
 	def add_warning(self, warning: str):
 		self.warnings.add(warning)
-	
+
 	def show_warnings(self):
 		if len(self.warnings):
 			self.report({'WARNING'}, 'Operator completed with warnings:')
 			for warning in self.warnings:
 				self.report({'WARNING'}, warning)
 			self.reset_warnings()
-	
+
 class ObjectDataExporter(WarningOperator):
 	'''Operator that uses warnings and can store original matrixes and meshes for use in exporting'''
 	def store_object_data(self):
 		store_original_mtx()
 		store_original_meshes(self.add_warning)
-	
+
 	def cleanup_temp_object_data(self):
 		cleanupTempMeshes()
 

--- a/fast64_internal/operators.py
+++ b/fast64_internal/operators.py
@@ -47,3 +47,30 @@ class AddWaterBox(bpy.types.Operator):
 		parentObject(planeObj, emptyObj)
 
 		return {"FINISHED"}
+
+class WarningOperator(bpy.types.Operator):
+	'''Extension of Operator that allows collecting and displaying warnings'''
+	warnings = set()
+
+	def reset_warnings(self):
+		self.warnings.clear()
+
+	def add_warning(self, warning: str):
+		self.warnings.add(warning)
+	
+	def show_warnings(self):
+		if len(self.warnings):
+			self.report({'WARNING'}, 'Operator completed with warnings:')
+			for warning in self.warnings:
+				self.report({'WARNING'}, warning)
+			self.reset_warnings()
+	
+class ObjectDataExporter(WarningOperator):
+	'''Operator that uses warnings and can store original matrixes and meshes for use in exporting'''
+	def store_object_data(self):
+		store_original_mtx()
+		store_original_meshes(self.add_warning)
+	
+	def cleanup_temp_object_data(self):
+		cleanupTempMeshes()
+

--- a/fast64_internal/sm64/sm64_geolayout_classes.py
+++ b/fast64_internal/sm64/sm64_geolayout_classes.py
@@ -17,8 +17,13 @@ drawLayerNames = {
 }
 
 def getDrawLayerName(drawLayer):
-	# Cast draw layer to int so it can be mapped to a name
-	layer = int(drawLayer) if isinstance(drawLayer, str) and drawLayer.isnumeric() else drawLayer
+	layer = drawLayer
+	if drawLayer is not None:
+		try:
+			# Cast draw layer to int so it can be mapped to a name
+			layer = int(drawLayer)
+		except ValueError:
+			pass
 	if layer in drawLayerNames:
 		return drawLayerNames[layer]
 	else:

--- a/fast64_internal/sm64/sm64_geolayout_classes.py
+++ b/fast64_internal/sm64/sm64_geolayout_classes.py
@@ -1,7 +1,7 @@
 from .sm64_geolayout_constants import *
 from .sm64_geolayout_utility import *
 from .sm64_constants import *
-from .sm64_function_map import func_map 
+from .sm64_function_map import func_map
 from ..utility import *
 import struct, copy
 
@@ -112,7 +112,7 @@ class GeolayoutGraph:
 			print(geolayout.name + " - " + \
 				str(geolayout.startAddress))
 		return address
-	
+
 	def to_binary(self, segmentData):
 		self.checkListSorted()
 		data = bytearray(0)
@@ -144,7 +144,7 @@ class GeolayoutGraph:
 		for geolayout in self.sortedList:
 			for node in geolayout.nodes:
 				node.convertToDynamic()
-	
+
 	def getDrawLayers(self):
 		drawLayers = self.startGeolayout.getDrawLayers()
 		for obj, geolayout in self.secondaryGeolayouts.items():
@@ -158,13 +158,13 @@ class Geolayout:
 		self.name = toAlnum(name)
 		self.startAddress = 0
 		self.isStartGeo = isStartGeo
-	
+
 	def size(self):
 		size = 4 # end command
 		for node in self.nodes:
 			size += node.size()
 		return size
-	
+
 	def get_ptr_addresses(self):
 		address = self.startAddress
 		addresses = []
@@ -223,7 +223,7 @@ class BaseDisplayListNode:
 		if self.hasDL and (self.dlRef or self.DLmicrocode is not None):
 			return self.dlRef or self.DLmicrocode.name
 		return 'NULL'
-	
+
 	def get_c_func_macro(self, base_cmd: str):
 		return f'{base_cmd}_{self.dl_ext}' if self.hasDL else base_cmd
 
@@ -258,10 +258,10 @@ class TransformNode:
 				self.node.hasDL = False
 				transformNode = TransformNode(funcNode)
 				self.children.insert(0, transformNode)
-		
+
 		for child in self.children:
 			child.convertToDynamic()
-	
+
 	def get_ptr_addresses(self, address):
 		addresses = []
 		if self.node is not None:
@@ -285,7 +285,7 @@ class TransformNode:
 			size += 8 # node open/close
 			for child in self.children:
 				size += child.size()
-			
+
 		return size
 
 	# Function commands usually effect the following command, so it is similar
@@ -329,7 +329,7 @@ class TransformNode:
 		elif type(self.node) is SwitchNode:
 			raise PluginError("A switch bone must have at least one child bone.")
 		return data
-	
+
 	def toTextDump(self, nodeLevel, segmentData):
 		data = ''
 		if self.node is not None:
@@ -355,7 +355,7 @@ class TransformNode:
 
 	def getDrawLayers(self):
 		if self.node is not None and self.node.hasDL:
-			drawLayers = set([self.node.drawLayer])	
+			drawLayers = set([self.node.drawLayer])
 		else:
 			drawLayers = set()
 		for child in self.children:
@@ -377,10 +377,10 @@ class JumpNode:
 		self.storeReturn = storeReturn
 		self.hasDL = False
 		self.geoRef = geoRef
-	
+
 	def size(self):
 		return 8
-	
+
 	def get_ptr_offsets(self):
 		return [4]
 
@@ -390,7 +390,7 @@ class JumpNode:
 			startAddress = encodeSegmentedAddr(address, segmentData)
 		else:
 			startAddress = bytearray([0x00] * 4)
-		command = bytearray([GEO_BRANCH, 
+		command = bytearray([GEO_BRANCH,
 			0x01 if self.storeReturn else 0x00, 0x00, 0x00])
 		command.extend(startAddress)
 		return command
@@ -420,7 +420,7 @@ class FunctionNode:
 
 	def size(self):
 		return 8
-		
+
 	def to_binary(self, segmentData):
 		command = bytearray([GEO_CALL_ASM, 0x00])
 		command.extend(self.func_param.to_bytes(2, 'big', signed = True))
@@ -439,14 +439,14 @@ class HeldObjectNode:
 
 	def size(self):
 		return 12
-	
+
 	def to_binary(self, segmentData):
 		command = bytearray([GEO_HELD_OBJECT, 0x00])
 		command.extend(bytearray([0x00] * 6))
 		writeVectorToShorts(command, 2, self.translate)
 		addFuncAddress(command, self.geo_func)
 		return command
-	
+
 	def to_c(self):
 		return "GEO_HELD_OBJECT(0, " + \
 			str(convertFloatToShort(self.translate[0])) + ', ' +\
@@ -457,10 +457,10 @@ class HeldObjectNode:
 class StartNode:
 	def __init__(self):
 		self.hasDL = False
-	
+
 	def size(self):
 		return 4
-	
+
 	def to_binary(self, segmentData):
 		command = bytearray([GEO_START, 0x00, 0x00, 0x00])
 		return command
@@ -474,7 +474,7 @@ class EndNode:
 
 	def size(self):
 		return 4
-	
+
 	def to_binary(self, segmentData):
 		command = bytearray([GEO_END, 0x00, 0x00, 0x00])
 		return command
@@ -495,7 +495,7 @@ class SwitchNode:
 
 	def size(self):
 		return 8
-	
+
 	def to_binary(self, segmentData):
 		command = bytearray([GEO_SWITCH, 0x00])
 		command.extend(self.defaultCase.to_bytes(2, 'big', signed = True))
@@ -520,7 +520,7 @@ class TranslateRotateNode(BaseDisplayListNode):
 		self.fMesh = None
 		self.DLmicrocode = None
 		self.dlRef = dlRef
-	
+
 	def get_ptr_offsets(self):
 		if self.hasDL:
 			if self.fieldLayout == 0:
@@ -533,7 +533,7 @@ class TranslateRotateNode(BaseDisplayListNode):
 				return [4]
 		else:
 			return []
-	
+
 	def size(self):
 		if self.fieldLayout == 0:
 			size = 16
@@ -547,29 +547,29 @@ class TranslateRotateNode(BaseDisplayListNode):
 		if self.hasDL:
 			size += 4
 		return size
-		
+
 	def to_binary(self, segmentData):
 		params = ((1 if self.hasDL else 0) << 7) & \
 			(self.fieldLayout << 4) | int(self.drawLayer)
-		
+
 		start_address = self.get_dl_address()
 
 		command = bytearray([GEO_TRANSLATE_ROTATE, params])
 		if self.fieldLayout == 0:
 			command.extend(bytearray([0x00] * 14))
 			writeVectorToShorts(command, 4, self.translate)
-			writeEulerVectorToShorts(command, 10, 
+			writeEulerVectorToShorts(command, 10,
 				self.rotate.to_euler(geoNodeRotateOrder))
 		elif self.fieldLayout == 1:
 			command.extend(bytearray([0x00] * 6))
 			writeVectorToShorts(command, 2, self.translate)
 		elif self.fieldLayout == 2:
 			command.extend(bytearray([0x00] * 6))
-			writeEulerVectorToShorts(command, 2, 
+			writeEulerVectorToShorts(command, 2,
 				self.rotate.to_euler(geoNodeRotateOrder))
 		elif self.fieldLayout == 3:
 			command.extend(bytearray([0x00] * 2))
-			writeFloatToShort(command, 2, 
+			writeFloatToShort(command, 2,
 			self.rotate.to_euler(geoNodeRotateOrder).y)
 		if start_address:
 			if segmentData is not None:
@@ -624,13 +624,13 @@ class TranslateNode(BaseDisplayListNode):
 		self.fMesh = None
 		self.DLmicrocode = None
 		self.dlRef = dlRef
-	
+
 	def get_ptr_offsets(self):
 		return [8] if self.hasDL else []
 
 	def size(self):
 		return 12 if self.hasDL else 8
-		
+
 	def to_binary(self, segmentData):
 		params = ((1 if self.hasDL else 0) << 7) | int(self.drawLayer)
 		command = bytearray([GEO_TRANSLATE, params])
@@ -644,7 +644,7 @@ class TranslateNode(BaseDisplayListNode):
 			else:
 				command.extend(bytearray([0x00] * 4))
 		return command
-	
+
 	def to_c(self):
 		return self.c_func_macro("GEO_TRANSLATE_NODE",
 			getDrawLayerName(self.drawLayer),
@@ -664,18 +664,18 @@ class RotateNode(BaseDisplayListNode):
 		self.fMesh = None
 		self.DLmicrocode = None
 		self.dlRef = dlRef
-	
+
 	def get_ptr_offsets(self):
 		return [8] if self.hasDL else []
-	
+
 	def size(self):
 		return 12 if self.hasDL else 8
-		
+
 	def to_binary(self, segmentData):
 		params = ((1 if self.hasDL else 0) << 7) | int(self.drawLayer)
 		command = bytearray([GEO_ROTATE, params])
 		command.extend(bytearray([0x00] * 6))
-		writeEulerVectorToShorts(command, 2, 
+		writeEulerVectorToShorts(command, 2,
 			self.rotate.to_euler(geoNodeRotateOrder))
 		if self.hasDL:
 			start_address = self.get_dl_address()
@@ -695,7 +695,7 @@ class RotateNode(BaseDisplayListNode):
 			str(convertEulerFloatToShort(self.rotate.to_euler(
 				geoNodeRotateOrder)[2]))
 		)
-	
+
 class BillboardNode(BaseDisplayListNode):
 	dl_ext = 'AND_DL'
 
@@ -706,10 +706,10 @@ class BillboardNode(BaseDisplayListNode):
 		self.fMesh = None
 		self.DLmicrocode = None
 		self.dlRef = dlRef
-	
+
 	def get_ptr_offsets(self):
 		return [8] if self.hasDL else []
-	
+
 	def size(self):
 		return 12 if self.hasDL else 8
 
@@ -741,10 +741,10 @@ class DisplayListNode(BaseDisplayListNode):
 		self.fMesh = None
 		self.DLmicrocode = None
 		self.dlRef = dlRef
-	
+
 	def get_ptr_offsets(self):
 		return [4]
-	
+
 	def size(self):
 		return 8
 
@@ -780,7 +780,7 @@ class ShadowNode:
 		command.extend(self.shadowSolidity.to_bytes(2, 'big'))
 		command.extend(self.shadowScale.to_bytes(2, 'big'))
 		return command
-	
+
 	def to_c(self):
 		return "GEO_SHADOW(" + \
 			str(self.shadowType) + ', ' +\
@@ -795,13 +795,13 @@ class ScaleNode(BaseDisplayListNode):
 		self.fMesh = None
 		self.DLmicrocode = None
 		self.dlRef = dlRef
-	
+
 	def get_ptr_offsets(self):
 		return [8] if self.hasDL else []
-	
+
 	def size(self):
 		return 12 if self.hasDL else 8
-	
+
 	def to_binary(self, segmentData):
 		params = ((1 if self.hasDL else 0) << 7) | int(self.drawLayer)
 		command = bytearray([GEO_SCALE, params, 0x00, 0x00])
@@ -812,7 +812,7 @@ class ScaleNode(BaseDisplayListNode):
 			else:
 				command.extend(bytearray([0x00] * 4))
 		return command
-	
+
 	def to_c(self):
 		return self.c_func_macro("GEO_SCALE",
 			getDrawLayerName(self.drawLayer),
@@ -823,7 +823,7 @@ class StartRenderAreaNode:
 	def __init__(self, cullingRadius):
 		self.cullingRadius = cullingRadius
 		self.hasDL = False
-	
+
 	def size(self):
 		return 4
 
@@ -831,7 +831,7 @@ class StartRenderAreaNode:
 		command = bytearray([GEO_START_W_RENDERAREA, 0x00])
 		command.extend(convertFloatToShort(self.cullingRadius).to_bytes(2, 'big'))
 		return command
-	
+
 	def to_c(self):
 		cullingRadius = convertFloatToShort(self.cullingRadius)
 		#if abs(cullingRadius) > 2**15 - 1:
@@ -844,7 +844,7 @@ class RenderRangeNode:
 		self.minDist = minDist
 		self.maxDist = maxDist
 		self.hasDL = False
-	
+
 	def size(self):
 		return 8
 
@@ -853,7 +853,7 @@ class RenderRangeNode:
 		command.extend(convertFloatToShort(self.minDist).to_bytes(2, 'big'))
 		command.extend(convertFloatToShort(self.maxDist).to_bytes(2, 'big'))
 		return command
-	
+
 	def to_c(self):
 		minDist = convertFloatToShort(self.minDist)
 		maxDist = convertFloatToShort(self.maxDist)
@@ -871,10 +871,10 @@ class DisplayListWithOffsetNode(BaseDisplayListNode):
 		self.fMesh = None
 		self.DLmicrocode = None
 		self.dlRef = dlRef
-	
+
 	def size(self):
 		return 12
-	
+
 	def get_ptr_offsets(self):
 		return [8] if self.hasDL else []
 
@@ -906,10 +906,10 @@ class ScreenAreaNode:
 		self.position = position
 		self.dimensions = dimensions
 		self.hasDL = False
-	
+
 	def size(self):
 		return 12
-		
+
 	def to_binary(self, segmentData):
 		position = [160, 120] if self.useDefaults else self.position
 		dimensions = [160, 120] if self.useDefaults else self.dimensions
@@ -937,10 +937,10 @@ class OrthoNode:
 	def __init__(self, scale):
 		self.scale = scale
 		self.hasDL = False
-	
+
 	def size(self):
 		return 4
-		
+
 	def to_binary(self, segmentData):
 		command = bytearray([GEO_SET_ORTHO, 0x00])
 		# FIX: This should be f32.
@@ -957,18 +957,18 @@ class FrustumNode:
 		self.far = int(round(far))
 		self.useFunc = True # Always use function?
 		self.hasDL = False
-	
+
 	def size(self):
 		return 12 if self.useFunc else 8
-		
+
 	def to_binary(self, segmentData):
-		command = bytearray([GEO_SET_CAMERA_FRUSTRUM, 
+		command = bytearray([GEO_SET_CAMERA_FRUSTRUM,
 			0x01 if self.useFunc else 0x00])
 		command.extend(bytearray(struct.pack(">f", self.fov)))
 		command.extend(self.near.to_bytes(2, 'big', signed = True)) # Conversion?
 		command.extend(self.far.to_bytes(2, 'big', signed = True)) # Conversion?
 
-		if self.useFunc: 
+		if self.useFunc:
 			command.extend(bytes.fromhex('8029AA3C'))
 		return command
 
@@ -988,7 +988,7 @@ class ZBufferNode:
 
 	def size(self):
 		return 4
-		
+
 	def to_binary(self, segmentData):
 		command = bytearray([GEO_SET_Z_BUF, 0x01 if self.enable else 0x00,
 			0x00, 0x00])
@@ -1006,7 +1006,7 @@ class CameraNode:
 			[int(round(value * bpy.context.scene.blenderToSM64Scale)) for value in lookAt]
 		self.geo_func = '80287D30'
 		self.hasDL = False
-	
+
 	def size(self):
 		return 20
 
@@ -1039,7 +1039,7 @@ class RenderObjNode:
 
 	def size(self):
 		return 4
-		
+
 	def to_binary(self, segmentData):
 		command = bytearray([GEO_SETUP_OBJ_RENDER, 0x00, 0x00, 0x00])
 		return command
@@ -1056,7 +1056,7 @@ class BackgroundNode:
 
 	def size(self):
 		return 8
-		
+
 	def to_binary(self, segmentData):
 		command = bytearray([GEO_SET_BG, 0x00])
 		command.extend(self.backgroundValue.to_bytes(2, 'big', signed = False))
@@ -1086,7 +1086,7 @@ class CustomNode:
 
 	def to_binary(self, segmentData):
 		raise PluginError('Custom Geo Nodes are not supported for binary exports.')
-	
+
 	def to_c(self):
 		return f"{self.command}({self.args}),"
 

--- a/fast64_internal/sm64/sm64_geolayout_writer.py
+++ b/fast64_internal/sm64/sm64_geolayout_writer.py
@@ -161,7 +161,7 @@ def appendRevertToGeolayout(geolayoutGraph, fModel):
 		DPSetAlphaCompare("G_AC_NONE")])
 
 	# Get all draw layers, turn layers into strings (some are ints), deduplicate using a set
-	drawLayers = set([str(layer) for layer in geolayoutGraph.getDrawLayers()])
+	drawLayers = set(str(layer) for layer in geolayoutGraph.getDrawLayers())
 
 	# Revert settings in each draw layer
 	for layer in sorted(drawLayers): # Must be sorted, otherwise ordering is random due to `set` behavior

--- a/fast64_internal/sm64/sm64_geolayout_writer.py
+++ b/fast64_internal/sm64/sm64_geolayout_writer.py
@@ -911,7 +911,7 @@ def processMesh(
 	elif obj.get('original_mtx'): # object is instanced or a transformation
 		orig_mtx = mathutils.Matrix(obj['original_mtx'])
 		translate, rotate, scale = orig_mtx.decompose()
-		translate = translate_xyz_to_xzy(translate)
+		translate = translate_blender_to_n64(translate)
 		rotate = rotate_quat_blender_to_n64(rotate)
 	else: # object is NOT instanced
 		translate, rotate, scale = obj.matrix_local.decompose()

--- a/fast64_internal/sm64/sm64_geolayout_writer.py
+++ b/fast64_internal/sm64/sm64_geolayout_writer.py
@@ -32,7 +32,7 @@ def replaceStarReferences(basePath):
 		'GEO\_OPEN\_NODE\(\)\,\s*' +\
 		'GEO\_ASM\([^\)]*?\)\,\s*' +\
 		'GEO\_TRANSLATE\_ROTATE\_WITH\_DL\([^\)]*? star\_seg3.*?GEO\_CLOSE\_NODE\(\)\,'
-	
+
 	unagiPattern = 'GEO\_SCALE\(0x00\, 16384\)\,\s*' +\
 		'GEO\_OPEN\_NODE\(\)\,\s*' +\
 		'GEO\_TRANSLATE\_ROTATE\_WITH\_DL\([^\)]*? star\_seg3.*?GEO\_CLOSE\_NODE\(\)\,'
@@ -58,7 +58,7 @@ def replaceTransparentStarReferences(basePath):
 		'GEO\_OPEN\_NODE\(\)\,\s*' +\
 		'GEO\_ASM\([^\)]*?\)\,\s*' +\
 		'GEO\_TRANSLATE\_ROTATE\_WITH\_DL\([^\)]*? transparent_star\_seg3.*?GEO\_CLOSE\_NODE\(\)\,'
-	
+
 	kleptoReplacement = 'GEO_TRANSLATE_ROTATE(LAYER_OPAQUE, 75, 75, 0, 180, 270, 0),\n' +\
         '\t' * 10 + 'GEO_OPEN_NODE(),\n' +\
         '\t' * 10 + '\tGEO_BRANCH_AND_LINK(transparent_star_geo),\n' +\
@@ -73,7 +73,7 @@ def replaceCapReferences(basePath):
 		'GEO\_OPEN\_NODE\(\)\,\s*' +\
 		'GEO\_ASM\([^\)]*?\)\,\s*' +\
 		'GEO\_TRANSLATE\_ROTATE\_WITH\_DL\([^\)]*? mario\_cap\_seg3.*?GEO\_CLOSE\_NODE\(\)\,'
-	
+
 	kleptoReplacement = 'GEO_TRANSLATE_ROTATE(LAYER_OPAQUE, 75, 75, 0, 180, 270, 0),\n' +\
         '\t' * 10 + 'GEO_OPEN_NODE(),\n' +\
         '\t' * 10 + '\tGEO_BRANCH_AND_LINK(marios_cap_geo),\n' +\
@@ -141,7 +141,7 @@ def getAllArmatures(armatureObj, currentArmatures):
 					elif switchOption.optionArmature not in linkedArmatures and \
 						switchOption.optionArmature not in currentArmatures:
 						linkedArmatures.append(switchOption.optionArmature)
-	
+
 	currentArmatures.extend(linkedArmatures)
 	for linkedArmature in linkedArmatures:
 		getAllArmatures(linkedArmature, currentArmatures)
@@ -154,9 +154,9 @@ def getCameraObj(camera):
 		' is no longer in the scene.')
 
 def appendRevertToGeolayout(geolayoutGraph, fModel):
-	fModel.materialRevert = GfxList(fModel.name + "_" + 'material_revert_render_settings', 
+	fModel.materialRevert = GfxList(fModel.name + "_" + 'material_revert_render_settings',
 		GfxListTag.MaterialRevert, fModel.DLFormat)
-	revertMatAndEndDraw(fModel.materialRevert, 
+	revertMatAndEndDraw(fModel.materialRevert,
 		[DPSetEnvColor(0xFF, 0xFF, 0xFF, 0xFF),
 		DPSetAlphaCompare("G_AC_NONE")])
 
@@ -175,9 +175,9 @@ def appendRevertToGeolayout(geolayoutGraph, fModel):
 		geolayoutGraph.startGeolayout.nodes[0].children.append(TransformNode(dlNode))
 
 # Convert to Geolayout
-def convertArmatureToGeolayout(armatureObj, obj, convertTransformMatrix, 
+def convertArmatureToGeolayout(armatureObj, obj, convertTransformMatrix,
 	f3dType, isHWv1, camera, name, DLFormat, convertTextureData):
-	
+
 	fModel = SM64Model(f3dType, isHWv1, name, DLFormat)
 
 	if len(armatureObj.children) == 0:
@@ -187,7 +187,7 @@ def convertArmatureToGeolayout(armatureObj, obj, convertTransformMatrix,
 
 	# Find start bone, which is not root. Root is the start for animation.
 	startBoneNames = findStartBones(armatureObj)
-	
+
 	convertTransformMatrix = convertTransformMatrix @ \
 		mathutils.Matrix.Diagonal(armatureObj.scale).to_4x4()
 
@@ -205,13 +205,13 @@ def convertArmatureToGeolayout(armatureObj, obj, convertTransformMatrix,
 			rootNode = TransformNode(StartNode())
 		geolayoutGraph.startGeolayout.nodes.append(rootNode)
 		meshGeolayout = geolayoutGraph.startGeolayout
-	
+
 	for i in range(len(startBoneNames)):
 		startBoneName = startBoneNames[i]
 		if i > 0:
 			meshGeolayout.nodes.append(TransformNode(StartNode()))
-		processBone(fModel, startBoneName, obj, armatureObj, 
-			convertTransformMatrix, None, None, None, meshGeolayout.nodes[i], 
+		processBone(fModel, startBoneName, obj, armatureObj,
+			convertTransformMatrix, None, None, None, meshGeolayout.nodes[i],
 			[], name, meshGeolayout, geolayoutGraph, infoDict, convertTextureData)
 	generateSwitchOptions(meshGeolayout.nodes[0], meshGeolayout, geolayoutGraph,
 		name)
@@ -222,12 +222,12 @@ def convertArmatureToGeolayout(armatureObj, obj, convertTransformMatrix,
 	return geolayoutGraph, fModel
 
 # Camera is unused here
-def convertObjectToGeolayout(obj, convertTransformMatrix, 
+def convertObjectToGeolayout(obj, convertTransformMatrix,
 	f3dType, isHWv1, camera, name, fModel: FModel, areaObj, DLFormat, convertTextureData):
-	
+
 	if fModel is None:
 		fModel = SM64Model(f3dType, isHWv1, name, DLFormat)
-	
+
 	#convertTransformMatrix = convertTransformMatrix @ \
 	#	mathutils.Matrix.Diagonal(obj.scale).to_4x4()
 
@@ -238,7 +238,7 @@ def convertObjectToGeolayout(obj, convertTransformMatrix,
 		meshGeolayout = saveCameraSettingsToGeolayout(
 			geolayoutGraph, areaObj, obj, name + '_geo')
 		rootObj = areaObj
-		fModel.global_data.addAreaData(areaObj.areaIndex, 
+		fModel.global_data.addAreaData(areaObj.areaIndex,
 			FAreaData(FFogData(areaObj.area_fog_position, areaObj.area_fog_color)))
 
 	else:
@@ -274,27 +274,27 @@ def convertObjectToGeolayout(obj, convertTransformMatrix,
 	return geolayoutGraph, fModel
 
 # C Export
-def exportGeolayoutArmatureC(armatureObj, obj, convertTransformMatrix, 
-	f3dType, isHWv1, dirPath, texDir, savePNG, texSeparate, camera, groupName, 
+def exportGeolayoutArmatureC(armatureObj, obj, convertTransformMatrix,
+	f3dType, isHWv1, dirPath, texDir, savePNG, texSeparate, camera, groupName,
 	headerType, dirName, geoName, levelName, customExport, DLFormat):
 	geolayoutGraph, fModel = convertArmatureToGeolayout(armatureObj, obj,
 		convertTransformMatrix, f3dType, isHWv1, camera, dirName, DLFormat, not savePNG)
 
-	return saveGeolayoutC(geoName, dirName, geolayoutGraph, fModel, dirPath, texDir, 
+	return saveGeolayoutC(geoName, dirName, geolayoutGraph, fModel, dirPath, texDir,
 		savePNG, texSeparate, groupName, headerType, levelName, customExport, DLFormat)
 
-def exportGeolayoutObjectC(obj, convertTransformMatrix, 
-	f3dType, isHWv1, dirPath, texDir, savePNG, texSeparate, camera, groupName, 
+def exportGeolayoutObjectC(obj, convertTransformMatrix,
+	f3dType, isHWv1, dirPath, texDir, savePNG, texSeparate, camera, groupName,
 	headerType, dirName, geoName, levelName, customExport, DLFormat):
-	geolayoutGraph, fModel = convertObjectToGeolayout(obj, 
+	geolayoutGraph, fModel = convertObjectToGeolayout(obj,
 		convertTransformMatrix, f3dType, isHWv1, camera, dirName, None, None, DLFormat, not savePNG)
 
-	return saveGeolayoutC(geoName, dirName, geolayoutGraph, fModel, dirPath, texDir, 
+	return saveGeolayoutC(geoName, dirName, geolayoutGraph, fModel, dirPath, texDir,
 		savePNG, texSeparate, groupName, headerType, levelName, customExport, DLFormat)
 
 def saveGeolayoutC(geoName, dirName, geolayoutGraph: GeolayoutGraph, fModel: FModel, exportDir, texDir, savePNG,
  	texSeparate, groupName, headerType, levelName, customExport, DLFormat):
-	dirPath, texDir = getExportDir(customExport, exportDir, headerType, 
+	dirPath, texDir = getExportDir(customExport, exportDir, headerType,
 		levelName, texDir, dirName)
 
 	dirName = toAlnum(dirName)
@@ -303,7 +303,7 @@ def saveGeolayoutC(geoName, dirName, geolayoutGraph: GeolayoutGraph, fModel: FMo
 
 	if not os.path.exists(geoDirPath):
 		os.mkdir(geoDirPath)
-	
+
 	if headerType == 'Actor':
 		scrollName = 'actor_geo_' + dirName
 	elif headerType == 'Level':
@@ -364,14 +364,14 @@ def saveGeolayoutC(geoName, dirName, geolayoutGraph: GeolayoutGraph, fModel: FMo
 		matCInclude = '#include "levels/' + levelName + '/' + dirName + '/material.inc.c"'
 		matHInclude = '#include "levels/' + levelName + '/' + dirName + '/material.inc.h"'
 		headerInclude = '#include "levels/' + levelName + '/' + dirName + '/geo_header.h"'
-	
+
 	modifyTexScrollFiles(exportDir, geoDirPath, cDefineScroll, scroll_data, hasScrolling)
-	
+
 	if DLFormat == DLFormat.Static:
 		staticData.source += '\n' + dynamicData.source
 		staticData.header = geoData.header + staticData.header + dynamicData.header
 	else:
-		geoData.source = writeMaterialFiles(exportDir, geoDirPath, 
+		geoData.source = writeMaterialFiles(exportDir, geoDirPath,
 			headerInclude, matHInclude,
 			dynamicData.header, dynamicData.source, geoData.source, customExport)
 
@@ -399,7 +399,7 @@ def saveGeolayoutC(geoName, dirName, geolayoutGraph: GeolayoutGraph, fModel: FMo
 	cDefFile = open(headerPath, 'w', newline='\n')
 	cDefFile.write(staticData.header)
 	cDefFile.close()
-	
+
 	fileStatus = None
 	if not customExport:
 		if headerType == 'Actor':
@@ -436,7 +436,7 @@ def saveGeolayoutC(geoName, dirName, geolayoutGraph: GeolayoutGraph, fModel: FMo
 			bubblePath = os.path.join(exportDir, 'actors/bubble/geo.inc.c')
 			if dirName == 'purple_marble' and bpy.context.scene.modifyOldGeo:
 				replaceDLReferenceInGeo(bubblePath, 'purple\_marble\_geo\[\]', 'purple\_marble\_geo\_old\[\]')
-			
+
 			# Instances where a geo file has multiple similar geolayouts
 			if dirName == 'bowser':
 				appendSecondaryGeolayout(geoDirPath, 'bowser', 'bowser2')
@@ -480,12 +480,12 @@ def saveGeolayoutC(geoName, dirName, geolayoutGraph: GeolayoutGraph, fModel: FMo
 			texscrollGroup = levelName
 			texscrollGroupInclude = '#include "levels/' + levelName + '/header.h"'
 
-		fileStatus = modifyTexScrollHeadersGroup(exportDir, texscrollIncludeC, texscrollIncludeH, 
+		fileStatus = modifyTexScrollHeadersGroup(exportDir, texscrollIncludeC, texscrollIncludeH,
 			texscrollGroup, cDefineScroll, texscrollGroupInclude, hasScrolling)
-		
+
 		if DLFormat != DLFormat.Static: # Change this
 			writeMaterialHeaders(exportDir, matCInclude, matHInclude)
-	
+
 	return staticData.header, fileStatus
 
 # Insertable Binary
@@ -493,20 +493,20 @@ def exportGeolayoutArmatureInsertableBinary(armatureObj, obj,
 	convertTransformMatrix, f3dType, isHWv1, filepath, camera):
 	geolayoutGraph, fModel = convertArmatureToGeolayout(armatureObj, obj,
 		convertTransformMatrix, f3dType, isHWv1, camera, armatureObj.name, DLFormat.Static, True)
-	
+
 	saveGeolayoutInsertableBinary(geolayoutGraph, fModel, filepath, f3dType)
 
-def exportGeolayoutObjectInsertableBinary(obj, convertTransformMatrix, 
+def exportGeolayoutObjectInsertableBinary(obj, convertTransformMatrix,
 	f3dType, isHWv1, filepath, camera):
-	geolayoutGraph, fModel = convertObjectToGeolayout(obj, 
+	geolayoutGraph, fModel = convertObjectToGeolayout(obj,
 		convertTransformMatrix, f3dType, isHWv1, camera, obj.name, None, None, DLFormat.Static, True)
-	
+
 	saveGeolayoutInsertableBinary(geolayoutGraph, fModel, filepath, f3dType)
 
 def saveGeolayoutInsertableBinary(geolayoutGraph, fModel, filepath, f3d):
 	data, startRAM = \
 		getBinaryBank0GeolayoutData(fModel, geolayoutGraph, 0, [0, 0xFFFFFF])
-	
+
 	address_ptrs = geolayoutGraph.get_ptr_addresses()
 	address_ptrs.extend(fModel.get_ptr_addresses(f3d))
 
@@ -514,27 +514,27 @@ def saveGeolayoutInsertableBinary(geolayoutGraph, fModel, filepath, f3d):
 		address_ptrs, geolayoutGraph.startGeolayout.startAddress, data)
 
 # Binary Bank 0 Export
-def exportGeolayoutArmatureBinaryBank0(romfile, armatureObj, obj, exportRange,	
- 	convertTransformMatrix, levelCommandPos, modelID, textDumpFilePath, 
+def exportGeolayoutArmatureBinaryBank0(romfile, armatureObj, obj, exportRange,
+ 	convertTransformMatrix, levelCommandPos, modelID, textDumpFilePath,
 	f3dType, isHWv1, RAMAddr, camera):
-	
+
 	geolayoutGraph, fModel = convertArmatureToGeolayout(armatureObj, obj,
 		convertTransformMatrix, f3dType, isHWv1, camera, armatureObj.name, DLFormat.Static, True)
-	
+
 	return saveGeolayoutBinaryBank0(romfile, fModel, geolayoutGraph,
 		exportRange, levelCommandPos, modelID, textDumpFilePath, RAMAddr)
 
-def exportGeolayoutObjectBinaryBank0(romfile, obj, exportRange,	
- 	convertTransformMatrix, levelCommandPos, modelID, textDumpFilePath, 
+def exportGeolayoutObjectBinaryBank0(romfile, obj, exportRange,
+ 	convertTransformMatrix, levelCommandPos, modelID, textDumpFilePath,
 	f3dType, isHWv1, RAMAddr, camera):
-	
-	geolayoutGraph, fModel = convertObjectToGeolayout(obj, 
+
+	geolayoutGraph, fModel = convertObjectToGeolayout(obj,
 		convertTransformMatrix, f3dType, isHWv1, camera, obj.name, None, None, DLFormat.Static, True)
-	
+
 	return saveGeolayoutBinaryBank0(romfile, fModel, geolayoutGraph,
 		exportRange, levelCommandPos, modelID, textDumpFilePath, RAMAddr)
 
-def saveGeolayoutBinaryBank0(romfile, fModel, geolayoutGraph, exportRange,	
+def saveGeolayoutBinaryBank0(romfile, fModel, geolayoutGraph, exportRange,
  	levelCommandPos, modelID, textDumpFilePath, RAMAddr):
 	data, startRAM = getBinaryBank0GeolayoutData(
 		fModel, geolayoutGraph, RAMAddr, exportRange)
@@ -548,10 +548,10 @@ def saveGeolayoutBinaryBank0(romfile, fModel, geolayoutGraph, exportRange,
 	segPointerData = encodeSegmentedAddr(geoStart, segmentData)
 	geoWriteLevelCommand(romfile, segPointerData, levelCommandPos, modelID)
 	geoWriteTextDump(textDumpFilePath, geolayoutGraph, segmentData)
-	
+
 	return ((startAddress, startAddress + len(data)), startRAM + 0x80000000,
 		geoStart + 0x80000000)
-	
+
 def getBinaryBank0GeolayoutData(fModel, geolayoutGraph, RAMAddr, exportRange):
 	fModel.freePalettes()
 	segmentData = copy.copy(bank0Segment)
@@ -572,33 +572,33 @@ def getBinaryBank0GeolayoutData(fModel, geolayoutGraph, RAMAddr, exportRange):
 	data = bytesIO.getvalue()[startRAM:]
 	bytesIO.close()
 	return data, startRAM
-	
+
 # Binary Export
-def exportGeolayoutArmatureBinary(romfile, armatureObj, obj, exportRange,	
+def exportGeolayoutArmatureBinary(romfile, armatureObj, obj, exportRange,
  	convertTransformMatrix, levelData, levelCommandPos, modelID,
 	textDumpFilePath, f3dType, isHWv1, camera):
 
 	geolayoutGraph, fModel = convertArmatureToGeolayout(armatureObj, obj,
 		convertTransformMatrix, f3dType, isHWv1, camera, armatureObj.name, DLFormat.Static, True)
 
-	return saveGeolayoutBinary(romfile, geolayoutGraph, fModel, exportRange,	
+	return saveGeolayoutBinary(romfile, geolayoutGraph, fModel, exportRange,
  		levelData, levelCommandPos, modelID, textDumpFilePath)
 
-def exportGeolayoutObjectBinary(romfile, obj, exportRange,	
+def exportGeolayoutObjectBinary(romfile, obj, exportRange,
  	convertTransformMatrix, levelData, levelCommandPos, modelID,
 	textDumpFilePath, f3dType, isHWv1, camera):
-	
-	geolayoutGraph, fModel = convertObjectToGeolayout(obj, 
+
+	geolayoutGraph, fModel = convertObjectToGeolayout(obj,
 		convertTransformMatrix, f3dType, isHWv1, camera, obj.name, None, None, DLFormat.Static, True)
-	
-	return saveGeolayoutBinary(romfile, geolayoutGraph, fModel, exportRange,	
+
+	return saveGeolayoutBinary(romfile, geolayoutGraph, fModel, exportRange,
  		levelData, levelCommandPos, modelID, textDumpFilePath)
-	
-def saveGeolayoutBinary(romfile, geolayoutGraph, fModel, exportRange,	
+
+def saveGeolayoutBinary(romfile, geolayoutGraph, fModel, exportRange,
  	levelData, levelCommandPos, modelID, textDumpFilePath):
 	fModel.freePalettes()
 
-	# Get length of data, then actually write it after relative addresses 
+	# Get length of data, then actually write it after relative addresses
 	# are found.
 	startAddress = get64bitAlignedAddr(exportRange[0])
 	nonGeoStartAddr = startAddress + geolayoutGraph.size()
@@ -615,7 +615,7 @@ def saveGeolayoutBinary(romfile, geolayoutGraph, fModel, exportRange,
 	segPointerData = encodeSegmentedAddr(geoStart, levelData)
 	geoWriteLevelCommand(romfile, segPointerData, levelCommandPos, modelID)
 	geoWriteTextDump(textDumpFilePath, geolayoutGraph, levelData)
-	
+
 	return (startAddress, addrRange[1]), bytesToHex(segPointerData)
 
 def geoWriteLevelCommand(romfile, segPointerData, levelCommandPos, modelID):
@@ -642,7 +642,7 @@ def geoWriteTextDump(textDumpFilePath, geolayoutGraph, levelData):
 def generateSwitchOptions(transformNode, geolayout, geolayoutGraph, prefix):
 	if isinstance(transformNode.node, JumpNode):
 		for node in transformNode.node.geolayout.nodes:
-			generateSwitchOptions(node, transformNode.node.geolayout, 
+			generateSwitchOptions(node, transformNode.node.geolayout,
 			geolayoutGraph, prefix)
 	overrideNodes = []
 	if isinstance(transformNode.node, SwitchNode):
@@ -679,7 +679,7 @@ def generateSwitchOptions(transformNode, geolayout, geolayoutGraph, prefix):
 				index = transformNode.children.index(childNode)
 				transformNode.children.remove(childNode)
 
-				# Switch option bones should have unique names across all 
+				# Switch option bones should have unique names across all
 				# armatures.
 				optionGeolayout = geolayoutGraph.addGeolayout(
 					childNode, prefixName)
@@ -695,17 +695,17 @@ def generateSwitchOptions(transformNode, geolayout, geolayoutGraph, prefix):
 				if len(option0Nodes) == 1 and \
 					isinstance(option0Nodes[0].node, StartNode):
 					for startChild in option0Nodes[0].children:
-						generateOverrideHierarchy(copyNode, startChild, 
+						generateOverrideHierarchy(copyNode, startChild,
 							material, specificMat, overrideType, drawLayer,
 							option0Nodes[0].children.index(startChild),
-							optionGeolayout, geolayoutGraph, 
+							optionGeolayout, geolayoutGraph,
 							optionGeolayout.name)
 				else:
 					for overrideChild in option0Nodes:
-						generateOverrideHierarchy(copyNode, overrideChild, 
+						generateOverrideHierarchy(copyNode, overrideChild,
 							material, specificMat, overrideType, drawLayer,
 							option0Nodes.index(overrideChild),
-							optionGeolayout, geolayoutGraph, 
+							optionGeolayout, geolayoutGraph,
 							optionGeolayout.name)
 				if material is not None:
 					overrideNodes.append(copyNode)
@@ -716,11 +716,11 @@ def generateSwitchOptions(transformNode, geolayout, geolayoutGraph, prefix):
 			prefixName = prefix + '_opt' + str(i)
 		else:
 			prefixName = prefix
-		
+
 		if childNode not in overrideNodes:
 			generateSwitchOptions(childNode, geolayout, geolayoutGraph, prefixName)
 
-def generateOverrideHierarchy(parentCopyNode, transformNode, 
+def generateOverrideHierarchy(parentCopyNode, transformNode,
 	material, specificMat, overrideType, drawLayer, index, geolayout,
 	geolayoutGraph, switchOptionName):
 	#print(transformNode.node)
@@ -744,7 +744,7 @@ def generateOverrideHierarchy(parentCopyNode, transformNode,
 			isinstance(oldGeolayout.nodes[0].node, StartNode):
 			for node in oldGeolayout.nodes[0].children:
 				generateOverrideHierarchy(startNode, node, material, specificMat,
-				overrideType, drawLayer, 
+				overrideType, drawLayer,
 				oldGeolayout.nodes[0].children.index(node),
 				jumpGeolayout, geolayoutGraph, jumpName)
 		else:
@@ -762,10 +762,10 @@ def generateOverrideHierarchy(parentCopyNode, transformNode,
 			copyNode.node.drawLayer = drawLayer
 
 	for child in transformNode.children:
-		generateOverrideHierarchy(copyNode, child, material, specificMat, 
+		generateOverrideHierarchy(copyNode, child, material, specificMat,
 			overrideType, drawLayer, transformNode.children.index(child),
 			geolayout, geolayoutGraph, switchOptionName)
-		
+
 def addParentNode(parentTransformNode: TransformNode, geoNode):
 	transformNode = TransformNode(geoNode)
 	transformNode.parent = parentTransformNode
@@ -867,7 +867,7 @@ def processInlineGeoNode(
 # The copy will have modifiers / scale applied and will be made single user
 def processMesh(
 	fModel: FModel,
-	obj: bpy.types.Object, 
+	obj: bpy.types.Object,
 	transformMatrix: mathutils.Matrix,
 	parentTransformNode: TransformNode,
 	geolayout: Geolayout,
@@ -937,7 +937,7 @@ def processMesh(
 			childObj = alphabeticalChildren[i]
 			if i == 0: # Outside room system
 				# TODO: Allow users to specify whether this should be rendered before or after rooms (currently, it is after)
-				processMesh(fModel, childObj, transformMatrix, preRoomSwitchParentNode, 
+				processMesh(fModel, childObj, transformMatrix, preRoomSwitchParentNode,
 					geolayout, geolayoutGraph, False, convertTextureData)
 			else:
 				optionGeolayout = geolayoutGraph.addGeolayout(
@@ -950,7 +950,7 @@ def processMesh(
 				else:
 					startNode = TransformNode(StartNode())
 				optionGeolayout.nodes.append(startNode)
-				processMesh(fModel, childObj, transformMatrix, startNode, 
+				processMesh(fModel, childObj, transformMatrix, startNode,
 					optionGeolayout, geolayoutGraph, False, convertTextureData)
 
 	else:
@@ -973,12 +973,12 @@ def processMesh(
 			else:
 				node = getOptimalNode(translate, rotate, int(obj.draw_layer_static), True,
 					zeroTranslation, zeroRotation)
-	
+
 		elif obj.geo_cmd_static == "DisplayListWithOffset":
 			if not zeroRotation or not zeroScaleChange:
 				# translate/rotate -> scale -> DisplayListWithOffset
 				node = DisplayListWithOffsetNode(int(obj.draw_layer_static), True,
-					mathutils.Vector((0,0,0)))	
+					mathutils.Vector((0,0,0)))
 
 				parentTransformNode = addParentNode(parentTransformNode,
 					TranslateRotateNode(1, 0, False, translate, rotate))
@@ -996,7 +996,7 @@ def processMesh(
 				node = DisplayListNode(int(obj.draw_layer_static))
 
 				# Add billboard to top layer with translation
-				parentTransformNode = addParentNode(parentTransformNode, 
+				parentTransformNode = addParentNode(parentTransformNode,
 					BillboardNode(int(obj.draw_layer_static), False, translate)
 				)
 
@@ -1063,15 +1063,15 @@ def processMesh(
 
 			else:
 				triConverterInfo = TriangleConverterInfo(temp_obj, None, fModel.f3d, transformMatrix, getInfoDict(temp_obj))
-				fMeshes = saveStaticModel(triConverterInfo, fModel, temp_obj, transformMatrix, fModel.name, 
+				fMeshes = saveStaticModel(triConverterInfo, fModel, temp_obj, transformMatrix, fModel.name,
 					convertTextureData, False, 'sm64')
 
 				temp_obj['src_meshes'] = [({ 'name': fMesh.draw.name, 'layer': drawLayer }) for drawLayer, fMesh in fMeshes.items()]
 				node.dlRef = temp_obj['src_meshes'][0]['name']
-				
+
 		else:
 			triConverterInfo = TriangleConverterInfo(obj, None, fModel.f3d, transformMatrix, getInfoDict(obj))
-			fMeshes = saveStaticModel(triConverterInfo, fModel, obj, transformMatrix, fModel.name, 
+			fMeshes = saveStaticModel(triConverterInfo, fModel, obj, transformMatrix, fModel.name,
 				convertTextureData, False, 'sm64')
 
 		if fMeshes is None or len(fMeshes) == 0:
@@ -1099,14 +1099,14 @@ def processMesh(
 
 		alphabeticalChildren = sorted(obj.children, key = lambda childObj: childObj.original_name.lower())
 		for childObj in alphabeticalChildren:
-			processMesh(fModel, childObj, transformMatrix, transformNode, 
+			processMesh(fModel, childObj, transformMatrix, transformNode,
 				geolayout, geolayoutGraph, False, convertTextureData)
 
 # need to remember last geometry holding parent bone.
 # to do skinning, add the 0x15 command before any non-geometry bone groups.
-# 
+#
 
-# transformMatrix is a constant matrix to apply to verts, 
+# transformMatrix is a constant matrix to apply to verts,
 # not related to heirarchy.
 
 # lastTransformParentName: last parent with mesh data.
@@ -1125,7 +1125,7 @@ def processBone(fModel, boneName, obj, armatureObj, transformMatrix,
 	boneGroup = poseBone.bone_group
 	finalTransform = copy.deepcopy(transformMatrix)
 	materialOverrides = copy.copy(materialOverrides)
-	
+
 	if bone.geo_cmd == 'Ignore':
 		return
 
@@ -1156,9 +1156,9 @@ def processBone(fModel, boneName, obj, armatureObj, transformMatrix,
 		rotAxis, rotAngle = rotate.to_axis_angle()
 		if rotAngle > 0.00001:
 			node = DisplayListWithOffsetNode(int(bone.draw_layer),
-				hasDL, mathutils.Vector((0,0,0)))	
+				hasDL, mathutils.Vector((0,0,0)))
 
-			parentTransformNode = addParentNode(parentTransformNode, 
+			parentTransformNode = addParentNode(parentTransformNode,
 				TranslateRotateNode(1, 0, False, translate, rotate))
 
 			lastTranslateName = boneName
@@ -1167,9 +1167,9 @@ def processBone(fModel, boneName, obj, armatureObj, transformMatrix,
 			node = DisplayListWithOffsetNode(int(bone.draw_layer),
 				hasDL, translate)
 			lastTranslateName = boneName
-		
-		finalTransform = transformMatrix @ translation	
-	
+
+		finalTransform = transformMatrix @ translation
+
 	elif bone.geo_cmd == 'Function':
 		if bone.geo_func == '':
 			raise PluginError('Function bone ' + boneName + ' function value is empty.')
@@ -1180,24 +1180,24 @@ def processBone(fModel, boneName, obj, armatureObj, transformMatrix,
 		node = HeldObjectNode(bone.geo_func, translate)
 	else:
 		if bone.geo_cmd == 'Switch':
-			# This is done so we can easily calculate transforms 
+			# This is done so we can easily calculate transforms
 			# of switch options.
-			
+
 			if bone.geo_func == '':
 				raise PluginError('Switch bone ' + boneName + \
 					' function value is empty.')
 			node = SwitchNode(bone.geo_func, bone.func_param, boneName)
 			processSwitchBoneMatOverrides(materialOverrides, bone)
-			
+
 		elif bone.geo_cmd == 'Start':
 			node = StartNode()
 		elif bone.geo_cmd == 'TranslateRotate':
 			drawLayer = int(bone.draw_layer)
 			fieldLayout = int(bone.field_layout)
-			
-			node = TranslateRotateNode(drawLayer, fieldLayout, hasDL, 
+
+			node = TranslateRotateNode(drawLayer, fieldLayout, hasDL,
 				translate, rotate)
-			
+
 			if node.fieldLayout == 0:
 				finalTransform = transformMatrix @ translation @ rotation
 				lastTranslateName = boneName
@@ -1213,7 +1213,7 @@ def processBone(fModel, boneName, obj, armatureObj, transformMatrix,
 				rotation = mathutils.Euler((0, yRot, 0)).to_matrix().to_4x4()
 				finalTransform = transformMatrix @ rotation
 				lastRotateName = boneName
-			
+
 		elif bone.geo_cmd == 'Translate':
 			node = TranslateNode(int(bone.draw_layer), hasDL,
 				translate)
@@ -1234,7 +1234,7 @@ def processBone(fModel, boneName, obj, armatureObj, transformMatrix,
 				raise PluginError("Display List (0x15) " + boneName + ' must be a deform bone. Make sure deform is checked in bone properties.')
 		elif bone.geo_cmd == 'Shadow':
 			shadowType = int(bone.shadow_type)
-			shadowSolidity = bone.shadow_solidity 
+			shadowSolidity = bone.shadow_solidity
 			shadowScale = bone.shadow_scale
 			node = ShadowNode(shadowType, shadowSolidity, shadowScale)
 		elif bone.geo_cmd == 'Scale':
@@ -1246,15 +1246,15 @@ def processBone(fModel, boneName, obj, armatureObj, transformMatrix,
 			node = StartRenderAreaNode(bone.culling_radius)
 		else:
 			raise PluginError("Invalid geometry command: " + bone.geo_cmd)
-	
+
 	transformNode = TransformNode(node)
 	additionalNodes = []
 
 	if node.hasDL:
-		triConverterInfo = TriangleConverterInfo(obj, armatureObj.data, fModel.f3d, 
+		triConverterInfo = TriangleConverterInfo(obj, armatureObj.data, fModel.f3d,
 			mathutils.Matrix.Scale(bpy.context.scene.blenderToSM64Scale, 4) @ bone.matrix_local.inverted(), infoDict)
 		fMeshes, fSkinnedMeshes, usedDrawLayers = saveModelGivenVertexGroup(
-			fModel, obj, bone.name, lastDeformName, armatureObj, materialOverrides, 
+			fModel, obj, bone.name, lastDeformName, armatureObj, materialOverrides,
 			namePrefix, infoDict, convertTextureData, triConverterInfo, 'sm64', int(bone.draw_layer))
 
 		if (fMeshes is None or len(fMeshes) == 0) and (fSkinnedMeshes is None or len(fSkinnedMeshes) == 0):
@@ -1286,7 +1286,7 @@ def processBone(fModel, boneName, obj, armatureObj, transformMatrix,
 					node.drawLayer = drawLayer
 					node.DLmicrocode = fMesh.draw
 					node.fMesh = fMesh # Used for material override switches
-				
+
 					parentTransformNode.children.append(transformNode)
 					transformNode.parent = parentTransformNode
 
@@ -1311,7 +1311,7 @@ def processBone(fModel, boneName, obj, armatureObj, transformMatrix,
 
 	if not isinstance(transformNode.node, SwitchNode):
 		#print(boneGroup.name if boneGroup is not None else "Offset")
-		if len(bone.children) > 0: 
+		if len(bone.children) > 0:
 			#print("\tHas Children")
 			if bone.geo_cmd == 'Function':
 				raise PluginError("Function bones cannot have children. They instead affect the next sibling bone in alphabetical order.")
@@ -1322,9 +1322,9 @@ def processBone(fModel, boneName, obj, armatureObj, transformMatrix,
 			# This is so it can be used for siblings.
 			childrenNames = sorted([bone.name for bone in bone.children])
 			for name in childrenNames:
-				processBone(fModel, name, obj, armatureObj, 
-					finalTransform, lastTranslateName, lastRotateName, 
-					lastDeformName, transformNode, materialOverrides, 
+				processBone(fModel, name, obj, armatureObj,
+					finalTransform, lastTranslateName, lastRotateName,
+					lastDeformName, transformNode, materialOverrides,
 					namePrefix, geolayout,
 					geolayoutGraph, infoDict, convertTextureData)
 				#transformNode.children.append(childNode)
@@ -1333,11 +1333,11 @@ def processBone(fModel, boneName, obj, armatureObj, transformMatrix,
 	# see generateSwitchOptions() for explanation.
 	else:
 		#print(boneGroup.name if boneGroup is not None else "Offset")
-		if len(bone.children) > 0: 
+		if len(bone.children) > 0:
 			#optionGeolayout = \
 			#	geolayoutGraph.addGeolayout(
 			#		transformNode, boneName + '_opt0')
-			#geolayoutGraph.addJumpNode(transformNode, geolayout, 
+			#geolayoutGraph.addJumpNode(transformNode, geolayout,
 			#	optionGeolayout)
 			#optionGeolayout.nodes.append(TransformNode(StartNode()))
 			nextStartNode = TransformNode(StartNode())
@@ -1346,9 +1346,9 @@ def processBone(fModel, boneName, obj, armatureObj, transformMatrix,
 
 			childrenNames = sorted([bone.name for bone in bone.children])
 			for name in childrenNames:
-				processBone(fModel, name, obj, armatureObj, 
-					finalTransform, lastTranslateName, lastRotateName, 
-					lastDeformName, nextStartNode, materialOverrides, 
+				processBone(fModel, name, obj, armatureObj,
+					finalTransform, lastTranslateName, lastRotateName,
+					lastDeformName, nextStartNode, materialOverrides,
 					namePrefix, geolayout,
 					geolayoutGraph, infoDict, convertTextureData)
 				#transformNode.children.append(childNode)
@@ -1377,7 +1377,7 @@ def processBone(fModel, boneName, obj, armatureObj, transformMatrix,
 					continue
 
 				#optionNode = addParentNode(switchTransformNode, StartNode())
-				
+
 				optionBoneName = getSwitchOptionBone(optionArmature)
 				optionBone = optionArmature.data.bones[optionBoneName]
 
@@ -1385,9 +1385,9 @@ def processBone(fModel, boneName, obj, armatureObj, transformMatrix,
 				optionGeolayout = \
 					geolayoutGraph.addGeolayout(
 						optionArmature, namePrefix + "_" + optionArmature.name)
-				geolayoutGraph.addJumpNode(transformNode, geolayout, 
+				geolayoutGraph.addJumpNode(transformNode, geolayout,
 					optionGeolayout)
-				
+
 				rotAxis, rotAngle = rotate.to_axis_angle()
 				if rotAngle > 0.00001 or translate.length > 0.0001:
 					startNode = TransformNode(
@@ -1395,7 +1395,7 @@ def processBone(fModel, boneName, obj, armatureObj, transformMatrix,
 				else:
 					startNode = TransformNode(StartNode())
 				optionGeolayout.nodes.append(startNode)
-	
+
 				childrenNames = sorted(
 					[bone.name for bone in optionBone.children])
 				for name in childrenNames:
@@ -1420,7 +1420,7 @@ def processBone(fModel, boneName, obj, armatureObj, transformMatrix,
 						optionArmature,
 						finalTransform, optionBone.name, optionBone.name,
 						optionBone.name, startNode,
-						materialOverrides, namePrefix + '_' + optionBone.name, 
+						materialOverrides, namePrefix + '_' + optionBone.name,
 						optionGeolayout, geolayoutGraph, optionInfoDict, convertTextureData)
 			else:
 				if switchOption.switchType == 'Material':
@@ -1439,7 +1439,7 @@ def processBone(fModel, boneName, obj, armatureObj, transformMatrix,
 					material = None
 					specificMat = None
 					drawLayer = int(switchOption.drawLayer)
-				
+
 				texDimensions = getTexDimensions(material) if material is not None else None
 				overrideNode = TransformNode(SwitchOverrideNode(
 					material, specificMat, drawLayer,
@@ -1461,7 +1461,7 @@ def processSwitchBoneMatOverrides(materialOverrides, switchBone):
 							switchBone.name + ', a switch option' + \
 							' has a material override field that is None.')
 				specificMat = tuple([matPtr.material for matPtr in \
-							switchOption.specificOverrideArray])		
+							switchOption.specificOverrideArray])
 			else:
 				for mat in switchOption.specificIgnoreArray:
 					if mat is None:
@@ -1535,7 +1535,7 @@ def checkIfFirstNonASMNode(childNode):
 # So the skinned mesh node must be inserted before any of those transforms.
 # Sibling mesh nodes thus cannot share the same transform nodes before it
 # If they are both deform.
-# Additionally, ASM nodes should count as modifiers for other nodes if 
+# Additionally, ASM nodes should count as modifiers for other nodes if
 # they precede them
 def addSkinnedMeshNode(armatureObj, boneName, skinnedMesh, transformNode, parentNode, drawLayer):
 	# Add node to its immediate parent
@@ -1567,7 +1567,7 @@ def addSkinnedMeshNode(armatureObj, boneName, skinnedMesh, transformNode, parent
 			DisplayListWithOffsetNode)
 
 		acrossSwitchNode |= isinstance(highestChildNode.parent.node, SwitchNode)
-			
+
 		highestChildNode = highestChildNode.parent
 		highestChildCopyParent = TransformNode(copy.copy(highestChildNode.node))
 		highestChildCopyParent.children = [highestChildCopy]
@@ -1579,7 +1579,7 @@ def addSkinnedMeshNode(armatureObj, boneName, skinnedMesh, transformNode, parent
 		raise PluginError("Issue with \"" + boneName + "\": Deform parent bone not found for skinning.")
 		#raise PluginError("There shouldn't be a skinned mesh section if there is no deform parent. This error may have ocurred if a switch option node is trying to skin to a parent but no deform parent exists.")
 
-	# Otherwise, remove the transformNode from the parent and 
+	# Otherwise, remove the transformNode from the parent and
 	# duplicate the node heirarchy up to the last deform parent.
 	# Add the skinned node first to the last deform parent,
 	# then add the duplicated node hierarchy afterward.
@@ -1588,7 +1588,7 @@ def addSkinnedMeshNode(armatureObj, boneName, skinnedMesh, transformNode, parent
 			#print("Hierarchy but not first child.")
 			if hasNonDeform0x13Command:
 				raise PluginError("Error with " + boneName + ': You cannot have more that one child skinned mesh connected to a parent skinned mesh with a non deform 0x13 bone in between. Try removing any unnecessary non-deform bones.')
-		
+
 			if acrossSwitchNode:
 				raise PluginError("Error with " + boneName + ': You can not' +\
 				' skin across a switch node with more than one child.')
@@ -1636,9 +1636,9 @@ def addSkinnedMeshNode(armatureObj, boneName, skinnedMesh, transformNode, parent
 		#print("Immediate child.")
 		nodeIndex = parentNode.children.index(transformNode)
 		parentNode.children.insert(nodeIndex, skinnedTransformNode)
-		skinnedTransformNode.parent = parentNode	
+		skinnedTransformNode.parent = parentNode
 
-	return transformNode	
+	return transformNode
 
 def getAncestorGroups(parentGroup, vertexGroup, armatureObj, obj):
     if parentGroup is None:
@@ -1648,22 +1648,22 @@ def getAncestorGroups(parentGroup, vertexGroup, armatureObj, obj):
     while len(processingBones) > 0:
         currentBone = processingBones[0]
         processingBones = processingBones[1:]
-        
+
         ancestorBones.append(currentBone)
         processingBones.extend(currentBone.children)
-    
+
     currentBone = armatureObj.data.bones[vertexGroup].parent
     while currentBone is not None and currentBone.name != parentGroup:
         ancestorBones.append(currentBone)
         currentBone = currentBone.parent
     ancestorBones.append(armatureObj.data.bones[parentGroup])
-    
+
     #print(vertexGroup + ", " + parentGroup)
     #print([bone.name for bone in ancestorBones])
     return [getGroupIndexFromname(obj, bone.name) for bone in armatureObj.data.bones if bone not in ancestorBones]
 
 # returns fMeshes, fSkinnedMeshes, makeLastDeformBone
-def saveModelGivenVertexGroup(fModel, obj, vertexGroup, 
+def saveModelGivenVertexGroup(fModel, obj, vertexGroup,
 	parentGroup, armatureObj, materialOverrides, namePrefix,
 	infoDict, convertTextureData, triConverterInfo, drawLayerField, drawLayerV3):
 	#checkForF3DMaterial(obj)
@@ -1680,7 +1680,7 @@ def saveModelGivenVertexGroup(fModel, obj, vertexGroup,
 	if len(vertIndices) == 0:
 		print("No vert indices in " + vertexGroup)
 		return None, None, None
-	
+
 	transformMatrix = mathutils.Matrix.Scale(bpy.context.scene.blenderToSM64Scale, 4)
 	if parentGroup is None:
 		parentMatrix = transformMatrix
@@ -1734,7 +1734,7 @@ def saveModelGivenVertexGroup(fModel, obj, vertexGroup,
 			if isChildSkinnedFace:
 				usedDrawLayers.add(drawLayer)
 				continue
-			
+
 			if len(loopsNotInGroup) == 0:
 				if drawLayer not in groupFaces:
 					groupFaces[drawLayer] = {}
@@ -1759,14 +1759,14 @@ def saveModelGivenVertexGroup(fModel, obj, vertexGroup,
 	fMeshes = {}
 	fSkinnedMeshes = {}
 	for drawLayer, materialFaces in skinnedFaces.items():
-		
+
 		meshName = getFMeshName(vertexGroup, namePrefix, drawLayer, False)
 		checkUniqueBoneNames(fModel, meshName, vertexGroup)
 		skinnedMeshName = getFMeshName(vertexGroup, namePrefix, drawLayer, True)
 		checkUniqueBoneNames(fModel, skinnedMeshName, vertexGroup)
 
 		fMesh, fSkinnedMesh = saveSkinnedMeshByMaterial(materialFaces, fModel,
-			meshName, skinnedMeshName, obj, parentMatrix, namePrefix, 
+			meshName, skinnedMeshName, obj, parentMatrix, namePrefix,
 			vertexGroup, drawLayer, convertTextureData, triConverterInfo)
 
 		fSkinnedMeshes[drawLayer] = fSkinnedMesh
@@ -1790,12 +1790,12 @@ def saveModelGivenVertexGroup(fModel, obj, vertexGroup,
 			fMaterial, texDimensions = \
 				saveOrGetF3DMaterial(material, fModel, obj, drawLayer, convertTextureData)
 			if fMaterial.useLargeTextures:
-				currentGroupIndex = saveMeshWithLargeTexturesByFaces(material, bFaces, fModel, 
+				currentGroupIndex = saveMeshWithLargeTexturesByFaces(material, bFaces, fModel,
 					fMeshes[drawLayer], obj, drawLayer, convertTextureData, None, triConverterInfo, None, None)
 			else:
-				saveMeshByFaces(material, bFaces, fModel, fMeshes[drawLayer], obj, 
+				saveMeshByFaces(material, bFaces, fModel, fMeshes[drawLayer], obj,
 					drawLayer, convertTextureData, None, triConverterInfo, None, None)
-		
+
 		fMeshes[drawLayer].draw.commands.extend([
 			SPEndDisplayList(),
 		])
@@ -1808,7 +1808,7 @@ def saveModelGivenVertexGroup(fModel, obj, vertexGroup,
 		for drawLayer, fMesh in fSkinnedMeshes.items():
 			saveOverrideDraw(obj, fModel, material, specificMat, overrideType,
 				fMesh, drawLayer, convertTextureData)
-	
+
 	return fMeshes, fSkinnedMeshes, usedDrawLayers
 
 def saveOverrideDraw(obj, fModel, material, specificMat, overrideType, fMesh, drawLayer, convertTextureData):
@@ -1840,14 +1840,14 @@ def saveOverrideDraw(obj, fModel, material, specificMat, overrideType, fMesh, dr
 					triCommand = meshMatOverride.commands[meshMatOverride.commands.index(command) + 1]
 					if triCommand not in triCommands:
 						triCommands.append(triCommand)
-						
+
 				if command.displayList == fMaterial.revert and shouldModify:
 					removeReverts.append(command)
 	for command in removeReverts:
 		meshMatOverride.commands.remove(command)
 	if fOverrideMat.revert is not None:
 		for command in triCommands:
-			meshMatOverride.commands.insert(meshMatOverride.commands.index(command) + 1, 
+			meshMatOverride.commands.insert(meshMatOverride.commands.index(command) + 1,
 			SPDisplayList(fOverrideMat.revert))
 
 	#else:
@@ -1856,7 +1856,7 @@ def saveOverrideDraw(obj, fModel, material, specificMat, overrideType, fMesh, dr
 	#		meshMatOverride.commands.append(SPDisplayList(triList))
 	#	if fOverrideMat.revert is not None:
 	#		meshMatOverride.commands.append(SPDisplayList(fOverrideMat.revert))
-	#	meshMatOverride.commands.append(SPEndDisplayList())		
+	#	meshMatOverride.commands.append(SPEndDisplayList())
 
 def findVertIndexInBuffer(loop, buffer, loopDict):
 	i = 0
@@ -1890,14 +1890,14 @@ def splitSkinnedFacesIntoTwoGroups(skinnedFaces, fModel, obj, uv_data, drawLayer
 		# These MUST be arrays (not dicts) as order is important
 		inGroupVerts = []
 		inGroupVertArray.append([material_index, inGroupVerts])
-		
+
 		notInGroupVerts = []
 		notInGroupVertArray.append([material_index, notInGroupVerts])
 
 		material = obj.material_slots[material_index].material
 		fMaterial, texDimensions = \
 			saveOrGetF3DMaterial(material, fModel, obj, drawLayer, convertTextureData)
-		
+
 		exportVertexColors = isLightingDisabled(material)
 		convertInfo = LoopConvertInfo(uv_data, obj, exportVertexColors)
 		for skinnedFace in skinnedFaceArray:
@@ -1916,7 +1916,7 @@ def splitSkinnedFacesIntoTwoGroups(skinnedFaces, fModel, obj, uv_data, drawLayer
 				if bufferVert not in notInGroupVerts:
 					notInGroupVerts.append(bufferVert)
 				loopDict[loop] = f3dVert
-	
+
 	return inGroupVertArray, notInGroupVertArray, loopDict, notInGroupBlenderVerts
 
 def getGroupVertCount(group):
@@ -1925,9 +1925,9 @@ def getGroupVertCount(group):
 		count += len(vertData)
 	return count
 
-def saveSkinnedMeshByMaterial(skinnedFaces, fModel, meshName, skinnedMeshName, obj, 
+def saveSkinnedMeshByMaterial(skinnedFaces, fModel, meshName, skinnedMeshName, obj,
 	parentMatrix, namePrefix, vertexGroup, drawLayer, convertTextureData, triConverterInfo):
-	# We choose one or more loops per vert to represent a material from which 
+	# We choose one or more loops per vert to represent a material from which
 	# texDimensions can be found, since it is required for UVs.
 	uv_data = obj.data.uv_layers['UVMap'].data
 	inGroupVertArray, notInGroupVertArray, loopDict, notInGroupBlenderVerts = \
@@ -1943,7 +1943,7 @@ def saveSkinnedMeshByMaterial(skinnedFaces, fModel, meshName, skinnedMeshName, o
 			"connected faces will count more than once. Try " +\
 			"keeping UVs contiguous, and avoid using " +\
 			"split normals.")
-	
+
 	# Load parent group vertices
 	fSkinnedMesh = FMesh(skinnedMeshName, fModel.DLFormat)
 
@@ -1969,8 +1969,8 @@ def saveSkinnedMeshByMaterial(skinnedFaces, fModel, meshName, skinnedMeshName, o
 		fSkinnedMesh.draw.commands.append(SPDisplayList(fMaterial.material))
 		fSkinnedMesh.draw.commands.append(SPDisplayList(skinnedTriGroup.triList))
 		skinnedTriGroup.triList.commands.append(
-			SPVertex(skinnedTriGroup.vertexList, 
-				len(skinnedTriGroup.vertexList.vertices), 
+			SPVertex(skinnedTriGroup.vertexList,
+				len(skinnedTriGroup.vertexList.vertices),
 				len(vertData), curIndex))
 		curIndex += len(vertData)
 
@@ -1978,7 +1978,7 @@ def saveSkinnedMeshByMaterial(skinnedFaces, fModel, meshName, skinnedMeshName, o
 			skinnedTriGroup.vertexList.vertices.append(convertVertexData(obj.data,
 				bufferVert.f3dVert[0], bufferVert.f3dVert[1], bufferVert.f3dVert[2], texDimensions,
 				parentMatrix, isPointSampled, exportVertexColors))
-		
+
 		skinnedTriGroup.triList.commands.append(SPEndDisplayList())
 		if fMaterial.revert is not None:
 			fSkinnedMesh.draw.commands.append(SPDisplayList(fMaterial.revert))
@@ -1998,13 +1998,13 @@ def saveSkinnedMeshByMaterial(skinnedFaces, fModel, meshName, skinnedMeshName, o
 		fMaterial, texDimensions = \
 			saveOrGetF3DMaterial(material, fModel, obj, drawLayer, convertTextureData)
 		if fMaterial.useLargeTextures:
-			saveMeshWithLargeTexturesByFaces(material, faces, fModel, fMesh, obj, 
-				drawLayer, convertTextureData, None, triConverterInfo, 
+			saveMeshWithLargeTexturesByFaces(material, faces, fModel, fMesh, obj,
+				drawLayer, convertTextureData, None, triConverterInfo,
 				copy.deepcopy(existingVertData), copy.deepcopy(matRegionDict))
 		else:
 			saveMeshByFaces(material, faces,
-				fModel, fMesh, obj, drawLayer, 
-				convertTextureData, None, triConverterInfo, 
+				fModel, fMesh, obj, drawLayer,
+				convertTextureData, None, triConverterInfo,
 				copy.deepcopy(existingVertData), copy.deepcopy(matRegionDict))
 
 	return fMesh, fSkinnedMesh
@@ -2027,13 +2027,13 @@ def saveSkinnedMeshByMaterial(skinnedFaces, fModel, meshName, skinnedMeshName, o
 	#	triConverter = TriangleConverter(triConverterInfo, texDimensions, material,
 	#		None, triGroup.triList, triGroup.vertexList, copy.deepcopy(existingVertData), copy.deepcopy(matRegionDict))
 	#	saveTriangleStrip(triConverter, [skinnedFace.bFace for skinnedFace in skinnedFaceArray], obj.data, True)
-	#	saveTriangleStrip(triConverterClass, 
+	#	saveTriangleStrip(triConverterClass,
 	#		[skinnedFace.bFace for skinnedFace in skinnedFaceArray],
-	#		convertInfo, triGroup.triList, triGroup.vertexList, fModel.f3d, 
+	#		convertInfo, triGroup.triList, triGroup.vertexList, fModel.f3d,
 	#		texDimensions, currentMatrix, isPointSampled, exportVertexColors,
 	#		copy.deepcopy(existingVertData), copy.deepcopy(matRegionDict),
 	#		infoDict, obj.data, None, True)
-	
+
 	return fMesh, fSkinnedMesh
 
 def writeDynamicMeshFunction(name, displayList):
@@ -2095,8 +2095,8 @@ class SM64_ExportGeolayoutObject(ObjectDataExporter):
 			saveTextures = bpy.context.scene.saveTextures or bpy.context.scene.ignoreTextureRestrictions
 
 			if context.scene.geoExportType == 'C':
-				exportPath, levelName = getPathAndLevel(context.scene.geoCustomExport, 
-					context.scene.geoExportPath, context.scene.geoLevelName, 
+				exportPath, levelName = getPathAndLevel(context.scene.geoCustomExport,
+					context.scene.geoExportPath, context.scene.geoLevelName,
 					context.scene.geoLevelOption)
 				if not context.scene.geoCustomExport:
 					applyBasicTweaks(exportPath)
@@ -2106,14 +2106,14 @@ class SM64_ExportGeolayoutObject(ObjectDataExporter):
 					bpy.context.scene.geoTexDir,
 					saveTextures,
 					saveTextures and bpy.context.scene.geoSeparateTextureDef,
-					None, bpy.context.scene.geoGroupName, 
+					None, bpy.context.scene.geoGroupName,
 					context.scene.geoExportHeaderType,
 					context.scene.geoName, context.scene.geoStructName, levelName, context.scene.geoCustomExport, DLFormat.Static)
 				self.report({'INFO'}, 'Success!')
 			elif context.scene.geoExportType == 'Insertable Binary':
 				exportGeolayoutObjectInsertableBinary(obj,
 					finalTransform, context.scene.f3d_type,
-					context.scene.isHWv1, 
+					context.scene.isHWv1,
 					bpy.path.abspath(bpy.context.scene.geoInsertableBinaryPath),
 					None)
 				self.report({'INFO'}, 'Success! Data at ' + \
@@ -2122,21 +2122,21 @@ class SM64_ExportGeolayoutObject(ObjectDataExporter):
 				tempROM = tempName(context.scene.outputRom)
 				checkExpanded(bpy.path.abspath(context.scene.exportRom))
 				romfileExport = open(
-					bpy.path.abspath(context.scene.exportRom), 'rb')	
-				shutil.copy(bpy.path.abspath(context.scene.exportRom), 
+					bpy.path.abspath(context.scene.exportRom), 'rb')
+				shutil.copy(bpy.path.abspath(context.scene.exportRom),
 					bpy.path.abspath(tempROM))
 				romfileExport.close()
 				romfileOutput = open(bpy.path.abspath(tempROM), 'rb+')
 
-				levelParsed = parseLevelAtPointer(romfileOutput, 
+				levelParsed = parseLevelAtPointer(romfileOutput,
 					level_pointers[context.scene.levelGeoExport])
 				segmentData = levelParsed.segmentData
 
 				if context.scene.extendBank4:
-					ExtendBank0x04(romfileOutput, segmentData, 
+					ExtendBank0x04(romfileOutput, segmentData,
 						defaultExtendSegment4)
 
-				exportRange = [int(context.scene.geoExportStart, 16), 
+				exportRange = [int(context.scene.geoExportStart, 16),
 					int(context.scene.geoExportEnd, 16)]
 				textDumpFilePath = \
 					bpy.path.abspath(context.scene.textDumpGeoPath) \
@@ -2151,9 +2151,9 @@ class SM64_ExportGeolayoutObject(ObjectDataExporter):
 				if context.scene.geoUseBank0:
 					addrRange, startRAM, geoStart = \
 						exportGeolayoutObjectBinaryBank0(
-						romfileOutput, obj, exportRange, 
+						romfileOutput, obj, exportRange,
  						finalTransform, *modelLoadInfo, textDumpFilePath,
-						context.scene.f3d_type, context.scene.isHWv1, 
+						context.scene.f3d_type, context.scene.isHWv1,
 						getAddressFromRAMAddress(int(
 						context.scene.geoRAMAddr, 16)),
 						None)
@@ -2161,7 +2161,7 @@ class SM64_ExportGeolayoutObject(ObjectDataExporter):
 					addrRange, segPointer = exportGeolayoutObjectBinary(
 						romfileOutput, obj,
 						exportRange, finalTransform, segmentData,
-						*modelLoadInfo, textDumpFilePath, 
+						*modelLoadInfo, textDumpFilePath,
 						context.scene.f3d_type, context.scene.isHWv1,
 						None)
 
@@ -2172,7 +2172,7 @@ class SM64_ExportGeolayoutObject(ObjectDataExporter):
 
 				if os.path.exists(bpy.path.abspath(context.scene.outputRom)):
 					os.remove(bpy.path.abspath(context.scene.outputRom))
-				os.rename(bpy.path.abspath(tempROM), 
+				os.rename(bpy.path.abspath(tempROM),
 					bpy.path.abspath(context.scene.outputRom))
 
 				if context.scene.geoUseBank0:
@@ -2184,7 +2184,7 @@ class SM64_ExportGeolayoutObject(ObjectDataExporter):
 					self.report({'INFO'}, 'Success! Geolayout at (' + \
 						hex(addrRange[0]) + ', ' + hex(addrRange[1]) + \
 						') (Seg. ' + segPointer + ').')
-			
+
 			self.cleanup_temp_object_data()
 			applyRotation([obj], math.radians(-90), 'X')
 			self.show_warnings()
@@ -2266,7 +2266,7 @@ class SM64_ExportGeolayoutArmature(bpy.types.Operator):
 
 		try:
 			# Rotate all armatures 90 degrees
-			applyRotation([armatureObj] + linkedArmatures, 
+			applyRotation([armatureObj] + linkedArmatures,
 				math.radians(90), 'X')
 
 			# You must ALSO apply object rotation after armature rotation.
@@ -2278,8 +2278,8 @@ class SM64_ExportGeolayoutArmature(bpy.types.Operator):
 			bpy.ops.object.transform_apply(location = False, rotation = True,
 				scale = True, properties =  False)
 			if context.scene.geoExportType == 'C':
-				exportPath, levelName = getPathAndLevel(context.scene.geoCustomExport, 
-					context.scene.geoExportPath, context.scene.geoLevelName, 
+				exportPath, levelName = getPathAndLevel(context.scene.geoCustomExport,
+					context.scene.geoExportPath, context.scene.geoLevelName,
 					context.scene.geoLevelOption)
 
 				saveTextures = bpy.context.scene.saveTextures or bpy.context.scene.ignoreTextureRestrictions
@@ -2298,7 +2298,7 @@ class SM64_ExportGeolayoutArmature(bpy.types.Operator):
 			elif context.scene.geoExportType == 'Insertable Binary':
 				exportGeolayoutArmatureInsertableBinary(armatureObj, obj,
 					finalTransform, context.scene.f3d_type,
-					context.scene.isHWv1, 
+					context.scene.isHWv1,
 					bpy.path.abspath(bpy.context.scene.geoInsertableBinaryPath),
 					None)
 				self.report({'INFO'}, 'Success! Data at ' + \
@@ -2307,21 +2307,21 @@ class SM64_ExportGeolayoutArmature(bpy.types.Operator):
 				tempROM = tempName(context.scene.outputRom)
 				checkExpanded(bpy.path.abspath(context.scene.exportRom))
 				romfileExport = open(
-					bpy.path.abspath(context.scene.exportRom), 'rb')	
-				shutil.copy(bpy.path.abspath(context.scene.exportRom), 
+					bpy.path.abspath(context.scene.exportRom), 'rb')
+				shutil.copy(bpy.path.abspath(context.scene.exportRom),
 					bpy.path.abspath(tempROM))
 				romfileExport.close()
 				romfileOutput = open(bpy.path.abspath(tempROM), 'rb+')
 
-				levelParsed = parseLevelAtPointer(romfileOutput, 
+				levelParsed = parseLevelAtPointer(romfileOutput,
 					level_pointers[context.scene.levelGeoExport])
 				segmentData = levelParsed.segmentData
 
 				if context.scene.extendBank4:
-					ExtendBank0x04(romfileOutput, segmentData, 
+					ExtendBank0x04(romfileOutput, segmentData,
 						defaultExtendSegment4)
 
-				exportRange = [int(context.scene.geoExportStart, 16), 
+				exportRange = [int(context.scene.geoExportStart, 16),
 					int(context.scene.geoExportEnd, 16)]
 				textDumpFilePath = \
 					bpy.path.abspath(context.scene.textDumpGeoPath) \
@@ -2336,16 +2336,16 @@ class SM64_ExportGeolayoutArmature(bpy.types.Operator):
 				if context.scene.geoUseBank0:
 					addrRange, startRAM, geoStart = \
 						exportGeolayoutArmatureBinaryBank0(
-						romfileOutput, armatureObj, obj, exportRange, 
+						romfileOutput, armatureObj, obj, exportRange,
  						finalTransform, *modelLoadInfo, textDumpFilePath,
-						context.scene.f3d_type, context.scene.isHWv1, 
+						context.scene.f3d_type, context.scene.isHWv1,
 						getAddressFromRAMAddress(int(
 						context.scene.geoRAMAddr, 16)), None)
 				else:
 					addrRange, segPointer = exportGeolayoutArmatureBinary(
 						romfileOutput, armatureObj, obj,
 						exportRange, finalTransform, segmentData,
-						*modelLoadInfo, textDumpFilePath, 
+						*modelLoadInfo, textDumpFilePath,
 						context.scene.f3d_type, context.scene.isHWv1,
 						None)
 
@@ -2356,7 +2356,7 @@ class SM64_ExportGeolayoutArmature(bpy.types.Operator):
 
 				if os.path.exists(bpy.path.abspath(context.scene.outputRom)):
 					os.remove(bpy.path.abspath(context.scene.outputRom))
-				os.rename(bpy.path.abspath(tempROM), 
+				os.rename(bpy.path.abspath(tempROM),
 					bpy.path.abspath(context.scene.outputRom))
 
 				if context.scene.geoUseBank0:
@@ -2369,7 +2369,7 @@ class SM64_ExportGeolayoutArmature(bpy.types.Operator):
 						hex(addrRange[0]) + ', ' + hex(addrRange[1]) + \
 						') (Seg. ' + segPointer + ').')
 
-			applyRotation([armatureObj] + linkedArmatures, 
+			applyRotation([armatureObj] + linkedArmatures,
 				math.radians(-90), 'X')
 
 			return {'FINISHED'} # must return a set
@@ -2377,8 +2377,8 @@ class SM64_ExportGeolayoutArmature(bpy.types.Operator):
 		except Exception as e:
 			if context.mode != 'OBJECT':
 				bpy.ops.object.mode_set(mode = 'OBJECT')
-			
-			applyRotation([armatureObj] + linkedArmatures, 
+
+			applyRotation([armatureObj] + linkedArmatures,
 				math.radians(-90), 'X')
 
 			if context.scene.geoExportType == 'Binary':
@@ -2453,7 +2453,7 @@ class SM64_ExportGeolayoutPanel(bpy.types.Panel):
 						warningBox.label(text = 'Use one of these geolayout names instead:')
 						warningBox.label(text = ' - koopa_with_shell')
 						warningBox.label(text = ' - koopa_without_shell')
-					
+
 					if context.scene.geoName == 'black_bobomb' or\
 						context.scene.geoName == 'bobomb_buddy':
 						col.prop(context.scene, 'modifyOldGeo')
@@ -2494,10 +2494,10 @@ class SM64_ExportGeolayoutPanel(bpy.types.Panel):
 				infoBox.label(text = 'to prevent compilation errors.')
 				decompFolderMessage(col)
 				writeBox = makeWriteInfoBox(col)
-				writeBoxExportType(writeBox, context.scene.geoExportHeaderType, 
+				writeBoxExportType(writeBox, context.scene.geoExportHeaderType,
 					context.scene.geoName, context.scene.geoLevelName,
 					context.scene.geoLevelOption)
-			
+
 			#extendedRAMLabel(col)
 		elif context.scene.geoExportType == 'Insertable Binary':
 			col.prop(context.scene, 'geoInsertableBinaryPath')
@@ -2547,14 +2547,14 @@ def sm64_geo_writer_register():
 		name = 'Start', default = '11D8930')
 	bpy.types.Scene.geoExportEnd = bpy.props.StringProperty(
 		name = 'End', default = '11FFF00')
-	
+
 	bpy.types.Scene.overwriteModelLoad = bpy.props.BoolProperty(
 		name = 'Modify level script', default = True)
 	bpy.types.Scene.modelLoadLevelScriptCmd = bpy.props.StringProperty(
 		name = 'Level script model load command', default = '2ABCE0')
-	bpy.types.Scene.modelID = bpy.props.StringProperty(name = 'Model ID', 
+	bpy.types.Scene.modelID = bpy.props.StringProperty(name = 'Model ID',
 		default = '1')
-	
+
 	bpy.types.Scene.textDumpGeo = bpy.props.BoolProperty(
 		name = 'Dump geolayout as text', default = False)
 	bpy.types.Scene.textDumpGeoPath =  bpy.props.StringProperty(
@@ -2564,7 +2564,7 @@ def sm64_geo_writer_register():
 	bpy.types.Scene.geoExportPath = bpy.props.StringProperty(
 		name = 'Directory', subtype = 'FILE_PATH')
 	bpy.types.Scene.geoUseBank0 = bpy.props.BoolProperty(name = 'Use Bank 0')
-	bpy.types.Scene.geoRAMAddr = bpy.props.StringProperty(name = 'RAM Address', 
+	bpy.types.Scene.geoRAMAddr = bpy.props.StringProperty(name = 'RAM Address',
 		default = '80000000')
 	bpy.types.Scene.geoTexDir = bpy.props.StringProperty(
 		name ='Include Path', default = 'actors/mario/')
@@ -2582,7 +2582,7 @@ def sm64_geo_writer_register():
 		name = 'Header Export', items = enumExportHeaderType, default = 'Actor')
 	bpy.types.Scene.geoCustomExport = bpy.props.BoolProperty(
 		name = 'Custom Export Path')
-	bpy.types.Scene.geoLevelName = bpy.props.StringProperty(name = 'Level', 
+	bpy.types.Scene.geoLevelName = bpy.props.StringProperty(name = 'Level',
 		default = 'bob')
 	bpy.types.Scene.geoLevelOption = bpy.props.EnumProperty(
 		items = enumLevelNames, name = 'Level', default = 'bob')

--- a/fast64_internal/sm64/sm64_geolayout_writer.py
+++ b/fast64_internal/sm64/sm64_geolayout_writer.py
@@ -912,7 +912,7 @@ def processMesh(
 		orig_mtx = mathutils.Matrix(obj['original_mtx'])
 		translate, rotate, scale = orig_mtx.decompose()
 		translate = translate_xyz_to_xzy(translate)
-		rotate = rotation_xyz_quat_to_xzy_quat(rotate)
+		rotate = rotate_quat_blender_to_n64(rotate)
 	else: # object is NOT instanced
 		translate, rotate, scale = obj.matrix_local.decompose()
 	rotAxis, rotAngle = rotate.to_axis_angle()

--- a/fast64_internal/sm64/sm64_level_writer.py
+++ b/fast64_internal/sm64/sm64_level_writer.py
@@ -38,7 +38,7 @@ def createGeoFile(levelName, filepath):
 		'#include "game/paintings.h"\n\n' +\
 		'#include "make_const_nonconst.h"\n\n' +\
 		'#include "levels/' + levelName + '/header.h"\n\n'
-	
+
 	geoFile = open(filepath, 'w', newline = '\n')
 	geoFile.write(result)
 	geoFile.close()
@@ -54,7 +54,7 @@ def createLevelDataFile(levelName, filepath):
 		'#include "textures.h"\n' +\
 		'#include "dialog_ids.h"\n\n' +\
 		'#include "make_const_nonconst.h"\n\n'
-	
+
 	levelDataFile = open(filepath, 'w', newline = '\n')
 	levelDataFile.write(result)
 	levelDataFile.close()
@@ -75,7 +75,7 @@ class ZoomOutMasks:
 	def __init__(self, masks, originalData):
 		self.masks = masks
 		self.originalData = originalData
-	
+
 	def to_c(self):
 		result = ''
 		#result += 'u8 sZoomOutAreaMasks[] = {\n'
@@ -87,14 +87,14 @@ class ZoomOutMasks:
 	def write(self, filepath):
 		matchResult = re.search('u8\s*sZoomOutAreaMasks\s*\[\]\s*=\s*\{' +\
 			'(((?!\}).)*)\}\s*;', self.originalData, re.DOTALL)
-	
+
 		if matchResult is None:
 			raise PluginError("Could not find sZoomOutAreaMasks in \"" + filepath + '".')
 		data = self.originalData[:matchResult.start(1)] + self.to_c() + self.originalData[matchResult.end(1):]
 
 		if data == self.originalData:
 			return
-			
+
 		maskFile = open(filepath, 'w', newline = '\n')
 		maskFile.write(data)
 		maskFile.close()
@@ -138,7 +138,7 @@ class CourseDefines:
 		result += 'DEFINE_COURSES_END()\n'
 		result += macrosToString(self.bonusCourses, False, tabDepth = 0)
 		return result
-	
+
 	def write(self, filepath):
 		data = self.to_c()
 		if data == self.originalData:
@@ -146,7 +146,7 @@ class CourseDefines:
 		defineFile = open(filepath, 'w', newline = '\n')
 		defineFile.write(data)
 		defineFile.close()
-	
+
 	def getOrMakeMacroByCourseName(self, courseEnum, isBonus):
 		for course in self.courses:
 			if course[1][0] == courseEnum:
@@ -161,7 +161,7 @@ class CourseDefines:
 			], '']
 
 			self.courses.append(macroCmd)
-			return macroCmd	
+			return macroCmd
 
 		else:
 			macroCmd = ['DEFINE_BONUS_COURSE', [
@@ -170,7 +170,7 @@ class CourseDefines:
 			], '']
 
 			self.bonusCourses.append(macroCmd)
-			return macroCmd	
+			return macroCmd
 
 class LevelDefines:
 	def __init__(self, headerInfo, defineMacros, originalData):
@@ -183,7 +183,7 @@ class LevelDefines:
 		result = self.headerInfo
 		result += macrosToString(self.defineMacros, False, tabDepth = 0)
 		return result
-	
+
 	def write(self, filepath, headerPath):
 		data = self.to_c()
 		if data == self.originalData:
@@ -201,8 +201,8 @@ class LevelDefines:
 			if macro[0] == 'DEFINE_LEVEL' and macro[1][3] == levelName:
 				return macro
 		macroCmd = ['DEFINE_LEVEL', [
-			'"' + levelName.upper() + '"', 
-			'LEVEL_' + levelName.upper(), 
+			'"' + levelName.upper() + '"',
+			'LEVEL_' + levelName.upper(),
 			'COURSE_' + levelName.upper(),
 			levelName,
 			'generic',
@@ -226,7 +226,7 @@ class LevelScript:
 		self.modelLoads = []
 		self.actorIncludes = []
 		self.marioStart = None
-	
+
 	def to_c(self, areaString):
 		result = '#include <ultra64.h>\n' +\
 			'#include "sm64.h"\n' +\
@@ -238,10 +238,10 @@ class LevelScript:
 			'#include "level_commands.h"\n\n' +\
 			'#include "game/level_update.h"\n\n' +\
 			'#include "levels/scripts.h"\n\n'
-		
+
 		for actorInclude in self.actorIncludes:
 			result += actorInclude + '\n'
-		
+
 		result += '\n#include "make_const_nonconst.h"\n'
 		result += '#include "levels/' + self.name + '/header.h"\n\n'
 		result += 'const LevelScript level_' + self.name + '_entry[] = {\n'
@@ -269,7 +269,7 @@ class LevelScript:
 		    '\tCLEAR_LEVEL(),\n' +\
 		    '\tSLEEP_BEFORE_EXIT(1),\n' +\
 		    '\tEXIT(),\n};\n'
-		
+
 		return result
 
 def parseCourseDefines(filepath):
@@ -319,7 +319,7 @@ def parseZoomMasks(filepath):
 
 	matchResult = re.search('u8\s*sZoomOutAreaMasks\s*\[\]\s*=\s*\{' +\
 		'(((?!\}).)*)\}\s*;', cameraData, re.DOTALL)
-	
+
 	if matchResult is None:
 		raise PluginError("Could not find sZoomOutAreaMasks in \"" + filepath + '".')
 
@@ -338,7 +338,7 @@ def replaceSegmentLoad(levelscript, segmentName, command, changedSegment):
 	if changedLoad is None:
 		changedLoad = [command, [hex(changedSegment), '', ''], '']
 		levelscript.segmentLoads.append(changedLoad)
-	
+
 	changedLoad[1][1] = segmentName + 'SegmentRomStart'
 	changedLoad[1][2] = segmentName + 'SegmentRomEnd'
 
@@ -355,9 +355,9 @@ def stringToMacros(data):
 		arguments = arguments.split(',')
 		for i in range(len(arguments)):
 			arguments[i] = arguments[i].strip()
-		
+
 		macroData.append([macro, arguments, comment])
-	
+
 	return macroData
 
 def macroToString(macroCmd, useComma):
@@ -392,10 +392,10 @@ def addActSelectorIgnore(basePath, levelEnum):
 		return
 
 	# This won't actually match whole function, but only up to first closing bracket.
-	# This should be okay though... ?	
+	# This should be okay though... ?
 	matchResultFunction = re.search('s32\s*lvl\_set\_current\_level\s*\((((?!\)).)*)\)\s*\{' +\
 		'(((?!\}).)*)\}', data, re.DOTALL)
-	
+
 	if matchResultFunction is None:
 		raise PluginError("Could not find lvl_set_current_level in \"" + filepath + '".')
 
@@ -424,7 +424,7 @@ def removeActSelectorIgnore(basePath, levelEnum):
 def parseLevelScript(filepath, levelName):
 	scriptPath = os.path.join(filepath, 'script.c')
 	scriptData = getDataFromFile(scriptPath)
-	
+
 	levelscript = LevelScript(levelName)
 
 	for matchResult in re.finditer('#include\s*"actors/(\w*)\.h"', scriptData):
@@ -432,7 +432,7 @@ def parseLevelScript(filepath, levelName):
 
 	matchResult = re.search('const\s*LevelScript\s*level\_\w*\_entry\[\]\s*=\s*\{' +\
 		'(((?!\}).)*)\}\s*;', scriptData, re.DOTALL)
-	
+
 	if matchResult is None:
 		raise PluginError("Could not find entry levelscript in \"" + scriptPath + '".')
 
@@ -454,12 +454,12 @@ def parseLevelScript(filepath, levelName):
 				levelscript.modelLoads.append(macroCmd)
 			elif macroCmd[0] == 'MARIO':
 				levelscript.mario = macroToString(macroCmd, True)
-		
+
 		if macroCmd[0] == 'AREA':
 			inArea = True
 		elif macroCmd[0] == 'END_AREA':
 			inArea = False
-		
+
 	return levelscript
 
 def overwritePuppycamData(filePath, levelToReplace, newPuppycamTriggers):
@@ -484,19 +484,19 @@ def overwritePuppycamData(filePath, levelToReplace, newPuppycamTriggers):
 			for entry in entriesList:
 				if re.search('(\{\s?' + levelToReplace + '\s?,)', re.sub('(/\*.+?\*/)|(//.+?\n)', '', entry), re.DOTALL) is None:
 					data += entry
-			
+
 			# Add the new entries from this export, then put the file back together again.
 			data += '\n\n' + newPuppycamTriggers
 			data = matchResult.group(1) + data + '\n' + matchResult.group(3)
 		else:
 			raise PluginError("Could not find 'struct newcam_hardpos newcam_fixedcam[]'.")
-		
+
 		dataFile = open(filePath, 'w', newline='\n')
 		dataFile.write(data)
 		dataFile.close()
 	else:
 		raise PluginError(filePath + " does not exist.")
-	
+
 class SM64OptionalFileStatus:
 	def __init__(self):
 		self.cameraC = False
@@ -506,12 +506,12 @@ def exportLevelC(obj, transformMatrix, f3dType, isHWv1, levelName, exportDir,
 	savePNG, customExport, levelCameraVolumeName, DLFormat):
 
 	fileStatus = SM64OptionalFileStatus()
-	
+
 	if customExport:
 		levelDir = os.path.join(exportDir, levelName)
 	else:
 		levelDir = os.path.join(exportDir, 'levels/' + levelName)
-		
+
 	if customExport or not os.path.exists(os.path.join(levelDir, 'script.c')):
 		prevLevelScript = LevelScript(levelName)
 	else:
@@ -549,7 +549,7 @@ def exportLevelC(obj, transformMatrix, f3dType, isHWv1, levelName, exportDir,
 		#    raise PluginError(child.name + ' does not have an area camera set.')
 		#setOrigin(obj, child)
 		areaDict[child.areaIndex] = child
-		
+
 		areaIndex = child.areaIndex
 		areaName = 'area_' + str(areaIndex)
 		areaDir = os.path.join(levelDir, areaName)
@@ -568,7 +568,7 @@ def exportLevelC(obj, transformMatrix, f3dType, isHWv1, levelName, exportDir,
 		setRooms(child)
 
 		geolayoutGraph, fModel = \
-			convertObjectToGeolayout(obj, transformMatrix, 
+			convertObjectToGeolayout(obj, transformMatrix,
 			f3dType, isHWv1, child.areaCamera, levelName + '_' + areaName, fModel, child, DLFormat, not savePNG)
 		geolayoutGraphC = geolayoutGraph.to_c()
 
@@ -580,7 +580,7 @@ def exportLevelC(obj, transformMatrix, f3dType, isHWv1, levelName, exportDir,
 		headerString += geolayoutGraphC.header
 
 		# Write collision
-		collision = exportCollisionCommon(child, transformMatrix, True, True, 
+		collision = exportCollisionCommon(child, transformMatrix, True, True,
 				levelName + '_' + areaName, child.areaIndex)
 		collisionC = collision.to_c()
 		colFile = open(os.path.join(areaDir, 'collision.inc.c'), 'w', newline = '\n')
@@ -599,7 +599,7 @@ def exportLevelC(obj, transformMatrix, f3dType, isHWv1, levelName, exportDir,
 			headerString += roomsC.header
 
 		# Get area
-		area = exportAreaCommon(child, transformMatrix, 
+		area = exportAreaCommon(child, transformMatrix,
 			geolayoutGraph.startGeolayout, collision, levelName + '_' + areaName)
 		if area.mario_start is not None:
 			prevLevelScript.marioStart = area.mario_start
@@ -627,17 +627,17 @@ def exportLevelC(obj, transformMatrix, f3dType, isHWv1, levelName, exportDir,
 
 	# Generate levelscript string
 	compressionFmt = bpy.context.scene.compressionFormat
-	replaceSegmentLoad(prevLevelScript, 
+	replaceSegmentLoad(prevLevelScript,
 		'_' + levelName + '_segment_7', 'LOAD_' + compressionFmt.upper(), 0x07)
 	if usesEnvFX:
-		replaceSegmentLoad(prevLevelScript, 
+		replaceSegmentLoad(prevLevelScript,
 			'_effect_' + compressionFmt, 'LOAD_' + compressionFmt.upper(), 0x0B)
 	if not obj.useBackgroundColor:
-		replaceSegmentLoad(prevLevelScript, 
+		replaceSegmentLoad(prevLevelScript,
 			'_' + backgroundSegments[obj.background] + '_skybox_' + compressionFmt, 'LOAD_' + compressionFmt.upper(), 0x0A)
 	levelscriptString = prevLevelScript.to_c(areaString)
 
-	if bpy.context.scene.exportHiddenGeometry:	
+	if bpy.context.scene.exportHiddenGeometry:
 		hideObjsInList(hiddenObjs)
 
 	# Remove old areas.
@@ -649,7 +649,7 @@ def exportLevelC(obj, transformMatrix, f3dType, isHWv1, levelName, exportDir,
 					existingArea = True
 			if not existingArea:
 				shutil.rmtree(os.path.join(levelDir, f))
-	
+
 	gfxFormatter = SM64GfxFormatter(ScrollMethod.Vertex)
 	exportData = fModel.to_c(TextureExportSettings(savePNG, savePNG, 'levels/' + levelName, levelDir), gfxFormatter)
 	staticData = exportData.staticData
@@ -673,8 +673,8 @@ def exportLevelC(obj, transformMatrix, f3dType, isHWv1, levelName, exportDir,
 	if DLFormat == DLFormat.Static:
 		staticData.append(dynamicData)
 	else:
-		geoString = writeMaterialFiles(exportDir, levelDir, 
-			'#include "levels/' + levelName + '/header.h"', 
+		geoString = writeMaterialFiles(exportDir, levelDir,
+			'#include "levels/' + levelName + '/header.h"',
 			'#include "levels/' + levelName + '/material.inc.h"',
 			dynamicData.header, dynamicData.source, geoString, customExport)
 
@@ -727,7 +727,7 @@ def exportLevelC(obj, transformMatrix, f3dType, isHWv1, levelName, exportDir,
 	if not customExport:
 		if DLFormat != DLFormat.Static:
 			# Write material headers
-			writeMaterialHeaders(exportDir,  
+			writeMaterialHeaders(exportDir,
 				'#include "levels/' + levelName + '/material.inc.c"',
 				'#include "levels/' + levelName + '/material.inc.h"')
 
@@ -755,7 +755,7 @@ def exportLevelC(obj, transformMatrix, f3dType, isHWv1, levelName, exportDir,
 		levelDefineMacro[1][levelDefineArgs['acoustic reach']] = obj.acousticReach
 		levelDefineMacro[1][levelDefineArgs['echo level 1']] = echoLevels[0]
 		levelDefineMacro[1][levelDefineArgs['echo level 2']] = echoLevels[1]
-		levelDefineMacro[1][levelDefineArgs['echo level 3']] = echoLevels[2] 
+		levelDefineMacro[1][levelDefineArgs['echo level 3']] = echoLevels[2]
 
 		levelDefines.write(levelDefinesPath, levelHeadersPath)
 
@@ -783,7 +783,7 @@ def exportLevelC(obj, transformMatrix, f3dType, isHWv1, levelName, exportDir,
 		geoPath = os.path.join(levelDir, 'geo.c')
 		levelDataPath = os.path.join(levelDir, 'leveldata.c')
 		headerPath = os.path.join(levelDir, 'header.h')
-		
+
 		# Create files if not already existing
 		if not os.path.exists(geoPath):
 			createGeoFile(levelName, geoPath)
@@ -792,34 +792,34 @@ def exportLevelC(obj, transformMatrix, f3dType, isHWv1, levelName, exportDir,
 		if not os.path.exists(headerPath):
 			createHeaderFile(levelName, headerPath)
 
-		# Write level data		
+		# Write level data
 		writeIfNotFound(geoPath, '\n#include "levels/' + levelName + '/geo.inc.c"\n', '')
 		writeIfNotFound(levelDataPath, '\n#include "levels/' + levelName + '/leveldata.inc.c"\n', '')
 		writeIfNotFound(headerPath, '\n#include "levels/' + levelName + '/header.inc.h"\n', '#endif')
-		
+
 		if fModel.texturesSavedLastExport == 0:
 			textureIncludePath = os.path.join(levelDir, 'texture_include.inc.c')
 			if os.path.exists(textureIncludePath):
 				os.remove(textureIncludePath)
 			# This one is for backwards compatibility purposes
-			deleteIfFound(os.path.join(levelDir, 'texture.inc.c'), 
+			deleteIfFound(os.path.join(levelDir, 'texture.inc.c'),
 				'#include "levels/' + levelName + '/texture_include.inc.c"')
-		
+
 		# This one is for backwards compatibility purposes
 		deleteIfFound(levelDataPath,
 			'#include "levels/' + levelName + '/texture_include.inc.c"')
-		
+
 		texscrollIncludeC = '#include "levels/' + levelName + '/texscroll.inc.c"'
 		texscrollIncludeH = '#include "levels/' + levelName + '/texscroll.inc.h"'
 		texscrollGroup = levelName
 		texscrollGroupInclude = '#include "levels/' + levelName + '/header.h"'
 
-		texScrollFileStatus = modifyTexScrollHeadersGroup(exportDir, texscrollIncludeC, texscrollIncludeH, 
+		texScrollFileStatus = modifyTexScrollHeadersGroup(exportDir, texscrollIncludeC, texscrollIncludeH,
 			texscrollGroup, headerScroll, texscrollGroupInclude, hasScrolling)
 
 		if texScrollFileStatus is not None:
 			fileStatus.starSelectC = texScrollFileStatus.starSelectC
-	
+
 	return fileStatus
 
 def addGeoC(levelName):
@@ -834,7 +834,7 @@ def addGeoC(levelName):
 		'#include "game/moving_texture.h"\n' \
 		'#include "game/screen_transition.h"\n' \
 		'#include "game/paintings.h"\n\n'
-	
+
 	header += '#include "levels/' + levelName + '/header.h"\n'
 	return header
 
@@ -851,7 +851,7 @@ def addLevelDataC(levelName):
 		'#include "dialog_ids.h"\n' \
 		'\n' \
 		'#include "make_const_nonconst.h"\n'
-	
+
 	return header
 
 def addHeaderC(levelName):
@@ -861,9 +861,9 @@ def addHeaderC(levelName):
 		'\n' \
 		'#include "types.h"\n' \
 		'#include "game/moving_texture.h"\n\n'
-	
+
 	return header
-	
+
 class SM64_ExportLevel(ObjectDataExporter):
 	# set bl_ properties
 	bl_idname = 'object.sm64_export_level'
@@ -871,7 +871,7 @@ class SM64_ExportLevel(ObjectDataExporter):
 	bl_options = {'REGISTER', 'UNDO', 'PRESET'}
 
 	def execute(self, context):
-		
+
 		try:
 			if context.mode != 'OBJECT':
 				raise PluginError("Operator can only be used in object mode.")
@@ -885,7 +885,7 @@ class SM64_ExportLevel(ObjectDataExporter):
 			finalTransform = mathutils.Matrix.Diagonal(
 				mathutils.Vector((scaleValue, scaleValue, scaleValue))
 			).to_4x4()
-		
+
 		except Exception as e:
 			raisePluginError(self, e)
 			return {'CANCELLED'} # must return a set
@@ -998,7 +998,7 @@ def sm64_level_panel_unregister():
 def sm64_level_register():
 	for cls in sm64_level_classes:
 		register_class(cls)
-	
+
 	bpy.types.Scene.levelName = bpy.props.StringProperty(name = 'Name', default = 'bob')
 	bpy.types.Scene.levelOption = bpy.props.EnumProperty(name = "Level", items = enumLevelNames, default = 'bob')
 	bpy.types.Scene.levelExportPath = bpy.props.StringProperty(

--- a/fast64_internal/sm64/sm64_objects.py
+++ b/fast64_internal/sm64/sm64_objects.py
@@ -5,8 +5,10 @@ from io import BytesIO
 from .sm64_constants import *
 from .sm64_function_map import func_map
 from .sm64_spline import *
+from .sm64_geolayout_classes import *
 
 from ..utility import *
+from ..f3d.f3d_material import sm64EnumDrawLayers
 
 enumTerrain = [
 	('Custom', 'Custom', 'Custom'),
@@ -132,8 +134,46 @@ enumWaterBoxType = [
 	('Toxic Haze', 'Toxic Haze', 'Toxic Haze')
 ]
 
+class InlineGeolayoutObjConfig:
+	def __init__(
+		self, name, geo_node,
+		can_have_dl=False,
+		must_have_dl=False,
+		must_have_geo=False,
+		uses_location=False,
+		uses_rotation=False,
+		uses_scale=False
+	):
+		self.name = name
+		self.geo_node = geo_node
+		self.can_have_dl = can_have_dl or must_have_dl
+		self.must_have_dl = must_have_dl
+		self.must_have_geo = must_have_geo
+		self.uses_location = uses_location
+		self.uses_rotation = uses_rotation
+		self.uses_scale = uses_scale
+
+inlineGeoLayoutObjects = {
+	'Geo ASM'				: InlineGeolayoutObjConfig('Geo ASM', 				FunctionNode),
+	'Geo Branch'			: InlineGeolayoutObjConfig('Geo Branch', 			JumpNode,
+								must_have_geo=True),
+	'Geo Translate/Rotate'	: InlineGeolayoutObjConfig('Geo Translate/Rotate', 	TranslateRotateNode,
+								can_have_dl=True, uses_location=True, uses_rotation=True),
+	'Geo Translate Node'	: InlineGeolayoutObjConfig('Geo Translate Node', 	TranslateNode,
+								can_have_dl=True, uses_location=True),
+	'Geo Rotation Node'		: InlineGeolayoutObjConfig('Geo Rotation Node', 	RotateNode,
+								can_have_dl=True, uses_rotation=True),
+	'Geo Billboard'			: InlineGeolayoutObjConfig('Geo Billboard', 		BillboardNode,
+								can_have_dl=True, uses_location=True),
+	'Geo Scale'				: InlineGeolayoutObjConfig('Geo Scale', 			ScaleNode,
+								can_have_dl=True, uses_scale=True),
+	'Geo Displaylist'		: InlineGeolayoutObjConfig('Geo Displaylist', 		DisplayListNode,
+								must_have_dl=True),
+	'Custom Geo Command'	: InlineGeolayoutObjConfig('Custom Geo Command', 	CustomNode),
+}
+
 # When adding new types related to geolayout,
-# Make sure to add exceptions in utility.py - selectMeshChildrenOnly
+# Make sure to add exceptions to enumSM64EmptyWithGeolayout
 enumObjectType = [
 	('None', 'None', 'None'),
 	('Level Root', 'Level Root', 'Level Root'),
@@ -147,6 +187,8 @@ enumObjectType = [
 	('Camera Volume', 'Camera Volume', 'Camera Volume'),
 	('Switch', 'Switch Node', 'Switch Node'),
 	('Puppycam Volume', 'Puppycam Volume', 'Puppycam Volume'),
+	('', 'Inline Geolayout Commands', ''), # This displays as a column header for the next set of options
+	*[(key, key, key) for key in inlineGeoLayoutObjects.keys()]
 ]
 
 enumPuppycamMode = [
@@ -781,12 +823,78 @@ class SM64ObjectPanel(bpy.types.Panel):
 	def poll(cls, context):
 		return context.scene.gameEditorMode == "SM64" and (context.object is not None and context.object.data is None)
 
+	def draw_inline_obj(self, box: bpy.types.UILayout, obj: bpy.types.Object):
+		obj_details: InlineGeolayoutObjConfig = inlineGeoLayoutObjects.get(obj.sm64_obj_type)
+
+		# display transformation warnings
+		warnings = set()
+		if obj_details.uses_scale and not obj_scale_is_unified(obj):
+			warnings.add("Object's scale must all be the same exact value (e.g. 2, 2, 2)")
+
+		if not obj_details.uses_scale and not all_values_equal_x(obj.scale, 1):
+			warnings.add("Object's scale values must all be set to 1")
+
+		loc = obj.matrix_local.decompose()[0]
+		if not obj_details.uses_location and not all_values_equal_x(loc, 0):
+			warnings.add("Object's relative location must be set to 0")
+
+		if not obj_details.uses_rotation and not all_values_equal_x(obj.rotation_euler, 0):
+			warnings.add("Object's rotations must be set to 0")
+
+		if len(warnings):
+			warning_box = box.box()
+			warning_box.alert = True
+			warning_box.label(text = "Warning: Unexpected export results from these issues:", icon = 'ERROR')
+			for warning in warnings:
+				warning_box.label(text = warning, icon = 'ERROR')
+			warning_box.label(text = f'Relative location: {", ".join([str(l) for l in loc])}')
+
+		if obj.sm64_obj_type == 'Geo ASM':
+			prop_split(box, obj, 'geoASMFunc', 'Function')
+			prop_split(box, obj, 'geoASMParam', 'Parameter')
+			return
+
+		elif obj.sm64_obj_type == 'Custom Geo Command':
+			prop_split(box, obj, 'customGeoCommand', 'Geo Macro')
+			prop_split(box, obj, 'customGeoCommandArgs', 'Parameters')
+			return
+
+		if obj_details.can_have_dl:
+			prop_split(box, obj, 'draw_layer_static', 'Draw Layer')
+
+			if not obj_details.must_have_dl:
+				prop_split(box, obj, 'useDLReference', 'Use DL Reference')
+
+			if obj_details.must_have_dl or obj.useDLReference:
+				# option to specify a mesh instead of string reference
+				prop_split(box, obj, 'dlReference', 'Displaylist variable or hex address')
+
+		if obj_details.must_have_geo:
+			prop_split(box, obj, 'geoReference', 'Geolayout variable or hex address')
+
+		if obj_details.uses_rotation or obj_details.uses_location or obj_details.uses_scale:
+			info_box = box.box()
+			info_box.label(text = "Note: uses empty object's:")
+			if obj_details.uses_location:
+				info_box.label(text = 'Location', icon = 'DOT')
+			if obj_details.uses_rotation:
+				info_box.label(text = 'Rotation', icon = 'DOT')
+			if obj_details.uses_scale:
+				info_box.label(text = 'Scale', icon = 'DOT')
+
+		if len(obj.children):
+			if checkIsSM64PreInlineGeoLayout(obj.sm64_obj_type):
+				box.box().label(text = 'Children of this object will just be the following geo commands.')
+			else:
+				box.box().label(text = 'Children of this object will be wrapped in GEO_OPEN_NODE and GEO_CLOSE_NODE.')
+
 	def draw(self, context):
 		prop_split(self.layout, context.scene, "gameEditorMode", "Game")
 		box = self.layout.box().column()
 		column = self.layout.box().column() # added just for puppycam trigger importing
 		box.box().label(text = 'SM64 Object Inspector')
 		obj = context.object
+		# TODO: Split options into columns: (second column is "Inline Geo Commands")
 		prop_split(box, obj, 'sm64_obj_type', 'Object Type')
 		if obj.sm64_obj_type == 'Object':
 			prop_split(box, obj, 'sm64_model_enum', 'Model')
@@ -962,6 +1070,9 @@ class SM64ObjectPanel(bpy.types.Panel):
 			prop_split(box, obj, 'switchFunc', 'Function')
 			prop_split(box, obj, 'switchParam', 'Parameter')
 			box.box().label(text = 'Children will ordered alphabetically.')
+		
+		elif obj.sm64_obj_type in inlineGeoLayoutObjects:
+			self.draw_inline_obj(box, obj)
 		
 		elif obj.sm64_obj_type == 'None':
 			box.box().label(text = 'This can be used as an empty transform node in a geolayout hierarchy.')
@@ -1459,7 +1570,23 @@ def sm64_obj_register():
 	
 	bpy.types.Object.switchParam = bpy.props.IntProperty(
 		name = 'Function Parameter', min = -2**(15), max = 2**(15) - 1, default = 0)
+
+	bpy.types.Object.geoASMFunc = bpy.props.StringProperty(
+		name = 'Geo ASM Function', default = '', 
+		description = 'Name of function for C, hex address for binary.')
+
+	bpy.types.Object.geoASMParam = bpy.props.IntProperty(
+		name = 'Geo ASM Parameter', min = -2**(15), max = 2**(15) - 1, default = 0, 
+		description = 'Function parameter.')
 	
+	bpy.types.Object.useDLReference = bpy.props.BoolProperty(name = 'Use displaylist reference')
+	bpy.types.Object.dlReference = bpy.props.StringProperty(name = 'Displaylist variable name or hex address for binary.')
+
+	bpy.types.Object.geoReference = bpy.props.StringProperty(name = 'Geolayout variable name or hex address for binary')
+
+	bpy.types.Object.customGeoCommand = bpy.props.StringProperty(name = 'Geolayout macro command', default = '')
+	bpy.types.Object.customGeoCommandArgs = bpy.props.StringProperty(name = 'Geolayout macro arguments', default = '')
+
 	bpy.types.Object.enableRoomSwitch = bpy.props.BoolProperty(name = 'Enable Room System')
 
 def sm64_obj_unregister():

--- a/fast64_internal/sm64/sm64_objects.py
+++ b/fast64_internal/sm64/sm64_objects.py
@@ -228,7 +228,7 @@ class SM64_Object:
 		self.acts = acts
 		self.position = position
 		self.rotation = rotation
-	
+
 	def to_c(self):
 		if self.acts == 0x1F:
 			return 'OBJECT(' + str(self.model) + ', ' + \
@@ -255,7 +255,7 @@ class SM64_Whirpool:
 		self.condition = condition
 		self.strength = strength
 		self.position = position
-	
+
 	def to_c(self):
 		return 'WHIRPOOL(' + str(self.index) + ', ' +  str(self.condition) + ', ' +\
 			str(int(round(self.position[0]))) + ', ' + \
@@ -269,7 +269,7 @@ class SM64_Macro_Object:
 		self.bparam = bparam
 		self.position = position
 		self.rotation = rotation
-	
+
 	def to_c(self):
 		if self.bparam is None:
 			return 'MACRO_OBJECT(' + str(self.preset) + ', ' + \
@@ -304,7 +304,7 @@ class SM64_Special_Object:
 			if self.bparam is not None:
 				data.extend(int(self.bparam).to_bytes(2, 'big'))
 		return data
-	
+
 	def to_c(self):
 		if self.rotation is None:
 			return 'SPECIAL_OBJECT(' + str(self.preset) + ', ' +\
@@ -330,13 +330,13 @@ class SM64_Mario_Start:
 		self.area = area
 		self.position = position
 		self.rotation = rotation
-	
+
 	def to_c(self):
 		return 'MARIO_POS(' + str(self.area) + ', ' + str(int(round(math.degrees(self.rotation[1])))) + ', ' +\
 			str(int(round(self.position[0]))) + ', ' + str(int(round(self.position[1]))) + ', ' + str(int(round(self.position[2]))) + ')'
 
 class SM64_Area:
-	def __init__(self, index, music_seq, music_preset, 
+	def __init__(self, index, music_seq, music_preset,
 		terrain_type, geolayout, collision, warpNodes, name, startDialog):
 		self.cameraVolumes = []
 		self.puppycamVolumes = []
@@ -407,7 +407,7 @@ class SM64_Area:
 			if spline.splineType == 'Cutscene':
 				return True
 		return False
-	
+
 	def to_c_splines(self):
 		data = CData()
 		for spline in self.splines:
@@ -434,7 +434,7 @@ class CollisionWaterBox:
 		data.extend(int(round(self.high[1])).to_bytes(2, 'big', signed=True))
 		data.extend(int(round(self.height)).to_bytes(2, 'big', signed=True))
 		return data
-	
+
 	def to_c(self):
 		data = 'COL_WATER_BOX(' + \
 			('0x00' if self.waterBoxType == 'Water' else '0x32') + ', ' + \
@@ -457,7 +457,7 @@ class CameraVolume:
 
 	def to_binary(self):
 		raise PluginError("Binary exporting not implemented for camera volumens.")
-	
+
 	def to_c(self):
 		data = '{' + \
 			str(self.area) + ', ' + str(self.functionName) + ', ' + \
@@ -490,15 +490,15 @@ class PuppycamVolume:
 			self.camPos = (camPos[0] * camScaleValue, camPos[2] * camScaleValue, camPos[1] * camScaleValue * -1)
 		else:
 			self.camPos = camPos
-		
+
 		if camFocus != (32767, 32767, 32767):
 			self.camFocus = (camFocus[0] * camScaleValue, camFocus[2] * camScaleValue, camFocus[1] * camScaleValue * -1)
 		else:
 			self.camFocus = camFocus
-		
+
 	def to_binary(self):
 		raise PluginError("Binary exporting not implemented for puppycam volumes.")
-	
+
 	def to_c(self):
 		data = '{' + \
 			str(self.level) + ', ' + str(self.area) + ', ' + ('1' if self.permaswap else '0') + ', ' + \
@@ -534,8 +534,8 @@ def exportAreaCommon(areaObj, transformMatrix, geolayout, collision, name):
 	else:
 		terrainType = areaObj.terrain_type
 
-	area = SM64_Area(areaObj.areaIndex, musicSeq, areaObj.music_preset, 
-		terrainType, geolayout, collision, 
+	area = SM64_Area(areaObj.areaIndex, musicSeq, areaObj.music_preset,
+		terrainType, geolayout, collision,
 		[areaObj.warpNodes[i].to_c() for i in range(len(areaObj.warpNodes))],
 		name, areaObj.startDialog if areaObj.showStartDialog else None)
 
@@ -590,7 +590,7 @@ def start_process_sm64_objects(obj, area, transformMatrix, specialsOnly):
 
 	# We want translations to be relative to area obj, but rotation/scale to be world space
 	translation, rotation, scale = obj.matrix_world.decompose()
-	process_sm64_objects(obj, area, 
+	process_sm64_objects(obj, area,
 		mathutils.Matrix.Translation(translation), transformMatrix, specialsOnly)
 
 def process_sm64_objects(obj, area, rootMatrix, transformMatrix, specialsOnly):
@@ -611,12 +611,12 @@ def process_sm64_objects(obj, area, rootMatrix, transformMatrix, specialsOnly):
 			if obj.sm64_obj_type == 'Special':
 				preset = obj.sm64_special_enum if obj.sm64_special_enum != 'Custom' else obj.sm64_obj_preset
 				preset = handleRefreshDiffSpecials(preset)
-				area.specials.append(SM64_Special_Object(preset, translation, 
-					rotation.to_euler() if obj.sm64_obj_set_yaw else None, 
+				area.specials.append(SM64_Special_Object(preset, translation,
+					rotation.to_euler() if obj.sm64_obj_set_yaw else None,
 					obj.sm64_obj_bparam if (obj.sm64_obj_set_yaw and obj.sm64_obj_set_bparam) else None))
 			elif obj.sm64_obj_type == 'Water Box':
 				checkIdentityRotation(obj, rotation, False)
-				area.water_boxes.append(CollisionWaterBox(obj.waterBoxType, 
+				area.water_boxes.append(CollisionWaterBox(obj.waterBoxType,
 					translation, scale, obj.empty_display_size))
 		else:
 			if obj.sm64_obj_type == 'Object':
@@ -624,11 +624,11 @@ def process_sm64_objects(obj, area, rootMatrix, transformMatrix, specialsOnly):
 				modelID = handleRefreshDiffModelIDs(modelID)
 				behaviour = func_map[bpy.context.scene.refreshVer][obj.sm64_behaviour_enum] if \
 					obj.sm64_behaviour_enum != 'Custom' else obj.sm64_obj_behaviour
-				area.objects.append(SM64_Object(modelID, translation, rotation.to_euler(), 
+				area.objects.append(SM64_Object(modelID, translation, rotation.to_euler(),
 					behaviour, obj.sm64_obj_bparam, get_act_string(obj)))
 			elif obj.sm64_obj_type == 'Macro':
 				macro = obj.sm64_macro_enum if obj.sm64_macro_enum != 'Custom' else obj.sm64_obj_preset
-				area.macros.append(SM64_Macro_Object(macro, translation, rotation.to_euler(), 
+				area.macros.append(SM64_Macro_Object(macro, translation, rotation.to_euler(),
 					obj.sm64_obj_bparam if obj.sm64_obj_set_bparam else None))
 			elif obj.sm64_obj_type == 'Mario Start':
 				mario_start = SM64_Mario_Start(obj.sm64_obj_mario_start_area, translation, rotation.to_euler())
@@ -637,7 +637,7 @@ def process_sm64_objects(obj, area, rootMatrix, transformMatrix, specialsOnly):
 			elif obj.sm64_obj_type == 'Trajectory':
 				pass
 			elif obj.sm64_obj_type == 'Whirpool':
-				area.objects.append(SM64_Whirpool(obj.whirlpool_index, 
+				area.objects.append(SM64_Whirpool(obj.whirlpool_index,
 					obj.whirpool_condition, obj.whirpool_strength, translation))
 			elif obj.sm64_obj_type == 'Camera Volume':
 				checkIdentityRotation(obj, rotation, True)
@@ -650,7 +650,7 @@ def process_sm64_objects(obj, area, rootMatrix, transformMatrix, specialsOnly):
 
 			elif obj.sm64_obj_type == 'Puppycam Volume':
 				checkIdentityRotation(obj, rotation, False)
-				
+
 				triggerIndex = area.index
 				puppycamProp = obj.puppycamProp
 				if(puppycamProp.puppycamUseFlags):
@@ -685,8 +685,8 @@ def process_sm64_objects(obj, area, rootMatrix, transformMatrix, specialsOnly):
 						puppycamModeString += " | NC_FLAG_SLIDECORRECT"
 				else:
 					puppycamModeString = (puppycamProp.puppycamMode if puppycamProp.puppycamMode != 'Custom' else puppycamProp.puppycamType)
-	
-	
+
+
 				if (not puppycamProp.puppycamUseEmptiesForPos) and puppycamProp.puppycamCamera is not None:
 					puppycamCamPosCoords = puppycamProp.puppycamCamera.location
 				elif puppycamProp.puppycamUseEmptiesForPos and puppycamProp.puppycamCamPos != "":
@@ -694,7 +694,7 @@ def process_sm64_objects(obj, area, rootMatrix, transformMatrix, specialsOnly):
 					puppycamCamPosCoords = puppycamPosObject.location
 				else:
 					puppycamCamPosCoords = (32767, 32767, 32767)
-				
+
 				if (not puppycamProp.puppycamUseEmptiesForPos) and puppycamProp.puppycamCamera is not None:
 					puppycamCamFocusCoords = (puppycamProp.puppycamCamera.matrix_local @ mathutils.Vector((0, 0, -1)))[:]
 				elif puppycamProp.puppycamUseEmptiesForPos and puppycamProp.puppycamCamFocus != "":
@@ -702,14 +702,14 @@ def process_sm64_objects(obj, area, rootMatrix, transformMatrix, specialsOnly):
 					puppycamCamFocusCoords = puppycamFocObject.location
 				else:
 					puppycamCamFocusCoords = (32767, 32767, 32767)
-	
-				area.puppycamVolumes.append(PuppycamVolume(triggerIndex, levelIDNames[bpy.data.scenes["Scene"].levelOption], 
+
+				area.puppycamVolumes.append(PuppycamVolume(triggerIndex, levelIDNames[bpy.data.scenes["Scene"].levelOption],
 				puppycamProp.puppycamVolumePermaswap, puppycamProp.puppycamVolumeFunction, translation, scale, obj.empty_display_size, puppycamCamPosCoords, puppycamCamFocusCoords, puppycamModeString))
 
 
 	elif not specialsOnly and assertCurveValid(obj):
 		area.splines.append(convertSplineObject(area.name + '_spline_' + obj.name , obj, finalTransform))
-			
+
 
 	for child in obj.children:
 		process_sm64_objects(child, area, rootMatrix, transformMatrix, specialsOnly)
@@ -741,7 +741,7 @@ class SearchModelIDEnumOperator(bpy.types.Operator):
 	bl_idname = "object.search_model_id_enum_operator"
 	bl_label = "Search Model IDs"
 	bl_property = "sm64_model_enum"
-	bl_options = {'REGISTER', 'UNDO'} 
+	bl_options = {'REGISTER', 'UNDO'}
 
 	sm64_model_enum : bpy.props.EnumProperty(items = enumModelIDs)
 
@@ -759,7 +759,7 @@ class SearchBehaviourEnumOperator(bpy.types.Operator):
 	bl_idname = "object.search_behaviour_enum_operator"
 	bl_label = "Search Behaviours"
 	bl_property = "sm64_behaviour_enum"
-	bl_options = {'REGISTER', 'UNDO'} 
+	bl_options = {'REGISTER', 'UNDO'}
 
 	sm64_behaviour_enum : bpy.props.EnumProperty(items = enumBehaviourPresets)
 
@@ -779,7 +779,7 @@ class SearchMacroEnumOperator(bpy.types.Operator):
 	bl_idname = "object.search_macro_enum_operator"
 	bl_label = "Search Macros"
 	bl_property = "sm64_macro_enum"
-	bl_options = {'REGISTER', 'UNDO'} 
+	bl_options = {'REGISTER', 'UNDO'}
 
 	sm64_macro_enum : bpy.props.EnumProperty(items = enumMacrosNames)
 
@@ -797,7 +797,7 @@ class SearchSpecialEnumOperator(bpy.types.Operator):
 	bl_idname = "object.search_special_enum_operator"
 	bl_label = "Search Specials"
 	bl_property = "sm64_special_enum"
-	bl_options = {'REGISTER', 'UNDO'} 
+	bl_options = {'REGISTER', 'UNDO'}
 
 	sm64_special_enum : bpy.props.EnumProperty(items = enumSpecialsNames)
 
@@ -817,7 +817,7 @@ class SM64ObjectPanel(bpy.types.Panel):
 	bl_space_type = 'PROPERTIES'
 	bl_region_type = 'WINDOW'
 	bl_context = "object"
-	bl_options = {'HIDE_HEADER'} 
+	bl_options = {'HIDE_HEADER'}
 
 	@classmethod
 	def poll(cls, context):
@@ -921,7 +921,7 @@ class SM64ObjectPanel(bpy.types.Panel):
 			box.prop(obj, 'sm64_obj_set_bparam', text = 'Set Behaviour Parameter')
 			if obj.sm64_obj_set_bparam:
 				prop_split(box, obj, 'sm64_obj_bparam', 'Behaviour Parameter')
-				
+
 		elif obj.sm64_obj_type == 'Special':
 			prop_split(box, obj, 'sm64_special_enum', 'Preset')
 			if obj.sm64_special_enum == 'Custom':
@@ -962,7 +962,7 @@ class SM64ObjectPanel(bpy.types.Panel):
 				#box.box().label(text = 'Background IDs defined in include/geo_commands.h.')
 			box.prop(obj, 'actSelectorIgnore')
 			box.prop(obj, 'setAsStartLevel')
-			prop_split(box, obj, 'acousticReach', 'Acoustic Reach')			
+			prop_split(box, obj, 'acousticReach', 'Acoustic Reach')
 			obj.starGetCutscenes.draw(box)
 
 		elif obj.sm64_obj_type == 'Area Root':
@@ -974,7 +974,7 @@ class SM64ObjectPanel(bpy.types.Panel):
 				prop_split(box, obj, 'musicSeqEnum', 'Music Sequence')
 				if obj.musicSeqEnum == 'Custom':
 					prop_split(box, obj, 'music_seq', '')
-				
+
 			prop_split(box, obj, 'terrainEnum', 'Terrain')
 			if obj.terrainEnum == 'Custom':
 				prop_split(box, obj, 'terrain_type', '')
@@ -998,10 +998,10 @@ class SM64ObjectPanel(bpy.types.Panel):
 
 			if obj.areaIndex == 1 or obj.areaIndex == 2 or obj.areaIndex == 3:
 				prop_split(box, obj, 'echoLevel', 'Echo Level')
-			
+
 			if obj.areaIndex == 1 or obj.areaIndex == 2 or obj.areaIndex == 3 or obj.areaIndex == 4:
 				box.prop(obj, 'zoomOutOnPause')
-			
+
 			box.prop(obj, 'areaOverrideBG')
 			if obj.areaOverrideBG:
 				prop_split(box, obj, 'areaBGColor', 'Background Color')
@@ -1021,7 +1021,7 @@ class SM64ObjectPanel(bpy.types.Panel):
 			if not obj.useDefaultScreenRect:
 				prop_split(box, obj, 'screenPos', 'Screen Position')
 				prop_split(box, obj, 'screenSize', 'Screen Size')
-		
+
 			prop_split(box, obj, 'clipPlanes', 'Clip Planes')
 
 			box.label(text = "Warp Nodes")
@@ -1039,13 +1039,13 @@ class SM64ObjectPanel(bpy.types.Panel):
 			prop_split(column, puppycamProp, 'puppycamVolumeFunction', 'Puppycam Function')
 			column.prop(puppycamProp, 'puppycamVolumePermaswap')
 			column.prop(puppycamProp, 'puppycamUseFlags')
-			
+
 			column.prop(puppycamProp, 'puppycamUseEmptiesForPos')
-			
+
 			if puppycamProp.puppycamUseEmptiesForPos:
 				column.label(text = "Fixed Camera Position (Optional)")
 				column.prop_search(puppycamProp, "puppycamCamPos", bpy.data, "objects", text = '')
-			
+
 				column.label(text = "Fixed Camera Focus (Optional)")
 				column.prop_search(puppycamProp, "puppycamCamFocus", bpy.data, "objects", text = '')
 			else:
@@ -1065,15 +1065,15 @@ class SM64ObjectPanel(bpy.types.Panel):
 					prop_split(column, puppycamProp, 'puppycamType', '')
 
 			column.box().label(text = "No rotation allowed.")
-		
+
 		elif obj.sm64_obj_type == 'Switch':
 			prop_split(box, obj, 'switchFunc', 'Function')
 			prop_split(box, obj, 'switchParam', 'Parameter')
 			box.box().label(text = 'Children will ordered alphabetically.')
-		
+
 		elif obj.sm64_obj_type in inlineGeoLayoutObjects:
 			self.draw_inline_obj(box, obj)
-		
+
 		elif obj.sm64_obj_type == 'None':
 			box.box().label(text = 'This can be used as an empty transform node in a geolayout hierarchy.')
 
@@ -1141,24 +1141,24 @@ class WarpNodeProperty(bpy.types.PropertyGroup):
 class AddWarpNode(bpy.types.Operator):
 	bl_idname = 'bone.add_warp_node'
 	bl_label = 'Add Warp Node'
-	bl_options = {'REGISTER', 'UNDO'} 
+	bl_options = {'REGISTER', 'UNDO'}
 	option : bpy.props.IntProperty()
 	def execute(self, context):
 		obj = context.object
 		obj.warpNodes.add()
 		obj.warpNodes.move(len(obj.warpNodes)-1, self.option)
 		self.report({'INFO'}, 'Success!')
-		return {'FINISHED'} 
+		return {'FINISHED'}
 
 class RemoveWarpNode(bpy.types.Operator):
 	bl_idname = 'bone.remove_warp_node'
 	bl_label = 'Remove Warp Node'
-	bl_options = {'REGISTER', 'UNDO'} 
+	bl_options = {'REGISTER', 'UNDO'}
 	option : bpy.props.IntProperty()
 	def execute(self, context):
 		context.object.warpNodes.remove(self.option)
 		self.report({'INFO'}, 'Success!')
-		return {'FINISHED'} 
+		return {'FINISHED'}
 
 def drawWarpNodeProperty(layout, warpNode, index):
 	box = layout.box().column()
@@ -1182,11 +1182,11 @@ def drawWarpNodeProperty(layout, warpNode, index):
 			prop_split(box, warpNode, 'warpFlagEnum', 'Warp Flags')
 			if warpNode.warpFlagEnum == 'Custom':
 				prop_split(box, warpNode, 'warpFlags', 'Warp Flags Value')
-		
+
 		buttons = box.row(align = True)
 		buttons.operator(RemoveWarpNode.bl_idname,
 			text = 'Remove Option').option = index
-		buttons.operator(AddWarpNode.bl_idname, 
+		buttons.operator(AddWarpNode.bl_idname,
 			text = 'Add Option').option = index + 1
 
 
@@ -1248,7 +1248,7 @@ def onUpdateObjectType(self, context):
 	isBoxEmpty = self.sm64_obj_type == 'Water Box' or self.sm64_obj_type == 'Camera Volume'
 	self.show_name = not (isBoxEmpty or isNoneEmpty)
 	self.show_axis = not (isBoxEmpty or isNoneEmpty)
-	
+
 	if isBoxEmpty:
 		self.empty_display_type = "CUBE"
 
@@ -1265,12 +1265,12 @@ class PuppycamSetupCamera(bpy.types.Operator):
 		scene.camera = bpy.context.active_object.puppycamProp.puppycamCamera
 		bpy.data.cameras[cameraObject].show_name = True
 		bpy.data.cameras[cameraObject].show_safe_areas = True
-		
+
 		scene.safe_areas.title[0] = 0
 		scene.safe_areas.title[1] = 8/240 # Use the safe areas to denote where default 8 pixel black bars will be
 		scene.safe_areas.action = (0, 0)
 
-		# If you could set resolution on a per-camera basis, I'd do that instead. Oh well. 
+		# If you could set resolution on a per-camera basis, I'd do that instead. Oh well.
 		scene.render.resolution_x = 320
 		scene.render.resolution_y = 240
 
@@ -1291,25 +1291,25 @@ class PuppycamProperty(bpy.types.PropertyGroup):
 
 	puppycamUseEmptiesForPos : bpy.props.BoolProperty(
 		name = 'Use Empty Objects for positions')
-	
+
 	puppycamCamera : bpy.props.PointerProperty(
         type=bpy.types.Object,
         poll=sm64_is_camera_poll
     )
-	
+
 	puppycamFOV : bpy.props.FloatProperty(
 		name = 'Field Of View', min = 0, max = 180, default = 45
 	)
 
 	puppycamMode : bpy.props.EnumProperty(
 		items = enumPuppycamMode, default = 'NC_MODE_NORMAL')
-	
+
 	puppycamType : bpy.props.StringProperty(
 		name = 'Custom Mode', default = 'NC_MODE_NORMAL')
-	
+
 	puppycamCamPos : bpy.props.StringProperty(
 		name = 'Fixed Camera Position')
-	
+
 	puppycamCamFocus : bpy.props.StringProperty(
 		name = 'Fixed Camera Focus')
 
@@ -1318,13 +1318,13 @@ class PuppycamProperty(bpy.types.PropertyGroup):
 
 	NC_FLAG_XTURN : bpy.props.BoolProperty(
 		name = 'X Turn')
-	
+
 	NC_FLAG_YTURN : bpy.props.BoolProperty(
 		name = 'Y Turn')
 
 	NC_FLAG_ZOOM : bpy.props.BoolProperty(
 		name = 'Y Turn')
-	
+
 	NC_FLAG_8D : bpy.props.BoolProperty(
 		name = '8 Directions')
 
@@ -1336,25 +1336,25 @@ class PuppycamProperty(bpy.types.PropertyGroup):
 
 	NC_FLAG_FOCUSX : bpy.props.BoolProperty(
 		name = 'Use X Focus')
-	
+
 	NC_FLAG_FOCUSY : bpy.props.BoolProperty(
 		name = 'Use Y Focus')
 
 	NC_FLAG_FOCUSZ : bpy.props.BoolProperty(
 		name = 'Use Z Focus')
-	
+
 	NC_FLAG_POSX : bpy.props.BoolProperty(
 		name = 'Move on X axis')
-	
+
 	NC_FLAG_POSY : bpy.props.BoolProperty(
 		name = 'Move on Y axis')
-	
+
 	NC_FLAG_POSZ : bpy.props.BoolProperty(
 		name = 'Move on Z axis')
-	
+
 	NC_FLAG_COLLISION : bpy.props.BoolProperty(
 		name = 'Camera Collision')
-	
+
 	NC_FLAG_SLIDECORRECT : bpy.props.BoolProperty(
 		name = 'Slide Correction')
 
@@ -1368,7 +1368,7 @@ sm64_obj_classes = (
 	SearchBehaviourEnumOperator,
 	SearchSpecialEnumOperator,
 	SearchMacroEnumOperator,
-	
+
 	StarGetCutscenesProperty,
 
 	PuppycamProperty,
@@ -1414,10 +1414,10 @@ def sm64_obj_register():
 	#	name = 'Special Name')
 	#bpy.types.Object.sm64_behaviour = bpy.props.StringProperty(
 	#	name = 'Behaviour Name')
-	
+
 	bpy.types.Object.sm64_obj_type = bpy.props.EnumProperty(
 		name = 'SM64 Object Type', items = enumObjectType, default = 'None', update = onUpdateObjectType)
-	
+
 	bpy.types.Object.sm64_obj_model = bpy.props.StringProperty(
 		name = 'Model', default = 'MODEL_NONE')
 
@@ -1457,10 +1457,10 @@ def sm64_obj_register():
 
 	bpy.types.Object.sm64_obj_set_bparam = bpy.props.BoolProperty(
 		name = 'Set Behaviour Parameter', default = True)
-	
+
 	bpy.types.Object.sm64_obj_set_yaw = bpy.props.BoolProperty(
 		name = 'Set Yaw', default = False)
-	
+
 	bpy.types.Object.useBackgroundColor = bpy.props.BoolProperty(
 		name = 'Use Solid Color For Background', default = False)
 
@@ -1469,17 +1469,17 @@ def sm64_obj_register():
 
 	bpy.types.Object.background = bpy.props.EnumProperty(
 		name = 'Background', items = enumBackground, default = 'OCEAN_SKY')
-	
+
 	bpy.types.Object.backgroundColor = bpy.props.FloatVectorProperty(
-		name = 'Background Color', subtype='COLOR', size = 4, 
+		name = 'Background Color', subtype='COLOR', size = 4,
 		min = 0, max = 1, default = (0,0,0,1))
 
 	bpy.types.Object.screenPos = bpy.props.IntVectorProperty(
-		name = 'Screen Position', size = 2, default = (160, 120), 
+		name = 'Screen Position', size = 2, default = (160, 120),
 		min = -2**15, max = 2**15 - 1)
 
 	bpy.types.Object.screenSize = bpy.props.IntVectorProperty(
-		name = 'Screen Size', size = 2, default = (160, 120), 
+		name = 'Screen Size', size = 2, default = (160, 120),
 		min = -2**15, max = 2**15 - 1)
 
 	bpy.types.Object.useDefaultScreenRect = bpy.props.BoolProperty(
@@ -1490,7 +1490,7 @@ def sm64_obj_register():
 	)
 
 	bpy.types.Object.area_fog_color = bpy.props.FloatVectorProperty(
-		name = 'Area Fog Color', subtype='COLOR', size = 4, 
+		name = 'Area Fog Color', subtype='COLOR', size = 4,
 		min = 0, max = 1, default = (0,0,0,1))
 
 	bpy.types.Object.area_fog_position = bpy.props.FloatVectorProperty(
@@ -1500,7 +1500,7 @@ def sm64_obj_register():
 		name = 'Override Background')
 
 	bpy.types.Object.areaBGColor = bpy.props.FloatVectorProperty(
-		name = 'Background Color', subtype='COLOR', size = 4, 
+		name = 'Background Color', subtype='COLOR', size = 4,
 		min = 0, max = 1, default = (0,0,0,1))
 
 	bpy.types.Object.camOption = bpy.props.EnumProperty(
@@ -1532,7 +1532,7 @@ def sm64_obj_register():
 
 	bpy.types.Object.acousticReach = bpy.props.StringProperty(
 		name = 'Acoustic Reach', default = '20000')
-	
+
 	bpy.types.Object.echoLevel = bpy.props.StringProperty(
 		name = 'Echo Level', default = '0x00')
 
@@ -1565,20 +1565,20 @@ def sm64_obj_register():
 	bpy.types.Object.setAsStartLevel = bpy.props.BoolProperty(name = 'Set As Start Level')
 
 	bpy.types.Object.switchFunc = bpy.props.StringProperty(
-		name = 'Function', default = '', 
+		name = 'Function', default = '',
 		description = 'Name of function for C, hex address for binary.')
-	
+
 	bpy.types.Object.switchParam = bpy.props.IntProperty(
 		name = 'Function Parameter', min = -2**(15), max = 2**(15) - 1, default = 0)
 
 	bpy.types.Object.geoASMFunc = bpy.props.StringProperty(
-		name = 'Geo ASM Function', default = '', 
+		name = 'Geo ASM Function', default = '',
 		description = 'Name of function for C, hex address for binary.')
 
 	bpy.types.Object.geoASMParam = bpy.props.IntProperty(
-		name = 'Geo ASM Parameter', min = -2**(15), max = 2**(15) - 1, default = 0, 
+		name = 'Geo ASM Parameter', min = -2**(15), max = 2**(15) - 1, default = 0,
 		description = 'Function parameter.')
-	
+
 	bpy.types.Object.useDLReference = bpy.props.BoolProperty(name = 'Use displaylist reference')
 	bpy.types.Object.dlReference = bpy.props.StringProperty(name = 'Displaylist variable name or hex address for binary.')
 
@@ -1599,7 +1599,7 @@ def sm64_obj_unregister():
 	#del bpy.types.Object.sm64_macro
 	#del bpy.types.Object.sm64_special
 	#del bpy.types.Object.sm64_behaviour
-	
+
 	del bpy.types.Object.sm64_obj_type
 	del bpy.types.Object.sm64_obj_model
 	del bpy.types.Object.sm64_obj_preset
@@ -1626,7 +1626,7 @@ def sm64_obj_unregister():
 	#del bpy.types.Object.backgroundID
 	del bpy.types.Object.background
 	del bpy.types.Object.backgroundColor
-	
+
 	del bpy.types.Object.screenPos
 	del bpy.types.Object.screenSize
 	del bpy.types.Object.useDefaultScreenRect
@@ -1663,7 +1663,7 @@ def sm64_obj_unregister():
 	del bpy.types.Object.actSelectorIgnore
 	del bpy.types.Object.setAsStartLevel
 	del bpy.types.Object.switchFunc
-	del bpy.types.Object.switchParam 
+	del bpy.types.Object.switchParam
 	del bpy.types.Object.enableRoomSwitch
 
 	for cls in reversed(sm64_obj_classes):

--- a/fast64_internal/sm64/sm64_objects.py
+++ b/fast64_internal/sm64/sm64_objects.py
@@ -894,7 +894,6 @@ class SM64ObjectPanel(bpy.types.Panel):
 		column = self.layout.box().column() # added just for puppycam trigger importing
 		box.box().label(text = 'SM64 Object Inspector')
 		obj = context.object
-		# TODO: Split options into columns: (second column is "Inline Geo Commands")
 		prop_split(box, obj, 'sm64_obj_type', 'Object Type')
 		if obj.sm64_obj_type == 'Object':
 			prop_split(box, obj, 'sm64_model_enum', 'Model')

--- a/fast64_internal/utility.py
+++ b/fast64_internal/utility.py
@@ -544,7 +544,7 @@ def store_original_mtx():
 
 def rotate_bounds(bounds, mtx: mathutils.Matrix):
 	return [
-		(mathutils.Vector(b) @ mtx).to_tuple()
+		(mtx @ mathutils.Vector(b)).to_tuple()
 		for b in bounds
 	]
 
@@ -596,15 +596,9 @@ def copy_object_and_apply(obj: bpy.types.Object, apply_scale = False, apply_modi
 	obj_copy['temp_export'] = True
 
 	# Override for F3D culling bounds (used in addCullCommand)
-	bounds_mtx = scale_mtx_from_vector([1, -1, -1]) # reverse y/z
+	bounds_mtx = transform_mtx_blender_to_n64()
 	if apply_scale:
-		bounds_mtx *= scale_mtx_from_vector(obj.scale) # apply scale if needed
-	bounds_mtx = bounds_mtx @ transform_mtx_blender_to_n64()
-	if obj.name == 'CubeSubdivided':
-		from pprint import pprint
-		print('HOHOHOHO')
-		pprint([b[:] for b in obj_copy.bound_box[:]])
-		print('HOHOHOHO')
+		bounds_mtx = bounds_mtx @ scale_mtx_from_vector(obj.scale) # apply scale if needed
 	obj_copy['culling_bounds'] = rotate_bounds(obj_copy.bound_box, bounds_mtx)
 
 def store_original_meshes(add_warning: Callable[[str], None]):

--- a/fast64_internal/utility.py
+++ b/fast64_internal/utility.py
@@ -1167,10 +1167,8 @@ def read16bitRGBA(data):
 def join_c_args(args: 'list[str]'):
 	return ', '.join(args)
 
-def translate_xyz_to_xzy(translate: mathutils.Vector):
-	xzy_translate = translate.xzy
-	xzy_translate[2] = -xzy_translate[2]
-	return xzy_translate
+def translate_blender_to_n64(translate: mathutils.Vector):
+	return transform_mtx_blender_to_n64() @ translate
 
 def rotate_quat_blender_to_n64(rotation: mathutils.Quaternion):
     new_rot = (transform_mtx_blender_to_n64() @ rotation.to_matrix().to_4x4() @ transform_mtx_blender_to_n64().inverted())

--- a/fast64_internal/utility.py
+++ b/fast64_internal/utility.py
@@ -531,13 +531,9 @@ def yield_children(obj: bpy.types.Object):
 		for o in obj.children:
 			yield from yield_children(o)
 
-def iter_from_active():
-	active_obj = bpy.context.view_layer.objects.active # keep original obj reference
-	yield from yield_children(active_obj)
-	bpy.context.view_layer.objects.active = active_obj
-
 def store_original_mtx():
-	for obj in iter_from_active():
+	active_obj = bpy.context.view_layer.objects.active
+	for obj in yield_children(active_obj):
 		obj['original_mtx'] = obj.matrix_local
 
 def rotate_bounds(bounds, mtx: mathutils.Matrix):
@@ -609,7 +605,8 @@ def store_original_meshes(add_warning: Callable[[str], None]):
 		- Original mesh name is saved to each object
 	'''
 	instanced_meshes = set()
-	for obj in iter_from_active():
+	active_obj = bpy.context.view_layer.objects.active
+	for obj in yield_children(active_obj):
 		if obj.data is not None:
 			has_modifiers = len(obj.modifiers) != 0
 			has_uneven_scale = not obj_scale_is_unified(obj)
@@ -630,6 +627,7 @@ def store_original_meshes(add_warning: Callable[[str], None]):
 			if obj.data.name not in instanced_meshes:
 				instanced_meshes.add(obj.data.name)
 				copy_object_and_apply(obj)
+	bpy.context.view_layer.objects.active = active_obj
 
 def get_obj_temp_mesh(obj):
 	for o in bpy.data.objects:

--- a/fast64_internal/utility.py
+++ b/fast64_internal/utility.py
@@ -600,6 +600,11 @@ def copy_object_and_apply(obj: bpy.types.Object, apply_scale = False, apply_modi
 	if apply_scale:
 		bounds_mtx *= scale_mtx_from_vector(obj.scale) # apply scale if needed
 	bounds_mtx = bounds_mtx @ transform_mtx_blender_to_n64()
+	if obj.name == 'CubeSubdivided':
+		from pprint import pprint
+		print('HOHOHOHO')
+		pprint([b[:] for b in obj_copy.bound_box[:]])
+		print('HOHOHOHO')
 	obj_copy['culling_bounds'] = rotate_bounds(obj_copy.bound_box, bounds_mtx)
 
 def store_original_meshes(add_warning: Callable[[str], None]):
@@ -1173,9 +1178,8 @@ def translate_xyz_to_xzy(translate: mathutils.Vector):
 	xzy_translate[2] = -xzy_translate[2]
 	return xzy_translate
 
-def rotation_xyz_quat_to_xzy_quat(rotation: mathutils.Quaternion):
-    euler_rot = rotation.to_matrix().inverted().to_euler('ZXY')
-    new_rot = mathutils.Euler([-euler_rot.x, -euler_rot.z, euler_rot.y], 'ZXY')
+def rotate_quat_blender_to_n64(rotation: mathutils.Quaternion):
+    new_rot = (transform_mtx_blender_to_n64() @ rotation.to_matrix().to_4x4() @ transform_mtx_blender_to_n64().inverted())
     return new_rot.to_quaternion()
 
 def all_values_equal_x(vals: Iterable, test):

--- a/fast64_internal/utility.py
+++ b/fast64_internal/utility.py
@@ -549,17 +549,14 @@ def obj_scale_is_unified(obj):
 def translation_rotation_from_mtx(mtx: mathutils.Matrix):
 	'''Strip scale from matrix'''
 	t, r, _ = mtx.decompose()
-	return Matrix.Translation(t).to_4x4() @ r.to_matrix().to_4x4()
+	return Matrix.Translation(t) @ r.to_matrix().to_4x4()
 
 def scale_mtx_from_vector(scale: mathutils.Vector):
-	scax = mathutils.Matrix.Scale(scale[0], 4, (1, 0, 0))
-	scay = mathutils.Matrix.Scale(scale[1], 4, (0, 1, 0))
-	scaz = mathutils.Matrix.Scale(scale[2], 4, (0, 0, 1))
-	return scax @ scay @ scaz
+	return mathutils.Matrix.Diagonal(scale[0:3]).to_4x4()
 
 def copy_object_and_apply(obj: bpy.types.Object, apply_scale = False, apply_modifiers = False):
 	if apply_scale or apply_modifiers:
-		# its a unique mesh, use object name
+		# it's a unique mesh, use object name
 		obj['instanced_mesh_name'] = obj.name
 		obj.original_name = obj.name
 		if apply_scale:

--- a/fast64_internal/utility.py
+++ b/fast64_internal/utility.py
@@ -13,7 +13,7 @@ class VertexWeightError(PluginError):
 geoNodeRotateOrder = 'ZXY'
 sm64BoneUp = Vector([1,0,0])
 
-rotate_mtx_blender_to_n64 = lambda: Matrix((
+transform_mtx_blender_to_n64 = lambda: Matrix((
 	(1,  0, 0, 0),
 	(0,  0, 1, 0),
 	(0, -1, 0, 0),
@@ -587,7 +587,7 @@ def copy_object_and_apply(obj: bpy.types.Object, apply_scale = False, apply_modi
 
 		bpy.context.view_layer.objects.active = prev_active
 
-	mtx = rotate_mtx_blender_to_n64()
+	mtx = transform_mtx_blender_to_n64()
 	if apply_scale:
 	 	mtx = mtx @ scale_mtx_from_vector(obj.scale)
 
@@ -599,7 +599,7 @@ def copy_object_and_apply(obj: bpy.types.Object, apply_scale = False, apply_modi
 	bounds_mtx = scale_mtx_from_vector([1, -1, -1]) # reverse y/z
 	if apply_scale:
 		bounds_mtx *= scale_mtx_from_vector(obj.scale) # apply scale if needed
-	bounds_mtx = bounds_mtx @ rotate_mtx_blender_to_n64()
+	bounds_mtx = bounds_mtx @ transform_mtx_blender_to_n64()
 	obj_copy['culling_bounds'] = rotate_bounds(obj_copy.bound_box, bounds_mtx)
 
 def store_original_meshes(add_warning: Callable[[str], None]):

--- a/fast64_internal/utility.py
+++ b/fast64_internal/utility.py
@@ -13,6 +13,12 @@ class VertexWeightError(PluginError):
 geoNodeRotateOrder = 'ZXY'
 sm64BoneUp = Vector([1,0,0])
 
+rotate_mtx_blender_to_n64 = lambda: Matrix((
+	(1,  0, 0, 0),
+	(0,  0, 1, 0),
+	(0, -1, 0, 0),
+	(0,  0, 0, 1)))
+
 axis_enums = [
 	('X', 'X', 'X'),
 	('Y', 'Y', 'Y'),
@@ -581,7 +587,7 @@ def copy_object_and_apply(obj: bpy.types.Object, apply_scale = False, apply_modi
 
 		bpy.context.view_layer.objects.active = prev_active
 
-	mtx = mathutils.Quaternion((1, 0, 0), math.radians(-90.0)).to_matrix().to_4x4()
+	mtx = rotate_mtx_blender_to_n64()
 	if apply_scale:
 	 	mtx = mtx @ scale_mtx_from_vector(obj.scale)
 
@@ -593,7 +599,7 @@ def copy_object_and_apply(obj: bpy.types.Object, apply_scale = False, apply_modi
 	bounds_mtx = scale_mtx_from_vector([1, -1, -1]) # reverse y/z
 	if apply_scale:
 		bounds_mtx *= scale_mtx_from_vector(obj.scale) # apply scale if needed
-	bounds_mtx = bounds_mtx @ mathutils.Quaternion((1, 0, 0), math.radians(-90.0)).to_matrix().to_4x4()
+	bounds_mtx = bounds_mtx @ rotate_mtx_blender_to_n64()
 	obj_copy['culling_bounds'] = rotate_bounds(obj_copy.bound_box, bounds_mtx)
 
 def store_original_meshes(add_warning: Callable[[str], None]):

--- a/fast64_internal/utility.py
+++ b/fast64_internal/utility.py
@@ -538,8 +538,8 @@ def store_original_mtx():
 
 def rotate_bounds(bounds, mtx: mathutils.Matrix):
 	return [
-		(mathutils.Vector(b[:]) @ mtx).to_tuple()
-		for b in bounds[:]
+		(mathutils.Vector(b) @ mtx).to_tuple()
+		for b in bounds
 	]
 
 def obj_scale_is_unified(obj):

--- a/fast64_internal/utility.py
+++ b/fast64_internal/utility.py
@@ -740,10 +740,10 @@ def cleanupDuplicatedObjects(selected_objects):
 
 def cleanupTempMeshes():
 	'''Delete meshes that have been duplicated for instancing'''
-	temp_meshes = []
+	remove_data = []
 	for obj in bpy.data.objects:
 		if obj.get('temp_export'):
-			temp_meshes.append(obj.data)
+			remove_data.append(obj.data)
 			bpy.data.objects.remove(obj)
 		else:
 			if obj.get('instanced_mesh_name'):
@@ -751,8 +751,12 @@ def cleanupTempMeshes():
 			if obj.get('original_mtx'):
 				del obj['original_mtx']
 
-	for mesh in temp_meshes:
-		bpy.data.meshes.remove(mesh)
+	for data in remove_data:
+		data_type = type(data)
+		if data_type == bpy.types.Mesh:
+			bpy.data.meshes.remove(data)
+		elif data_type == bpy.types.Curve:
+			bpy.data.curves.remove(data)
 
 def combineObjects(obj, includeChildren, ignoreAttr, areaIndex):
 	obj.original_name = obj.name

--- a/fast64_internal/utility.py
+++ b/fast64_internal/utility.py
@@ -634,8 +634,10 @@ def store_original_meshes(add_warning: Callable[[str], None]):
 
 def get_obj_temp_mesh(obj):
 	for o in bpy.data.objects:
-		if o.get('temp_export') and \
-			o.get('instanced_mesh_name') == obj.get('instanced_mesh_name'):
+		if (
+			o.get('temp_export')
+			and o.get('instanced_mesh_name') == obj.get('instanced_mesh_name')
+		):
 			return o
 
 def duplicateHierarchy(obj, ignoreAttr, includeEmpties, areaIndex):
@@ -716,10 +718,11 @@ def selectMeshChildrenOnly(obj, ignoreAttr, includeEmpties, areaIndex):
 		return
 	ignoreObj = ignoreAttr is not None and getattr(obj, ignoreAttr)
 	isMesh = isinstance(obj.data, bpy.types.Mesh)
-	isEmpty = \
-		(obj.data is None) and \
-		includeEmpties and \
-		checkSM64EmptyUsesGeoLayout(obj.sm64_obj_type)
+	isEmpty = (
+		obj.data is None
+		and includeEmpties
+		and checkSM64EmptyUsesGeoLayout(obj.sm64_obj_type)
+	)
 	if (isMesh or isEmpty) and not ignoreObj:
 		obj.select_set(True)
 		obj.original_name = obj.name

--- a/fast64_internal/utility.py
+++ b/fast64_internal/utility.py
@@ -13,9 +13,9 @@ class VertexWeightError(PluginError):
 geoNodeRotateOrder = 'ZXY'
 sm64BoneUp = Vector([1,0,0])
 
-axis_enums = [	
-	('X', 'X', 'X'), 
-	('Y', 'Y', 'Y'), 
+axis_enums = [
+	('X', 'X', 'X'),
+	('Y', 'Y', 'Y'),
 	('-X', '-X', '-X'),
 	('-Y', '-Y', '-Y'),
 ]
@@ -71,7 +71,7 @@ def unhideAllAndGetHiddenList(scene):
 	for obj in scene.objects:
 		if obj.hide_get():
 			hiddenObjs.append(obj)
-	
+
 	if bpy.context.mode != 'OBJECT':
 		bpy.ops.object.mode_set(mode = "OBJECT")
 	bpy.ops.object.hide_view_clear()
@@ -106,7 +106,7 @@ def parentObject(parent, child):
 	bpy.ops.object.parent_set(type='OBJECT', keep_transform=True)
 
 def attemptModifierApply(modifier):
-	try:	
+	try:
 		bpy.ops.object.modifier_apply(modifier=modifier.name)
 	except Exception as e:
 		print("Skipping modifier " + str(modifier.name))
@@ -211,8 +211,8 @@ def propertyGroupEquals(oldProp, newProp):
 
 			if not isEquivalent:
 				pass #print("Not equivalent: " + str(sub_value) + " " + str(newValue) + " " + str(sub_value_attr))
-			equivalent &= isEquivalent 
-	
+			equivalent &= isEquivalent
+
 	return equivalent
 
 def writeCData(data, headerPath, sourcePath):
@@ -276,7 +276,7 @@ def findStartBones(armatureObj):
 			'in ' + armatureObj.name + '. Is this the root armature?')
 	else:
 		return noParentBones
-	
+
 	if len(noParentBones) == 1:
 		return noParentBones[0]
 	elif len(noParentBones) == 0:
@@ -326,9 +326,9 @@ def enableExtendedRAM(baseDir):
 		segmentFile.close()
 
 def writeMaterialHeaders(exportDir, matCInclude, matHInclude):
-	writeIfNotFound(os.path.join(exportDir, 'src/game/materials.c'), 
+	writeIfNotFound(os.path.join(exportDir, 'src/game/materials.c'),
 		'\n' + matCInclude, '')
-	writeIfNotFound(os.path.join(exportDir, 'src/game/materials.h'), 
+	writeIfNotFound(os.path.join(exportDir, 'src/game/materials.h'),
 		'\n' + matHInclude, '#endif')
 
 def writeMaterialFiles(exportDir, assetDir, headerInclude, matHInclude,
@@ -361,7 +361,7 @@ def writeMaterialBase(baseDir):
 			'#endif')
 
 		matHFile.close()
-	
+
 	matCPath = os.path.join(baseDir, 'src/game/materials.c')
 	if not os.path.exists(matCPath):
 		matCFile = open(matCPath, 'w', newline = '\n')
@@ -465,7 +465,7 @@ def getExportDir(customExport, dirPath, headerType, levelName, texDir, dirName):
 		elif headerType == 'Level':
 			dirPath = os.path.join(dirPath, 'levels/' + levelName)
 			texDir = 'levels/' + levelName
-	
+
 	return dirPath, texDir
 
 def overwriteData(headerRegex, name, value, filePath, writeNewBeforeString, isFunction):
@@ -578,7 +578,7 @@ def copy_object_and_apply(obj: bpy.types.Object, apply_scale = False, apply_modi
 	obj_copy.data = obj_copy.data.copy()
 
 	if apply_modifiers:
-		# In order to correctly apply modifiers, we have to go through blender and add the object to the collection, then apply modifiers 
+		# In order to correctly apply modifiers, we have to go through blender and add the object to the collection, then apply modifiers
 		prev_active = bpy.context.view_layer.objects.active
 		bpy.context.collection.objects.link(obj_copy)
 		obj_copy.select_set(True)
@@ -649,7 +649,7 @@ def duplicateHierarchy(obj, ignoreAttr, includeEmpties, areaIndex):
 		allObjs = bpy.context.selected_objects
 
 		bpy.ops.object.make_single_user(obdata = True)
-		bpy.ops.object.transform_apply(location = False, 
+		bpy.ops.object.transform_apply(location = False,
 			rotation = True, scale = True, properties =  False)
 
 		for selectedObj in allObjs:
@@ -771,22 +771,22 @@ def combineObjects(obj, includeChildren, ignoreAttr, areaIndex):
 		# duplicate obj and apply modifiers / make single user
 		allObjs = bpy.context.selected_objects
 		bpy.ops.object.make_single_user(obdata = True)
-		bpy.ops.object.transform_apply(location = False, 
+		bpy.ops.object.transform_apply(location = False,
 			rotation = True, scale = True, properties =  False)
 		for selectedObj in allObjs:
 			bpy.ops.object.select_all(action = 'DESELECT')
 			selectedObj.select_set(True)
 			for modifier in selectedObj.modifiers:
 				attemptModifierApply(modifier)
-					
+
 		bpy.ops.object.select_all(action = 'DESELECT')
-		
+
 		# Joining causes orphan data, so we remove it manually.
 		meshList = []
 		for selectedObj in allObjs:
 			selectedObj.select_set(True)
 			meshList.append(selectedObj.data)
-		
+
 		joinedObj = bpy.context.selected_objects[0]
 		bpy.context.view_layer.objects.active = joinedObj
 		joinedObj.select_set(True)
@@ -800,11 +800,11 @@ def combineObjects(obj, includeChildren, ignoreAttr, areaIndex):
 
 		# Need to clear parent transform in order to correctly apply transform.
 		bpy.ops.object.parent_clear(type='CLEAR_KEEP_TRANSFORM')
-		bpy.ops.object.transform_apply(location = False, 
+		bpy.ops.object.transform_apply(location = False,
 			rotation = True, scale = True, properties =  False)
 		bpy.context.view_layer.objects.active = joinedObj
 		joinedObj.select_set(True)
-		bpy.ops.object.transform_apply(location = False, 
+		bpy.ops.object.transform_apply(location = False,
 			rotation = True, scale = True, properties =  False)
 
 	except Exception as e:
@@ -852,7 +852,7 @@ def writeInsertableFile(filepath, dataType, address_ptrs, startPtr, data):
 		address += 4
 
 	openfile.seek(address)
-	openfile.write(data)	
+	openfile.write(data)
 	openfile.close()
 
 def colorTo16bitRGBA(color):
@@ -883,7 +883,7 @@ def applyRotation(objList, angle, axis):
 	direction = getDirectionGivenAppVersion()
 
 	bpy.ops.transform.rotate(value = direction * angle, orient_axis = axis, orient_type='GLOBAL')
-	bpy.ops.object.transform_apply(location = False, 
+	bpy.ops.object.transform_apply(location = False,
 		rotation = True, scale = True, properties =  False)
 
 def doRotation(angle, axis):
@@ -948,11 +948,11 @@ def getNameFromPath(path, removeExtension = False):
 	if removeExtension:
 		name = os.path.splitext(name)[0]
 	return toAlnum(name)
-	
+
 def gammaCorrect(color):
 	return [
-		gammaCorrectValue(color[0]), 
-		gammaCorrectValue(color[1]), 
+		gammaCorrectValue(color[0]),
+		gammaCorrectValue(color[1]),
 		gammaCorrectValue(color[2])]
 
 def gammaCorrectValue(u):
@@ -960,13 +960,13 @@ def gammaCorrectValue(u):
 		y = u * 12.92
 	else:
 		y = 1.055 * pow(u, (1/2.4)) - 0.055
-	
+
 	return min(max(y, 0), 1)
 
 def gammaInverse(color):
 	return [
-		gammaInverseValue(color[0]), 
-		gammaInverseValue(color[1]), 
+		gammaInverseValue(color[0]),
+		gammaInverseValue(color[1]),
 		gammaInverseValue(color[2])]
 
 def gammaInverseValue(u):
@@ -974,7 +974,7 @@ def gammaInverseValue(u):
 		y = u / 12.92
 	else:
 		y = ((u + 0.055) / 1.055) ** 2.4
-	
+
 	return min(max(y, 0), 1)
 
 def printBlenderMessage(msgSet, message, blenderOp):
@@ -1030,7 +1030,7 @@ def readVectorFromShorts(command, offset):
 		in range(offset, offset + 6, 2)]
 
 def readFloatFromShort(command, offset):
-	return int.from_bytes(command[offset: offset + 2], 
+	return int.from_bytes(command[offset: offset + 2],
 		'big', signed = True) / bpy.context.scene.blenderToSM64Scale
 
 def writeVectorToShorts(command, offset, values):
@@ -1059,7 +1059,7 @@ def readEulerVectorFromShorts(command, offset):
 		in range(offset, offset + 6, 2)]
 
 def readEulerFloatFromShort(command, offset):
-	return radians(int.from_bytes(command[offset: offset + 2], 
+	return radians(int.from_bytes(command[offset: offset + 2],
 		'big', signed = True))
 
 def writeEulerVectorToShorts(command, offset, values):
@@ -1123,7 +1123,7 @@ def convertUV(normalizedUVs, textureWidth, textureHeight):
 def convertFloatToFixed16Bytes(value):
 	value *= 2**5
 	value = min(max(value, -2**15), 2**15 - 1)
-	
+
 	return int(round(value)).to_bytes(2, 'big', signed = True)
 
 def convertFloatToFixed16(value):


### PR DESCRIPTION
Regarding the number of changes:
I enabled "Remove trailing whitespace" in VSCode... There is a TON of trailing whitespace throughout this repo so you may want to disable viewing whitespace changes when reviewing!

Instancing:
In a nutshell, this allows people to use Alt D to create object links, and those links will be exported as the same displaylist. Its a bit tricky because all transformations need to happen in the GeoLayout itself, instead of applying all transformations. This needed to happen in order to get these custom geolayout commands to work, since applying their transformations would break the intended transformation.

Custom Geolayout Commands:
Before this change, there were only a small handful of geolayout commands you could use with objects, while armatures were a low more flexible (no pun intended) and you could basically do any geolayout command wherever you wanted. Now people can attach any number of functions anywhere, use custom macros, scale, billboard, etc. Its pretty useful! Removes the need for most edits after exporting.

Maybe a similar system could be done for OOT. Sharing displaylists is pretty useful.