### PR TITLE
Added ability to ignore blocks of code in level scripts

### DIFF
--- a/fast64_internal/sm64/sm64_level_writer.py
+++ b/fast64_internal/sm64/sm64_level_writer.py
@@ -482,7 +482,7 @@ def parseLevelPersistentBlocks(scriptData: str, levelScript: LevelScript):
 			if areaIndex:
 				levelScript.persistentBlocks[curBlock][areaIndex].append(line)
 			else:
-				raise PluginError(f'script.c: "{PersistentBlocks.beginMagic} [area commands]" found outside of area block')
+				raise PluginError(f'script.c: "{PersistentBlocks.beginMagic} {PersistentBlocks.areaCommands}" found outside of area block')
 
 		elif curBlock:
 			levelScript.persistentBlocks[curBlock].append(line)

--- a/fast64_internal/sm64/sm64_objects.py
+++ b/fast64_internal/sm64/sm64_objects.py
@@ -359,7 +359,7 @@ class SM64_Area:
 	def macros_name(self):
 		return self.name + '_macro_objs'
 
-	def to_c_script(self, includeRooms):
+	def to_c_script(self, includeRooms, keepString: str = ''):
 		data = ''
 		data += '\tAREA(' + str(self.index) + ', ' + self.geolayout.name + '),\n'
 		for warpNode in self.warpNodes:
@@ -377,6 +377,7 @@ class SM64_Area:
 		if self.startDialog is not None:
 			data += '\t\tSHOW_DIALOG(0x00, ' + self.startDialog + '),\n'
 		data += '\t\tTERRAIN_TYPE(' + self.terrain_type + '),\n'
+		data += f'{keepString}\n'
 		data += '\tEND_AREA(),\n\n'
 		return data
 

--- a/fast64_internal/sm64/sm64_objects.py
+++ b/fast64_internal/sm64/sm64_objects.py
@@ -359,7 +359,7 @@ class SM64_Area:
 	def macros_name(self):
 		return self.name + '_macro_objs'
 
-	def to_c_script(self, includeRooms, keepString: str = ''):
+	def to_c_script(self, includeRooms, persistentBlockString: str = ''):
 		data = ''
 		data += '\tAREA(' + str(self.index) + ', ' + self.geolayout.name + '),\n'
 		for warpNode in self.warpNodes:
@@ -377,7 +377,7 @@ class SM64_Area:
 		if self.startDialog is not None:
 			data += '\t\tSHOW_DIALOG(0x00, ' + self.startDialog + '),\n'
 		data += '\t\tTERRAIN_TYPE(' + self.terrain_type + '),\n'
-		data += f'{keepString}\n'
+		data += f'{persistentBlockString}\n'
 		data += '\tEND_AREA(),\n\n'
 		return data
 


### PR DESCRIPTION
## SM64 Level Exporting
this change adds various areas in a levelscript where you can add any sort of code that will stay in that spot

```c
/* FAST64KEEP INCLUDES */
put whatever you want in here
/* FAST64END INCLUDES */
```

This makes it so that anything thats not covered by Fast64 (or just custom in general) doesn't get overwritten when exporting levels. A more generic solution could be cool to eventually implement... (e.g. keep anything between `/* FAST64KEEP BLOCK */` to `/* FAST64END BLOCK */`, but a lot of conflicts could come out of this, so I think its better to be specific for now)