### PR TITLE
[SM64] Apply scale by default and add option to skip applying scale

### DIFF
--- a/fast64_internal/sm64/sm64_geolayout_bone.py
+++ b/fast64_internal/sm64/sm64_geolayout_bone.py
@@ -217,6 +217,8 @@ class GeolayoutObjectPanel(bpy.types.Panel):
 		col.prop(obj, 'ignore_render')
 		col.prop(obj, 'ignore_collision')
 		col.prop(obj, 'use_f3d_culling')
+		if obj_scale_is_unified(obj) and len(obj.modifiers) == 0:
+			col.prop(obj, 'scaleFromGeolayout')
 		#prop_split(col, obj, 'room_num', 'Room')
 
 class MaterialPointerProperty(bpy.types.PropertyGroup):
@@ -519,6 +521,12 @@ def sm64_bone_register():
 	bpy.types.Object.use_render_range = bpy.props.BoolProperty(name = 'Use Render Range (LOD)')
 	bpy.types.Object.render_range = bpy.props.FloatVectorProperty(name = 'Render Range', 
 		size = 2, default = (0,100))
+	
+	bpy.types.Object.scaleFromGeolayout = bpy.props.BoolProperty(
+		name = 'Scale from Geolayout',
+		description = 'If scale is all a single value (e.g. 2, 2, 2), do not apply scale when exporting, and instead use GeoLayout to scale. Can be used to enhance precision by setting scaling values to a value less than 1.',
+		default = False
+	)
 
 	# Used during object duplication on export
 	bpy.types.Object.original_name = bpy.props.StringProperty()
@@ -553,4 +561,6 @@ def sm64_bone_unregister():
 	del bpy.types.Object.add_func
 
 	del bpy.types.Object.use_render_range
-	del bpy.types.Object.render_range 
+	del bpy.types.Object.render_range
+
+	del bpy.types.Object.scaleFromGeolayout

--- a/fast64_internal/utility.py
+++ b/fast64_internal/utility.py
@@ -564,6 +564,7 @@ def copy_object_and_apply(obj: bpy.types.Object, apply_scale = False, apply_modi
 	if apply_scale or apply_modifiers:
 		# it's a unique mesh, use object name
 		obj['instanced_mesh_name'] = obj.name
+
 		obj.original_name = obj.name
 		if apply_scale:
 			obj['original_mtx'] = translation_rotation_from_mtx(mathutils.Matrix(obj['original_mtx']))
@@ -613,17 +614,23 @@ def store_original_meshes(add_warning: Callable[[str], None]):
 			has_modifiers = len(obj.modifiers) != 0
 			has_uneven_scale = not obj_scale_is_unified(obj)
 			shares_mesh = obj.data.users > 1
-			if has_modifiers or has_uneven_scale:
+			if has_modifiers or has_uneven_scale or not shares_mesh:
 				if shares_mesh and has_modifiers:
 					add_warning(
 						f'Object "{obj.name}" cannot be instanced due to having modifiers so an extra displaylist will be created. Remove modifiers to allow instancing.')
 				if shares_mesh and has_uneven_scale:
 					add_warning(
 						f'Object "{obj.name}" cannot be instanced due to uneven object scaling and an extra displaylist will be created. Set all scale values to the same value to allow instancing.')
-				copy_object_and_apply(obj, apply_scale=has_uneven_scale, apply_modifiers=has_modifiers)
-				continue
+				
+				if obj.scaleFromGeolayout and not has_modifiers and not has_uneven_scale:
+					# Object was intended to be instanced and scaled via geolayout
+					pass
+				else:
+					copy_object_and_apply(obj, apply_scale=True, apply_modifiers=has_modifiers)
+					continue
 
-			obj['instanced_mesh_name'] = obj.data.name
+			# add `_shared_mesh` to instanced name because `obj.data.name` can be the same as object names
+			obj['instanced_mesh_name'] = f'{obj.data.name}_shared_mesh'
 			obj.original_name = obj.name
 
 			if obj.data.name not in instanced_meshes:


### PR DESCRIPTION
People have been setting object scale's to massive values, causing exported objects to loose a ton of precision. So now scaling is _not_ applied by default, and objects are only instanced if there is > 1 user, and I added an option to specifically scale in the `GeoLayout`. Just in case people would want that (like for adding extra precision).