### PR TITLE
Have all exports use global 'save textures as PNG'

### DIFF
--- a/fast64_internal/f3d/f3d_writer.py
+++ b/fast64_internal/f3d/f3d_writer.py
@@ -2348,7 +2348,7 @@ class F3D_ExportDL(bpy.types.Operator):
 			f3dType = context.scene.f3d_type
 			isHWv1 = context.scene.isHWv1
 			texDir = bpy.context.scene.DLTexDir
-			savePNG = bpy.context.scene.DLSaveTextures or bpy.context.scene.ignoreTextureRestrictions
+			savePNG = bpy.context.scene.saveTextures or bpy.context.scene.ignoreTextureRestrictions
 			separateTexDef = bpy.context.scene.DLSeparateTextureDef
 			DLName = bpy.context.scene.DLName
 			matWriteMethod = getWriteMethodFromEnum(context.scene.matWriteMethod)
@@ -2357,7 +2357,7 @@ class F3D_ExportDL(bpy.types.Operator):
 				f3dType, isHWv1, texDir, savePNG, separateTexDef, DLName, matWriteMethod)
 
 			self.report({'INFO'}, 'Success!')
-				
+
 			applyRotation([obj], math.radians(-90), 'X')
 			return {'FINISHED'} # must return a set
 
@@ -2365,7 +2365,7 @@ class F3D_ExportDL(bpy.types.Operator):
 			if context.mode != 'OBJECT':
 				bpy.ops.object.mode_set(mode = 'OBJECT')
 			applyRotation([obj], math.radians(-90), 'X')
-			
+
 			raisePluginError(self, e)
 			return {'CANCELLED'} # must return a set
 
@@ -2392,10 +2392,9 @@ class F3D_ExportDLPanel(bpy.types.Panel):
 		col.prop(context.scene, 'DLExportisStatic')
 		
 		if not bpy.context.scene.ignoreTextureRestrictions:
-			col.prop(context.scene, 'DLSaveTextures')
-			if context.scene.DLSaveTextures:
+			if context.scene.saveTextures:
 				prop_split(col, context.scene, 'DLTexDir',
-					'Texture Include Path')	
+					'Texture Include Path') 
 				col.prop(context.scene, 'DLSeparateTextureDef')
 
 f3d_writer_classes = (

--- a/fast64_internal/sm64/sm64_f3d_writer.py
+++ b/fast64_internal/sm64/sm64_f3d_writer.py
@@ -509,7 +509,7 @@ class SM64_ExportDL(bpy.types.Operator):
 					DLFormat.Static if context.scene.DLExportisStatic else DLFormat.Dynamic, finalTransform,
 					context.scene.f3d_type, context.scene.isHWv1,
 					bpy.context.scene.DLTexDir,
-					bpy.context.scene.DLSaveTextures or bpy.context.scene.ignoreTextureRestrictions,
+					bpy.context.scene.saveTextures or bpy.context.scene.ignoreTextureRestrictions,
 					bpy.context.scene.DLSeparateTextureDef,
 					bpy.context.scene.DLincludeChildren, bpy.context.scene.DLName, levelName, context.scene.DLGroupName,
 					context.scene.DLCustomExport,
@@ -520,7 +520,7 @@ class SM64_ExportDL(bpy.types.Operator):
 				#	'DLFormat.Static if context.scene.DLExportisStatic else DLFormat.Dynamic, finalTransform,' +\
 				#	'context.scene.f3d_type, context.scene.isHWv1,' +\
 				#	'bpy.context.scene.DLTexDir,' +\
-				#	'bpy.context.scene.DLSaveTextures or bpy.context.scene.ignoreTextureRestrictions,' +\
+				#	'bpy.context.scene.saveTextures or bpy.context.scene.ignoreTextureRestrictions,' +\
 				#	'bpy.context.scene.DLSeparateTextureDef,' +\
 				#	'bpy.context.scene.DLincludeChildren, bpy.context.scene.DLName, levelName, context.scene.DLGroupName,' +\
 				#	'context.scene.DLCustomExport,' +\
@@ -634,12 +634,10 @@ class SM64_ExportDLPanel(bpy.types.Panel):
 			if context.scene.DLCustomExport:
 				col.prop(context.scene, 'DLExportPath')
 				prop_split(col, context.scene, 'DLName', 'Name')
-				if not bpy.context.scene.ignoreTextureRestrictions:
-					col.prop(context.scene, 'DLSaveTextures')
-					if context.scene.DLSaveTextures:
-						prop_split(col, context.scene, 'DLTexDir',
-							'Texture Include Path')	
-						col.prop(context.scene, 'DLSeparateTextureDef')
+				if not bpy.context.scene.ignoreTextureRestrictions and context.scene.saveTextures:
+					prop_split(col, context.scene, 'DLTexDir',
+						'Texture Include Path')	
+					col.prop(context.scene, 'DLSeparateTextureDef')
 				customExportWarning(col)
 			else:
 				prop_split(col, context.scene, 'DLExportHeaderType', 'Export Type')
@@ -650,10 +648,8 @@ class SM64_ExportDLPanel(bpy.types.Panel):
 					prop_split(col, context.scene, 'DLLevelOption', 'Level')
 					if context.scene.DLLevelOption == 'custom':
 						prop_split(col, context.scene, 'DLLevelName', 'Level Name')
-				if not bpy.context.scene.ignoreTextureRestrictions:
-					col.prop(context.scene, 'DLSaveTextures')
-					if context.scene.DLSaveTextures:
-						col.prop(context.scene, 'DLSeparateTextureDef')
+				if not bpy.context.scene.ignoreTextureRestrictions and context.scene.saveTextures:
+					col.prop(context.scene, 'DLSeparateTextureDef')
 				
 				decompFolderMessage(col)
 				writeBox = makeWriteInfoBox(col)
@@ -701,7 +697,7 @@ class ExportTexRectDraw(bpy.types.Operator):
 					context.scene.texrect,
 					context.scene.f3d_type, context.scene.isHWv1,
 					'textures/segment2',
-					context.scene.TexRectSaveTextures or bpy.context.scene.ignoreTextureRestrictions,
+					context.scene.saveTextures or bpy.context.scene.ignoreTextureRestrictions,
 					context.scene.TexRectName,
 					not context.scene.TexRectCustomExport,
 					enumHUDPaths[context.scene.TexRectExportType])
@@ -756,8 +752,6 @@ class ExportTexRectDrawPanel(bpy.types.Panel):
 			col.prop(textureProp.T, 'mirror', text = 'Mirror T')
 			
 		prop_split(col, context.scene, 'TexRectName', 'Name')
-		if not bpy.context.scene.ignoreTextureRestrictions:
-			col.prop(context.scene, 'TexRectSaveTextures')
 		col.prop(context.scene, 'TexRectCustomExport')
 		if context.scene.TexRectCustomExport:
 			col.prop(context.scene, 'TexRectExportPath')
@@ -899,8 +893,6 @@ def sm64_dl_writer_register():
 		default = '80000000')
 	bpy.types.Scene.DLTexDir = bpy.props.StringProperty(
 		name ='Include Path', default = 'levels/bob')
-	bpy.types.Scene.DLSaveTextures = bpy.props.BoolProperty(
-		name = 'Save Textures As PNGs (Breaks CI Textures)')
 	bpy.types.Scene.DLSeparateTextureDef = bpy.props.BoolProperty(
 		name = 'Save texture.inc.c separately')
 	bpy.types.Scene.DLincludeChildren = bpy.props.BoolProperty(
@@ -924,7 +916,6 @@ def sm64_dl_writer_register():
 	bpy.types.Scene.texrectImageTexture = bpy.props.PointerProperty(type = bpy.types.ImageTexture)
 	bpy.types.Scene.TexRectExportPath = bpy.props.StringProperty(name = 'Export Path', subtype='FILE_PATH')
 	bpy.types.Scene.TexRectTexDir = bpy.props.StringProperty(name = 'Include Path', default = 'textures/segment2')
-	bpy.types.Scene.TexRectSaveTextures = bpy.props.BoolProperty(name = 'Save Textures as PNGs (Breaks CI Textures)')
 	bpy.types.Scene.TexRectName = bpy.props.StringProperty(name = 'Name', default = 'render_hud_image')
 	bpy.types.Scene.TexRectCustomExport = bpy.props.BoolProperty(name = 'Custom Export Path')
 	bpy.types.Scene.TexRectExportType = bpy.props.EnumProperty(name = 'Export Type', items = enumHUDExportLocation)
@@ -945,7 +936,6 @@ def sm64_dl_writer_unregister():
 	del bpy.types.Scene.DLUseBank0
 	del bpy.types.Scene.DLRAMAddr
 	del bpy.types.Scene.DLTexDir
-	del bpy.types.Scene.DLSaveTextures
 	del bpy.types.Scene.DLSeparateTextureDef
 	del bpy.types.Scene.DLincludeChildren
 	del bpy.types.Scene.DLInsertableBinaryPath
@@ -959,7 +949,6 @@ def sm64_dl_writer_unregister():
 	del bpy.types.Scene.texrect
 	del bpy.types.Scene.TexRectExportPath
 	del bpy.types.Scene.TexRectTexDir
-	del bpy.types.Scene.TexRectSaveTextures
 	del bpy.types.Scene.TexRectName
 	del bpy.types.Scene.texrectImageTexture
 	del bpy.types.Scene.TexRectCustomExport

--- a/fast64_internal/sm64/sm64_geolayout_writer.py
+++ b/fast64_internal/sm64/sm64_geolayout_writer.py
@@ -1973,7 +1973,7 @@ class SM64_ExportGeolayoutObject(bpy.types.Operator):
 			# Rotate all armatures 90 degrees
 			applyRotation([obj], math.radians(90), 'X')
 
-			saveTextures = bpy.context.scene.geoSaveTextures or bpy.context.scene.ignoreTextureRestrictions
+			saveTextures = bpy.context.scene.saveTextures or bpy.context.scene.ignoreTextureRestrictions
 
 			if context.scene.geoExportType == 'C':
 				exportPath, levelName = getPathAndLevel(context.scene.geoCustomExport, 
@@ -2160,7 +2160,7 @@ class SM64_ExportGeolayoutArmature(bpy.types.Operator):
 					context.scene.geoExportPath, context.scene.geoLevelName, 
 					context.scene.geoLevelOption)
 
-				saveTextures = bpy.context.scene.geoSaveTextures or bpy.context.scene.ignoreTextureRestrictions
+				saveTextures = bpy.context.scene.saveTextures or bpy.context.scene.ignoreTextureRestrictions
 				if not context.scene.geoCustomExport:
 					applyBasicTweaks(exportPath)
 				header, fileStatus = exportGeolayoutArmatureC(armatureObj, obj, finalTransform,
@@ -2289,12 +2289,10 @@ class SM64_ExportGeolayoutPanel(bpy.types.Panel):
 
 		col.prop(context.scene, 'geoExportType')
 		if context.scene.geoExportType == 'C':
-			if not bpy.context.scene.ignoreTextureRestrictions:
-				col.prop(context.scene, 'geoSaveTextures')
-				if context.scene.geoSaveTextures:
-					if context.scene.geoCustomExport:
-						prop_split(col, context.scene, 'geoTexDir', 'Texture Include Path')	
-					col.prop(context.scene, 'geoSeparateTextureDef')
+			if not bpy.context.scene.ignoreTextureRestrictions and context.scene.saveTextures:
+				if context.scene.geoCustomExport:
+					prop_split(col, context.scene, 'geoTexDir', 'Texture Include Path')	
+				col.prop(context.scene, 'geoSeparateTextureDef')
 			
 			col.prop(context.scene, 'geoCustomExport')
 			if context.scene.geoCustomExport:
@@ -2448,8 +2446,6 @@ def sm64_geo_writer_register():
 		default = '80000000')
 	bpy.types.Scene.geoTexDir = bpy.props.StringProperty(
 		name ='Include Path', default = 'actors/mario/')
-	bpy.types.Scene.geoSaveTextures = bpy.props.BoolProperty(
-		name = 'Save Textures As PNGs (Breaks CI Textures)')
 	bpy.types.Scene.geoSeparateTextureDef = bpy.props.BoolProperty(
 		name = 'Save texture.inc.c separately')
 	bpy.types.Scene.geoInsertableBinaryPath = bpy.props.StringProperty(
@@ -2496,7 +2492,6 @@ def sm64_geo_writer_unregister():
 	del bpy.types.Scene.geoUseBank0
 	del bpy.types.Scene.geoRAMAddr
 	del bpy.types.Scene.geoTexDir
-	del bpy.types.Scene.geoSaveTextures
 	del bpy.types.Scene.geoSeparateTextureDef
 	del bpy.types.Scene.geoInsertableBinaryPath
 	del bpy.types.Scene.geoIsSegPtr

--- a/fast64_internal/sm64/sm64_level_writer.py
+++ b/fast64_internal/sm64/sm64_level_writer.py
@@ -907,14 +907,14 @@ class SM64_ExportLevel(bpy.types.Operator):
 				applyBasicTweaks(exportPath)
 			#cProfile.runctx('exportLevelC(obj, finalTransform,' +\
 			#	'context.scene.f3d_type, context.scene.isHWv1, levelName, exportPath,' +\
-			#	'context.scene.levelSaveTextures or bpy.context.scene.ignoreTextureRestrictions,' +\
+			#	'context.scene.saveTextures or bpy.context.scene.ignoreTextureRestrictions,' +\
 			#	'context.scene.levelCustomExport, triggerName, DLFormat.Static)',
 			#	globals(), locals(), "E:/blender.prof")
 			#p = pstats.Stats("E:/blender.prof")
 			#p.sort_stats("cumulative").print_stats(2000)
 			fileStatus = exportLevelC(obj, finalTransform,
 				context.scene.f3d_type, context.scene.isHWv1, levelName, exportPath, 
-				context.scene.levelSaveTextures or bpy.context.scene.ignoreTextureRestrictions, 
+				context.scene.saveTextures or bpy.context.scene.ignoreTextureRestrictions, 
 				context.scene.levelCustomExport, triggerName, DLFormat.Static)
 
 			cameraWarning(self, fileStatus)
@@ -954,8 +954,6 @@ class SM64_ExportLevelPanel(bpy.types.Panel):
 		col = self.layout.column()
 		col.label(text = 'This is for decomp only.')
 		col.operator(SM64_ExportLevel.bl_idname)
-		if not bpy.context.scene.ignoreTextureRestrictions:
-			col.prop(context.scene, 'levelSaveTextures')
 		col.prop(context.scene, 'levelCustomExport')
 		if context.scene.levelCustomExport:
 			prop_split(col, context.scene, 'levelExportPath', 'Directory')
@@ -1001,8 +999,6 @@ def sm64_level_register():
 	bpy.types.Scene.levelOption = bpy.props.EnumProperty(name = "Level", items = enumLevelNames, default = 'bob')
 	bpy.types.Scene.levelExportPath = bpy.props.StringProperty(
 		name = 'Directory', subtype = 'FILE_PATH')
-	bpy.types.Scene.levelSaveTextures = bpy.props.BoolProperty(
-		name = 'Save Textures As PNGs (Breaks CI Textures)')
 	bpy.types.Scene.levelCustomExport = bpy.props.BoolProperty(
 		name = 'Custom Export Path')
 
@@ -1012,6 +1008,5 @@ def sm64_level_unregister():
 
 	del bpy.types.Scene.levelName
 	del bpy.types.Scene.levelExportPath 
-	del bpy.types.Scene.levelSaveTextures
 	del bpy.types.Scene.levelCustomExport
 	del bpy.types.Scene.levelOption


### PR DESCRIPTION
Like basic F3D settings, all `save textures as PNG` toggles are just in the F3D menu as a global setting (helps prevent people from accidentally pressing it)