### PR TITLE
Panel UI refactor

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -359,8 +359,4 @@ def unregister():
 	for cls in classes:
 		unregister_class(cls)
 	
-	bpy.app.handlers.load_post = [
-		handler for handler in bpy.app.handlers.load_post
-		if handler is not after_load
-	]
-
+	bpy.app.handlers.load_post.remove(after_load)

--- a/__init__.py
+++ b/__init__.py
@@ -332,6 +332,7 @@ def register():
 	bpy.types.Scene.blenderF3DScale = bpy.props.FloatProperty(name = "F3D Blender Scale", default = 100)
 
 	bpy.types.Scene.fast64 = bpy.props.PointerProperty(type=Fast64_Properties, name="Fast64 Properties")
+	bpy.app.handlers.load_post.append(after_load)
 
 # called on add-on disabling
 def unregister():
@@ -357,6 +358,3 @@ def unregister():
 
 	for cls in classes:
 		unregister_class(cls)
-
-if __name__ == '__main__':
-	bpy.app.handlers.load_post.append(after_load)

--- a/__init__.py
+++ b/__init__.py
@@ -290,13 +290,13 @@ classes = (
 	Fast64_GlobalToolsPanel,
 )
 
-def derive_legacy_defaults():
+def upgrade_changed_props():
 	'''Set scene properties after a scene loads, used for migrating old properties'''
-	SM64_Properties.derive_defaults()
+	SM64_Properties.upgrade_changed_props()
 
 @bpy.app.handlers.persistent
 def after_load(_a, _b):
-	derive_legacy_defaults()
+	upgrade_changed_props()
 
 # called on add-on enabling
 # register operators and panels here

--- a/__init__.py
+++ b/__init__.py
@@ -358,3 +358,9 @@ def unregister():
 
 	for cls in classes:
 		unregister_class(cls)
+	
+	bpy.app.handlers.load_post = [
+		handler for handler in bpy.app.handlers.load_post
+		if handler is not after_load
+	]
+

--- a/__init__.py
+++ b/__init__.py
@@ -155,16 +155,9 @@ class SM64_AddWaterBox(AddWaterBox):
 	def setEmptyType(self, emptyObj):
 		emptyObj.sm64_obj_type = "Water Box"
 
-class SM64_ArmatureToolsPanel(bpy.types.Panel):
+class SM64_ArmatureToolsPanel(SM64_Panel):
 	bl_idname = "SM64_PT_armature_tools"
 	bl_label = "SM64 Tools"
-	bl_space_type = 'VIEW_3D'
-	bl_region_type = 'UI'
-	bl_category = 'SM64'
-
-	@classmethod
-	def poll(cls, context):
-		return True
 
 	# called every frame
 	def draw(self, context):

--- a/fast64_internal/__init__.py
+++ b/fast64_internal/__init__.py
@@ -2,3 +2,4 @@ from .f3d_material_converter import *
 from .f3d import *
 from .sm64 import *
 from .oot import *
+from .panels import *

--- a/fast64_internal/f3d/f3d_parser.py
+++ b/fast64_internal/f3d/f3d_parser.py
@@ -434,7 +434,7 @@ def convertF3DUV(value, maxSize):
 	try:
 		valueBytes = int.to_bytes(value, 2, 'big', signed = True)
 	except OverflowError:
-		valueBytes = int.to_bytes(valule, 2, 'big', signed = False)
+		valueBytes = int.to_bytes(value, 2, 'big', signed = False)
 	
 	return ((int.from_bytes(valueBytes, 'big', signed = True) / 32) + 0.5) / (maxSize if maxSize > 0 else 1)
 
@@ -1920,6 +1920,7 @@ class F3D_ImportDLPanel(bpy.types.Panel):
 	bl_space_type = 'VIEW_3D'
 	bl_region_type = 'UI'
 	bl_category = 'Fast64'
+	bl_options = {'DEFAULT_CLOSED'}
 
 	@classmethod
 	def poll(cls, context):

--- a/fast64_internal/f3d/f3d_writer.py
+++ b/fast64_internal/f3d/f3d_writer.py
@@ -2376,6 +2376,7 @@ class F3D_ExportDLPanel(bpy.types.Panel):
 	bl_space_type = 'VIEW_3D'
 	bl_region_type = 'UI'
 	bl_category = 'Fast64'
+	bl_options = {'DEFAULT_CLOSED'}
 
 	@classmethod
 	def poll(cls, context):

--- a/fast64_internal/oot/__init__.py
+++ b/fast64_internal/oot/__init__.py
@@ -25,10 +25,12 @@ ootEnumRefreshVer = [
 class OOT_FileSettingsPanel(OOT_Panel):
 	bl_idname = "OOT_PT_file_settings"
 	bl_label = "OOT File Settings"
+	bl_options = set() # default to being open
 
 	# called every frame
 	def draw(self, context):
 		col = self.layout.column()	
+		col.scale_y = 1.1 # extra padding, makes it easier to see these main settings
 		prop_split(col, context.scene, 'ootBlenderScale', 'OOT Scene Scale')
 		prop_split(col, context.scene, 'ootActorBlenderScale', 'OOT Actor Scale')
 		
@@ -38,8 +40,13 @@ class OOT_FileSettingsPanel(OOT_Panel):
 		
 		#prop_split(col, context.scene, 'ootRefreshVer', 'Decomp Func Map')
 
+class OOT_Properties(bpy.types.PropertyGroup):
+	'''Global OOT Scene Properties found under scene.fast64.oot'''
+	version: bpy.props.IntProperty(name="OOT_Properties Version", default=0)
+
 oot_classes = (
 	OOT_FileSettingsPanel,
+	OOT_Properties,
 )
 
 def oot_panel_register():

--- a/fast64_internal/oot/__init__.py
+++ b/fast64_internal/oot/__init__.py
@@ -1,3 +1,4 @@
+from ..panels import OOT_Panel
 from .oot_f3d_writer import *
 #from .oot_geolayout_writer import *
 #from .oot_geolayout_parser import *
@@ -21,16 +22,9 @@ ootEnumRefreshVer = [
 	("Refresh 3", "Refresh 3", "Refresh 3"),
 ]
 
-class OOT_FileSettingsPanel(bpy.types.Panel):
+class OOT_FileSettingsPanel(OOT_Panel):
 	bl_idname = "OOT_PT_file_settings"
 	bl_label = "OOT File Settings"
-	bl_space_type = 'VIEW_3D'
-	bl_region_type = 'UI'
-	bl_category = 'OOT'
-
-	@classmethod
-	def poll(cls, context):
-		return True
 
 	# called every frame
 	def draw(self, context):

--- a/fast64_internal/oot/oot_anim.py
+++ b/fast64_internal/oot/oot_anim.py
@@ -5,6 +5,7 @@ from .oot_constants import *
 from .oot_utility import *
 from .oot_skeleton import *
 from ..utility import *
+from ..panels import OOT_Panel
 
 class OOTAnimation:
 	def __init__(self, name):
@@ -345,16 +346,9 @@ class OOT_ImportAnim(bpy.types.Operator):
 
 		return {'FINISHED'} # must return a set
 
-class OOT_ExportAnimPanel(bpy.types.Panel):
+class OOT_ExportAnimPanel(OOT_Panel):
 	bl_idname = "OOT_PT_export_anim"
 	bl_label = "OOT Animation Exporter"
-	bl_space_type = 'VIEW_3D'
-	bl_region_type = 'UI'
-	bl_category = 'OOT'
-
-	@classmethod
-	def poll(cls, context):
-		return True
 
 	# called every frame
 	def draw(self, context):

--- a/fast64_internal/oot/oot_collision.py
+++ b/fast64_internal/oot/oot_collision.py
@@ -2,6 +2,7 @@ from .oot_constants import *
 from .oot_utility import *
 
 from ..utility import *
+from ..panels import OOT_Panel
 
 from bpy.utils import register_class, unregister_class
 from io import BytesIO
@@ -865,16 +866,9 @@ class OOT_ExportCollision(bpy.types.Operator):
 			raisePluginError(self, e)
 			return {'CANCELLED'} # must return a set
 
-class OOT_ExportCollisionPanel(bpy.types.Panel):
+class OOT_ExportCollisionPanel(OOT_Panel):
 	bl_idname = "OOT_PT_export_collision"
 	bl_label = "OOT Collision Exporter"
-	bl_space_type = 'VIEW_3D'
-	bl_region_type = 'UI'
-	bl_category = 'OOT'
-
-	@classmethod
-	def poll(cls, context):
-		return True
 
 	# called every frame
 	def draw(self, context):

--- a/fast64_internal/oot/oot_f3d_writer.py
+++ b/fast64_internal/oot/oot_f3d_writer.py
@@ -7,6 +7,7 @@ from .oot_constants import *
 from .oot_utility import *
 from .oot_scene_room import *
 from ..f3d.f3d_parser import *
+from ..panels import OOT_Panel
 
 class OOTModel(FModel):
 	def __init__(self, f3dType, isHWv1, name, DLFormat, drawLayerOverride):
@@ -494,16 +495,9 @@ class OOT_ExportDL(bpy.types.Operator):
 			raisePluginError(self, e)
 			return {'CANCELLED'} # must return a set
 
-class OOT_ExportDLPanel(bpy.types.Panel):
+class OOT_ExportDLPanel(OOT_Panel):
 	bl_idname = "OOT_PT_export_dl"
 	bl_label = "OOT DL Exporter"
-	bl_space_type = 'VIEW_3D'
-	bl_region_type = 'UI'
-	bl_category = 'OOT'
-
-	@classmethod
-	def poll(cls, context):
-		return True
 
 	# called every frame
 	def draw(self, context):

--- a/fast64_internal/oot/oot_level_writer.py
+++ b/fast64_internal/oot/oot_level_writer.py
@@ -11,6 +11,7 @@ from .oot_spline import *
 from .c_writer import *
 
 from ..utility import *
+from ..panels import OOT_Panel
 
 from bpy.utils import register_class, unregister_class
 from io import BytesIO
@@ -599,16 +600,9 @@ class OOT_RemoveScene(bpy.types.Operator):
 		self.report({'INFO'}, 'Success!')
 		return {'FINISHED'} # must return a set
 
-class OOT_ExportScenePanel(bpy.types.Panel):
+class OOT_ExportScenePanel(OOT_Panel):
 	bl_idname = "OOT_PT_export_level"
 	bl_label = "OOT Scene Exporter"
-	bl_space_type = 'VIEW_3D'
-	bl_region_type = 'UI'
-	bl_category = 'OOT'
-
-	@classmethod
-	def poll(cls, context):
-		return True
 
 	# called every frame
 	def draw(self, context):

--- a/fast64_internal/oot/oot_operators.py
+++ b/fast64_internal/oot/oot_operators.py
@@ -3,6 +3,7 @@ from bpy.utils import register_class, unregister_class
 from ..utility import *
 from ..f3d.f3d_material import *
 from ..operators import *
+from ..panels import OOT_Panel
 
 class OOT_AddWaterBox(AddWaterBox):
 	bl_idname = 'object.oot_add_water_box'
@@ -137,16 +138,9 @@ class OOT_AddRoom(bpy.types.Operator):
 		context.view_layer.objects.active = roomObj
 		return {"FINISHED"}
 
-class OOT_OperatorsPanel(bpy.types.Panel):
+class OOT_OperatorsPanel(OOT_Panel):
 	bl_idname = "OOT_PT_operators"
 	bl_label = "OOT Tools"
-	bl_space_type = 'VIEW_3D'
-	bl_region_type = 'UI'
-	bl_category = 'OOT'
-
-	@classmethod
-	def poll(cls, context):
-		return True
 
 	# called every frame
 	def draw(self, context):

--- a/fast64_internal/oot/oot_skeleton.py
+++ b/fast64_internal/oot/oot_skeleton.py
@@ -8,6 +8,7 @@ from .oot_constants import *
 from .oot_utility import *
 from .oot_f3d_writer import *
 from ..utility import *
+from ..panels import OOT_Panel
 
 ootEnumBoneType = [
 	("Default", "Default", "Default"),
@@ -772,16 +773,9 @@ class OOT_ExportSkeleton(bpy.types.Operator):
 			raisePluginError(self, e)
 			return {'CANCELLED'} # must return a set
 
-class OOT_ExportSkeletonPanel(bpy.types.Panel):
+class OOT_ExportSkeletonPanel(OOT_Panel):
 	bl_idname = "OOT_PT_export_skeleton"
 	bl_label = "OOT Skeleton Exporter"
-	bl_space_type = 'VIEW_3D'
-	bl_region_type = 'UI'
-	bl_category = 'OOT'
-
-	@classmethod
-	def poll(cls, context):
-		return True
 
 	# called every frame
 	def draw(self, context):

--- a/fast64_internal/panels.py
+++ b/fast64_internal/panels.py
@@ -2,19 +2,44 @@
 import bpy
 from .fast64_internal import *
 
+sm64GoalImport = 'Import' # Not in enum, separate UI option
+sm64GoalTypeEnum = [
+	('All', 'All', 'All'),
+	('Export Object/Actor/Anim', 'Export Object/Actor/Anim', 'Export Object/Actor/Anim'),
+	('Export Level', 'Export Level', 'Export Level'),
+	('Export Displaylist', 'Export Displaylist', 'Export Displaylist'),
+	('Export UI Image', 'Export UI Image', 'Export UI Image'),
+]
+
 class SM64_Panel(bpy.types.Panel):
     bl_space_type = 'VIEW_3D'
     bl_region_type = 'UI'
     bl_category = 'SM64'
+    bl_options = {'DEFAULT_CLOSED'}
+    goal = None
+    decomp_only = False
 
     @classmethod
     def poll(cls, context):
-        return context.scene.gameEditorMode == 'SM64'
+        sm64Props = bpy.context.scene.fast64.sm64
+        if context.scene.gameEditorMode != 'SM64':
+            return False
+        elif not cls.goal:
+            return True # Panel should always be shown
+        elif cls.goal == sm64GoalImport:
+            # Only show if importing is enabled
+            return sm64Props.showImportingMenus
+        elif cls.decomp_only and sm64Props.exportType != 'C':
+            return False
+
+        sceneGoal = sm64Props.goal
+        return sceneGoal == 'All' or sceneGoal == cls.goal
 
 class OOT_Panel(bpy.types.Panel):
     bl_space_type = 'VIEW_3D'
     bl_region_type = 'UI'
     bl_category = 'OOT'
+    bl_options = {'DEFAULT_CLOSED'}
 
     @classmethod
     def poll(cls, context):

--- a/fast64_internal/panels.py
+++ b/fast64_internal/panels.py
@@ -16,7 +16,9 @@ class SM64_Panel(bpy.types.Panel):
     bl_region_type = 'UI'
     bl_category = 'SM64'
     bl_options = {'DEFAULT_CLOSED'}
+    # goal refers to the selected sm64GoalTypeEnum, a different selection than this goal will filter this panel out
     goal = None
+    # if this is True, the panel is hidden whenever the scene's exportType is not 'C'
     decomp_only = False
 
     @classmethod

--- a/fast64_internal/panels.py
+++ b/fast64_internal/panels.py
@@ -1,0 +1,21 @@
+
+import bpy
+from .fast64_internal import *
+
+class SM64_Panel(bpy.types.Panel):
+    bl_space_type = 'VIEW_3D'
+    bl_region_type = 'UI'
+    bl_category = 'SM64'
+
+    @classmethod
+    def poll(cls, context):
+        return context.scene.gameEditorMode == 'SM64'
+
+class OOT_Panel(bpy.types.Panel):
+    bl_space_type = 'VIEW_3D'
+    bl_region_type = 'UI'
+    bl_category = 'OOT'
+
+    @classmethod
+    def poll(cls, context):
+        return context.scene.gameEditorMode == 'OOT'

--- a/fast64_internal/sm64/__init__.py
+++ b/fast64_internal/sm64/__init__.py
@@ -169,7 +169,7 @@ class SM64_Properties(bpy.types.PropertyGroup):
 	# exportInsertableBinaryPath: bpy.props.StringProperty(name = 'Filepath', subtype = 'FILE_PATH')
 
 	@staticmethod
-	def derive_defaults():
+	def upgrade_changed_props():
 		if bpy.context.scene.fast64.sm64.version != SM64_Properties.cur_version:
 			bpy.context.scene.fast64.sm64.exportType = get_legacy_export_type()
 			bpy.context.scene.fast64.sm64.version = SM64_Properties.cur_version

--- a/fast64_internal/sm64/__init__.py
+++ b/fast64_internal/sm64/__init__.py
@@ -127,12 +127,9 @@ def get_legacy_export_type():
 	scene = bpy.context.scene
 
 	for exportKey in ['animExportType', 'colExportType', 'DLExportType', 'geoExportType']:
-		try:
-			eType = scene.pop(exportKey)
-			if eType and legacy_export_types[eType] != 'C':
-				return legacy_export_types[eType]
-		except KeyError:
-			pass
+		eType = scene.pop(exportKey, None)
+		if eType is not None and legacy_export_types[eType] != 'C':
+			return legacy_export_types[eType]
 
 	return 'C'
 

--- a/fast64_internal/sm64/__init__.py
+++ b/fast64_internal/sm64/__init__.py
@@ -128,24 +128,21 @@ class SM64_AddressConvertPanel(SM64_Panel):
 def get_legacy_export_type():
 	legacy_export_types = ('C', 'Binary', 'Insertable Binary')
 	scene = bpy.context.scene
-	if scene.get('already_derived_legacy_export_type'):
-		return scene.fast64.sm64.exportType
-	scene['already_derived_legacy_export_type'] = True
 
-	exportTypes = set()
-	exportTypes.add(legacy_export_types[scene.get('animExportType', 0)])
-	exportTypes.add(legacy_export_types[scene.get('colExportType', 0)])
-	exportTypes.add(legacy_export_types[scene.get('DLExportType', 0)])
-	exportTypes.add(legacy_export_types[scene.get('geoExportType', 0)])
-	exportTypes = exportTypes - {'C'}
+	for exportKey in ['animExportType', 'colExportType', 'DLExportType', 'geoExportType']:
+		try:
+			eType = scene.pop(exportKey)
+			if eType and legacy_export_types[eType] != 'C':
+				return legacy_export_types[eType]
+		except KeyError:
+			pass
 
-	if len(exportTypes):
-		return exportTypes.pop()
 	return 'C'
 
 class SM64_Properties(bpy.types.PropertyGroup):
 	'''Global SM64 Scene Properties found under scene.fast64.sm64'''
 	version: bpy.props.IntProperty(name="SM64_Properties Version", default=0)
+	cur_version = 1 # version after property migration
 
 	# UI Selection
 	showImportingMenus: bpy.props.BoolProperty(name='Show Importing Menus', default=False)
@@ -173,7 +170,9 @@ class SM64_Properties(bpy.types.PropertyGroup):
 
 	@staticmethod
 	def derive_defaults():
-		bpy.context.scene.fast64.sm64.exportType = get_legacy_export_type()
+		if bpy.context.scene.fast64.sm64.version != SM64_Properties.cur_version:
+			bpy.context.scene.fast64.sm64.exportType = get_legacy_export_type()
+			bpy.context.scene.fast64.sm64.version = SM64_Properties.cur_version
 
 
 sm64_classes = (

--- a/fast64_internal/sm64/__init__.py
+++ b/fast64_internal/sm64/__init__.py
@@ -72,7 +72,6 @@ class SM64_MenuVisibilityPanel(SM64_Panel):
 	bl_options = set() # default to open
 	bl_order = 0 # force to front
 
-	# called every frame
 	def draw(self, context):
 		col = self.layout.column()
 		col.scale_y = 1.1 # extra padding
@@ -86,7 +85,6 @@ class SM64_FileSettingsPanel(SM64_Panel):
 	bl_label = "SM64 File Settings"
 	bl_options = set()
 
-	# called every frame
 	def draw(self, context):
 		col = self.layout.column()
 		col.scale_y = 1.1 # extra padding
@@ -113,7 +111,6 @@ class SM64_AddressConvertPanel(SM64_Panel):
 	bl_label = "SM64 Address Converter"
 	goal = sm64GoalImport
 
-	# called every frame
 	def draw(self, context):
 		col = self.layout.column()
 		segToVirtOp = col.operator(SM64_AddrConv.bl_idname, 

--- a/fast64_internal/sm64/__init__.py
+++ b/fast64_internal/sm64/__init__.py
@@ -1,3 +1,4 @@
+from ..panels import SM64_Panel
 from .sm64_f3d_writer import *
 from .sm64_geolayout_writer import *
 from .sm64_geolayout_parser import *
@@ -65,16 +66,9 @@ class SM64_AddrConv(bpy.types.Operator):
 			raisePluginError(self, e)
 			return {'CANCELLED'} # must return a set
 
-class SM64_FileSettingsPanel(bpy.types.Panel):
+class SM64_FileSettingsPanel(SM64_Panel):
 	bl_idname = "SM64_PT_file_settings"
 	bl_label = "SM64 File Settings"
-	bl_space_type = 'VIEW_3D'
-	bl_region_type = 'UI'
-	bl_category = 'SM64'
-
-	@classmethod
-	def poll(cls, context):
-		return True
 
 	# called every frame
 	def draw(self, context):
@@ -93,16 +87,9 @@ class SM64_FileSettingsPanel(bpy.types.Panel):
 		prop_split(col, context.scene, 'refreshVer', 'Decomp Func Map')
 		prop_split(col, context.scene, 'compressionFormat', 'Compression Format')
 
-class SM64_AddressConvertPanel(bpy.types.Panel):
+class SM64_AddressConvertPanel(SM64_Panel):
 	bl_idname = "SM64_PT_addr_conv"
 	bl_label = "SM64 Address Converter"
-	bl_space_type = 'VIEW_3D'
-	bl_region_type = 'UI'
-	bl_category = 'SM64'
-
-	@classmethod
-	def poll(cls, context):
-		return True
 
 	# called every frame
 	def draw(self, context):

--- a/fast64_internal/sm64/sm64_anim.py
+++ b/fast64_internal/sm64/sm64_anim.py
@@ -6,6 +6,7 @@ from math import pi
 from bpy.utils import register_class, unregister_class
 
 from ..utility import *
+from ..panels import SM64_Panel
 
 sm64_anim_types = {'ROTATE', 'TRANSLATE'}
 
@@ -703,16 +704,9 @@ class SM64_ExportAnimMario(bpy.types.Operator):
 
 		return {'FINISHED'} # must return a set
 
-class SM64_ExportAnimPanel(bpy.types.Panel):
+class SM64_ExportAnimPanel(SM64_Panel):
 	bl_idname = "SM64_PT_export_anim"
 	bl_label = "SM64 Animation Exporter"
-	bl_space_type = 'VIEW_3D'
-	bl_region_type = 'UI'
-	bl_category = 'SM64'
-
-	@classmethod
-	def poll(cls, context):
-		return True
 
 	# called every frame
 	def draw(self, context):
@@ -820,16 +814,9 @@ class SM64_ImportAnimMario(bpy.types.Operator):
 
 		return {'FINISHED'} # must return a set
 
-class SM64_ImportAnimPanel(bpy.types.Panel):
+class SM64_ImportAnimPanel(SM64_Panel):
 	bl_idname = "SM64_PT_import_anim"
 	bl_label = "SM64 Animation Importer"
-	bl_space_type = 'VIEW_3D'
-	bl_region_type = 'UI'
-	bl_category = 'SM64'
-
-	@classmethod
-	def poll(cls, context):
-		return True
 
 	# called every frame
 	def draw(self, context):

--- a/fast64_internal/sm64/sm64_anim.py
+++ b/fast64_internal/sm64/sm64_anim.py
@@ -6,7 +6,7 @@ from math import pi
 from bpy.utils import register_class, unregister_class
 
 from ..utility import *
-from ..panels import SM64_Panel
+from ..panels import SM64_Panel, sm64GoalImport
 
 sm64_anim_types = {'ROTATE', 'TRANSLATE'}
 
@@ -605,7 +605,7 @@ class SM64_ExportAnimMario(bpy.types.Operator):
 			applyRotation([armatureObj], 
 				math.radians(90), 'X')
 
-			if context.scene.animExportType == 'C':
+			if context.scene.fast64.sm64.exportType == 'C':
 				exportPath, levelName = getPathAndLevel(context.scene.animCustomExport, 
 					context.scene.animExportPath, context.scene.animLevelName, 
 					context.scene.animLevelOption)
@@ -616,7 +616,7 @@ class SM64_ExportAnimMario(bpy.types.Operator):
 					bpy.context.scene.animGroupName,
 					context.scene.animCustomExport, context.scene.animExportHeaderType, levelName)
 				self.report({'INFO'}, 'Success!')
-			elif context.scene.animExportType == 'Insertable Binary':
+			elif context.scene.fast64.sm64.exportType == 'Insertable Binary':
 				exportAnimationInsertableBinary(
 					bpy.path.abspath(context.scene.animInsertableBinaryPath),
 					armatureObj, context.scene.isDMAExport, 
@@ -707,15 +707,15 @@ class SM64_ExportAnimMario(bpy.types.Operator):
 class SM64_ExportAnimPanel(SM64_Panel):
 	bl_idname = "SM64_PT_export_anim"
 	bl_label = "SM64 Animation Exporter"
+	goal = "Export Object/Actor/Anim"
 
 	# called every frame
 	def draw(self, context):
 		col = self.layout.column()
 		propsAnimExport = col.operator(SM64_ExportAnimMario.bl_idname)
-		
-		col.prop(context.scene, 'animExportType')
+
 		col.prop(context.scene, 'loopAnimation')
-		if context.scene.animExportType == 'C':
+		if context.scene.fast64.sm64.exportType == 'C':
 			col.prop(context.scene, 'animCustomExport')
 			if context.scene.animCustomExport:
 				col.prop(context.scene, 'animExportPath')
@@ -737,7 +737,7 @@ class SM64_ExportAnimPanel(SM64_Panel):
 					context.scene.animName, context.scene.animLevelName,
 					context.scene.animLevelOption)
 
-		elif context.scene.animExportType == 'Insertable Binary':
+		elif context.scene.fast64.sm64.exportType == 'Insertable Binary':
 			col.prop(context.scene, 'isDMAExport')
 			col.prop(context.scene, 'animInsertableBinaryPath')
 		else:
@@ -817,6 +817,7 @@ class SM64_ImportAnimMario(bpy.types.Operator):
 class SM64_ImportAnimPanel(SM64_Panel):
 	bl_idname = "SM64_PT_import_anim"
 	bl_label = "SM64 Animation Importer"
+	goal = sm64GoalImport
 
 	# called every frame
 	def draw(self, context):
@@ -874,8 +875,6 @@ def sm64_anim_register():
 		name = '0x27 Command Address', default = '21CD00')
 	bpy.types.Scene.addr_0x28 = bpy.props.StringProperty(
 		name = '0x28 Command Address', default = '21CD08')
-	bpy.types.Scene.animExportType = bpy.props.EnumProperty(
-		items = enumExportType, name = 'Export', default = 'C')
 	bpy.types.Scene.animExportPath = bpy.props.StringProperty(
 		name = 'Directory', subtype = 'FILE_PATH')
 	bpy.types.Scene.animOverwriteDMAEntry = bpy.props.BoolProperty(
@@ -923,7 +922,6 @@ def sm64_anim_unregister():
 	del bpy.types.Scene.overwrite_0x28
 	del bpy.types.Scene.addr_0x27
 	del bpy.types.Scene.addr_0x28
-	del bpy.types.Scene.animExportType
 	del bpy.types.Scene.animExportPath
 	del bpy.types.Scene.animOverwriteDMAEntry
 	del bpy.types.Scene.animInsertableBinaryPath

--- a/fast64_internal/sm64/sm64_collision.py
+++ b/fast64_internal/sm64/sm64_collision.py
@@ -6,6 +6,7 @@ from .sm64_rom_tweaks import ExtendBank0x04
 import bpy, bmesh, os, math
 from io import BytesIO
 from ..utility import *
+from ..panels import SM64_Panel
 
 class CollisionVertex:
 	def __init__(self, position):
@@ -555,16 +556,9 @@ class SM64_ExportCollision(bpy.types.Operator):
 			raisePluginError(self, e)
 			return {'CANCELLED'} # must return a set
 
-class SM64_ExportCollisionPanel(bpy.types.Panel):
+class SM64_ExportCollisionPanel(SM64_Panel):
 	bl_idname = "SM64_PT_export_collision"
 	bl_label = "SM64 Collision Exporter"
-	bl_space_type = 'VIEW_3D'
-	bl_region_type = 'UI'
-	bl_category = 'SM64'
-
-	@classmethod
-	def poll(cls, context):
-		return True
 
 	# called every frame
 	def draw(self, context):

--- a/fast64_internal/sm64/sm64_collision.py
+++ b/fast64_internal/sm64/sm64_collision.py
@@ -3,7 +3,7 @@ from .sm64_objects import *
 from bpy.utils import register_class, unregister_class
 from .sm64_level_parser import parseLevelAtPointer
 from .sm64_rom_tweaks import ExtendBank0x04
-import bpy, bmesh, os, math
+import bpy, shutil, os, math
 from io import BytesIO
 from ..utility import *
 from ..panels import SM64_Panel
@@ -478,7 +478,7 @@ class SM64_ExportCollision(bpy.types.Operator):
 		
 		try:
 			applyRotation([obj], math.radians(90), 'X')
-			if context.scene.colExportType == 'C':
+			if context.scene.fast64.sm64.exportType == 'C':
 				exportPath, levelName = getPathAndLevel(context.scene.colCustomExport, 
 					context.scene.colExportPath, context.scene.colLevelName, 
 					context.scene.colLevelOption)
@@ -490,7 +490,7 @@ class SM64_ExportCollision(bpy.types.Operator):
 					bpy.context.scene.colName, context.scene.colCustomExport, context.scene.colExportRooms,
 					context.scene.colExportHeaderType, context.scene.colGroupName, levelName)
 				self.report({'INFO'}, 'Success!')
-			elif context.scene.colExportType == 'Insertable Binary':
+			elif context.scene.fast64.sm64.exportType == 'Insertable Binary':
 				exportCollisionInsertableBinary(obj, finalTransform, 
 					bpy.path.abspath(context.scene.colInsertableBinaryPath), 
 					False, context.scene.colIncludeChildren)
@@ -546,7 +546,7 @@ class SM64_ExportCollision(bpy.types.Operator):
 
 			applyRotation([obj], math.radians(-90), 'X')
 
-			if context.scene.colExportType == 'Binary':
+			if context.scene.fast64.sm64.exportType == 'Binary':
 				if romfileOutput is not None:
 					romfileOutput.close()
 				if tempROM is not None and os.path.exists(bpy.path.abspath(tempROM)):
@@ -559,16 +559,16 @@ class SM64_ExportCollision(bpy.types.Operator):
 class SM64_ExportCollisionPanel(SM64_Panel):
 	bl_idname = "SM64_PT_export_collision"
 	bl_label = "SM64 Collision Exporter"
+	goal = "Export Object/Actor/Anim"
 
 	# called every frame
 	def draw(self, context):
 		col = self.layout.column()
 		propsColE = col.operator(SM64_ExportCollision.bl_idname)
 
-		col.prop(context.scene, 'colExportType')
 		col.prop(context.scene, 'colIncludeChildren')
 		
-		if context.scene.colExportType == 'C':
+		if context.scene.fast64.sm64.exportType == 'C':
 			col.prop(context.scene, 'colExportRooms')
 			col.prop(context.scene, 'colCustomExport')
 			if context.scene.colCustomExport:
@@ -590,7 +590,7 @@ class SM64_ExportCollisionPanel(SM64_Panel):
 				writeBoxExportType(writeBox, context.scene.colExportHeaderType, 
 					context.scene.colName, context.scene.colLevelName, context.scene.colLevelOption)
 			
-		elif context.scene.colExportType == 'Insertable Binary':
+		elif context.scene.fast64.sm64.exportType == 'Insertable Binary':
 			col.prop(context.scene, 'colInsertableBinaryPath')
 		else:
 			prop_split(col, context.scene, 'colStartAddr', 'Start Address')
@@ -627,8 +627,6 @@ def sm64_col_register():
 	# Collision
 	bpy.types.Scene.colExportPath = bpy.props.StringProperty(
 		name = 'Directory', subtype = 'FILE_PATH')
-	bpy.types.Scene.colExportType = bpy.props.EnumProperty(
-		items = enumExportType, name = 'Export', default = 'C')
 	bpy.types.Scene.colExportLevel = bpy.props.EnumProperty(items = level_enums, 
 		name = 'Level Used By Collision', default = 'WF')
 	bpy.types.Scene.addr_0x2A = bpy.props.StringProperty(
@@ -683,7 +681,6 @@ def sm64_col_register():
 def sm64_col_unregister():
 	# Collision
 	del bpy.types.Scene.colExportPath
-	del bpy.types.Scene.colExportType
 	del bpy.types.Scene.colExportLevel
 	del bpy.types.Scene.addr_0x2A
 	del bpy.types.Scene.set_addr_0x2A

--- a/fast64_internal/sm64/sm64_f3d_parser.py
+++ b/fast64_internal/sm64/sm64_f3d_parser.py
@@ -1,5 +1,5 @@
 import bpy
-from ..panels import SM64_Panel
+from ..panels import SM64_Panel, sm64GoalImport
 from ..utility import *
 from ..f3d.f3d_parser import *
 from bpy.utils import register_class, unregister_class
@@ -54,6 +54,7 @@ class SM64_ImportDL(bpy.types.Operator):
 class SM64_ImportDLPanel(SM64_Panel):
 	bl_idname = "SM64_PT_import_dl"
 	bl_label = "SM64 DL Importer"
+	goal = sm64GoalImport
 
 	# called every frame
 	def draw(self, context):

--- a/fast64_internal/sm64/sm64_f3d_parser.py
+++ b/fast64_internal/sm64/sm64_f3d_parser.py
@@ -1,4 +1,5 @@
 import bpy
+from ..panels import SM64_Panel
 from ..utility import *
 from ..f3d.f3d_parser import *
 from bpy.utils import register_class, unregister_class
@@ -50,16 +51,9 @@ class SM64_ImportDL(bpy.types.Operator):
 			raisePluginError(self, e)
 			return {'CANCELLED'}
 
-class SM64_ImportDLPanel(bpy.types.Panel):
+class SM64_ImportDLPanel(SM64_Panel):
 	bl_idname = "SM64_PT_import_dl"
 	bl_label = "SM64 DL Importer"
-	bl_space_type = 'VIEW_3D'
-	bl_region_type = 'UI'
-	bl_category = 'SM64'
-
-	@classmethod
-	def poll(cls, context):
-		return True
 
 	# called every frame
 	def draw(self, context):

--- a/fast64_internal/sm64/sm64_f3d_writer.py
+++ b/fast64_internal/sm64/sm64_f3d_writer.py
@@ -7,10 +7,10 @@ from ..f3d.f3d_gbi import FMaterial
 from .sm64_texscroll import *
 from .sm64_utility import *
 from bpy.utils import register_class, unregister_class
-from .sm64_constants import level_enums, enumLevelNames
+from .sm64_constants import level_enums, enumLevelNames, level_pointers, defaultExtendSegment4, bank0Segment, insertableBinaryTypes
 from .sm64_level_parser import parseLevelAtPointer
 from .sm64_rom_tweaks import ExtendBank0x04
-from .sm64_constants import level_pointers, defaultExtendSegment4, bank0Segment
+
 
 enumHUDExportLocation = [
 	('HUD', 'HUD', 'Exports to src/game/hud.c'),
@@ -500,7 +500,7 @@ class SM64_ExportDL(bpy.types.Operator):
 		
 		try:
 			applyRotation([obj], math.radians(90), 'X')
-			if context.scene.DLExportType == 'C':
+			if context.scene.fast64.sm64.exportType == 'C':
 				exportPath, levelName = getPathAndLevel(context.scene.DLCustomExport, 
 					context.scene.DLExportPath, context.scene.DLLevelName, 
 					context.scene.DLLevelOption)
@@ -531,7 +531,7 @@ class SM64_ExportDL(bpy.types.Operator):
 				#p.sort_stats("cumulative").print_stats(2000)
 				self.report({'INFO'}, 'Success!')
 				
-			elif context.scene.DLExportType == 'Insertable Binary':
+			elif context.scene.fast64.sm64.exportType == 'Insertable Binary':
 				exportF3DtoInsertableBinary(
 					bpy.path.abspath(context.scene.DLInsertableBinaryPath),
 					finalTransform, obj, context.scene.f3d_type,
@@ -602,7 +602,7 @@ class SM64_ExportDL(bpy.types.Operator):
 			if context.mode != 'OBJECT':
 				bpy.ops.object.mode_set(mode = 'OBJECT')
 			applyRotation([obj], math.radians(-90), 'X')
-			if context.scene.DLExportType == 'Binary':
+			if context.scene.fast64.sm64.exportType == 'Binary':
 				if romfileOutput is not None:
 					romfileOutput.close()
 				if tempROM is not None and os.path.exists(bpy.path.abspath(tempROM)):
@@ -613,14 +613,14 @@ class SM64_ExportDL(bpy.types.Operator):
 class SM64_ExportDLPanel(SM64_Panel):
 	bl_idname = "SM64_PT_export_dl"
 	bl_label = "SM64 DL Exporter"
+	goal = 'Export Displaylist'
 
 	# called every frame
 	def draw(self, context):
 		col = self.layout.column()
 		propsDLE = col.operator(SM64_ExportDL.bl_idname)
 
-		col.prop(context.scene, 'DLExportType')
-		if context.scene.DLExportType == 'C':
+		if context.scene.fast64.sm64.exportType == 'C':
 			col.prop(context.scene, 'DLExportisStatic')
 			
 			
@@ -650,7 +650,7 @@ class SM64_ExportDLPanel(SM64_Panel):
 				writeBoxExportType(writeBox, context.scene.DLExportHeaderType, 
 					context.scene.DLName, context.scene.DLLevelName, context.scene.DLLevelOption)
 			
-		elif context.scene.DLExportType == 'Insertable Binary':
+		elif context.scene.fast64.sm64.exportType == 'Insertable Binary':
 			col.prop(context.scene, 'DLInsertableBinaryPath')
 		else:
 			prop_split(col, context.scene, 'DLExportStart', 'Start Address')
@@ -716,6 +716,8 @@ class UnlinkTexRect(bpy.types.Operator):
 class ExportTexRectDrawPanel(SM64_Panel):
 	bl_idname = "TEXTURE_PT_export_texrect"
 	bl_label = "SM64 UI Image Exporter"
+	goal = 'Export UI Image'
+	decomp_only = True
 
 	# called every frame
 	def draw(self, context):
@@ -867,8 +869,6 @@ def sm64_dl_writer_register():
 		name ='Geolayout Pointer', default = '132AA8')
 	bpy.types.Scene.overwriteGeoPtr = bpy.props.BoolProperty(
 		name = "Overwrite geolayout pointer", default = False)
-	bpy.types.Scene.DLExportType = bpy.props.EnumProperty(
-		items = enumExportType, name = 'Export', default = 'C')
 	bpy.types.Scene.DLExportPath = bpy.props.StringProperty(
 		name = 'Directory', subtype = 'FILE_PATH')
 	bpy.types.Scene.DLExportisStatic = bpy.props.BoolProperty(
@@ -916,7 +916,6 @@ def sm64_dl_writer_unregister():
 	del bpy.types.Scene.DLExportEnd
 	del bpy.types.Scene.DLExportGeoPtr
 	del bpy.types.Scene.overwriteGeoPtr
-	del bpy.types.Scene.DLExportType
 	del bpy.types.Scene.DLExportPath
 	del bpy.types.Scene.DLExportisStatic
 	del bpy.types.Scene.DLDefinePath

--- a/fast64_internal/sm64/sm64_f3d_writer.py
+++ b/fast64_internal/sm64/sm64_f3d_writer.py
@@ -1,5 +1,6 @@
 import shutil, copy, bpy, cProfile, pstats
 
+from ..panels import SM64_Panel
 from ..f3d.f3d_writer import *
 from ..f3d.f3d_material import *
 from ..f3d.f3d_gbi import FMaterial
@@ -609,16 +610,9 @@ class SM64_ExportDL(bpy.types.Operator):
 			raisePluginError(self, e)
 			return {'CANCELLED'} # must return a set
 
-class SM64_ExportDLPanel(bpy.types.Panel):
+class SM64_ExportDLPanel(SM64_Panel):
 	bl_idname = "SM64_PT_export_dl"
 	bl_label = "SM64 DL Exporter"
-	bl_space_type = 'VIEW_3D'
-	bl_region_type = 'UI'
-	bl_category = 'SM64'
-
-	@classmethod
-	def poll(cls, context):
-		return True
 
 	# called every frame
 	def draw(self, context):
@@ -719,16 +713,9 @@ class UnlinkTexRect(bpy.types.Operator):
 		context.scene.texrect.tex = None
 		return {'FINISHED'} # must return a set
 
-class ExportTexRectDrawPanel(bpy.types.Panel):
+class ExportTexRectDrawPanel(SM64_Panel):
 	bl_idname = "TEXTURE_PT_export_texrect"
 	bl_label = "SM64 UI Image Exporter"
-	bl_space_type = 'VIEW_3D'
-	bl_region_type = 'UI'
-	bl_category = 'SM64'
-
-	@classmethod
-	def poll(cls, context):
-		return True
 
 	# called every frame
 	def draw(self, context):

--- a/fast64_internal/sm64/sm64_geolayout_parser.py
+++ b/fast64_internal/sm64/sm64_geolayout_parser.py
@@ -11,6 +11,7 @@ from .sm64_constants import *
 from ..f3d.f3d_material import createF3DMat, update_preset_manual
 from ..f3d.f3d_parser import *
 from ..utility import *
+from ..panels import SM64_Panel
 
 blender_modes = {'OBJECT', 'BONE'}
 
@@ -1196,16 +1197,9 @@ class SM64_ImportGeolayout(bpy.types.Operator):
 			raisePluginError(self, e)
 			return {'CANCELLED'} # must return a set
 
-class SM64_ImportGeolayoutPanel(bpy.types.Panel):
+class SM64_ImportGeolayoutPanel(SM64_Panel):
 	bl_idname = "SM64_PT_import_geolayout"
 	bl_label = "SM64 Geolayout Importer"
-	bl_space_type = 'VIEW_3D'
-	bl_region_type = 'UI'
-	bl_category = 'SM64'
-
-	@classmethod
-	def poll(cls, context):
-		return True
 
 	# called every frame
 	def draw(self, context):

--- a/fast64_internal/sm64/sm64_geolayout_parser.py
+++ b/fast64_internal/sm64/sm64_geolayout_parser.py
@@ -11,7 +11,7 @@ from .sm64_constants import *
 from ..f3d.f3d_material import createF3DMat, update_preset_manual
 from ..f3d.f3d_parser import *
 from ..utility import *
-from ..panels import SM64_Panel
+from ..panels import SM64_Panel, sm64GoalImport
 
 blender_modes = {'OBJECT', 'BONE'}
 
@@ -1200,6 +1200,7 @@ class SM64_ImportGeolayout(bpy.types.Operator):
 class SM64_ImportGeolayoutPanel(SM64_Panel):
 	bl_idname = "SM64_PT_import_geolayout"
 	bl_label = "SM64 Geolayout Importer"
+	goal = sm64GoalImport
 
 	# called every frame
 	def draw(self, context):

--- a/fast64_internal/sm64/sm64_geolayout_writer.py
+++ b/fast64_internal/sm64/sm64_geolayout_writer.py
@@ -2098,7 +2098,7 @@ class SM64_ExportGeolayoutObject(ObjectDataExporter):
 
 			saveTextures = bpy.context.scene.saveTextures or bpy.context.scene.ignoreTextureRestrictions
 
-			if context.scene.geoExportType == 'C':
+			if context.scene.fast64.sm64.exportType == 'C':
 				exportPath, levelName = getPathAndLevel(context.scene.geoCustomExport,
 					context.scene.geoExportPath, context.scene.geoLevelName,
 					context.scene.geoLevelOption)
@@ -2114,7 +2114,7 @@ class SM64_ExportGeolayoutObject(ObjectDataExporter):
 					context.scene.geoExportHeaderType,
 					context.scene.geoName, context.scene.geoStructName, levelName, context.scene.geoCustomExport, DLFormat.Static)
 				self.report({'INFO'}, 'Success!')
-			elif context.scene.geoExportType == 'Insertable Binary':
+			elif context.scene.fast64.sm64.exportType == 'Insertable Binary':
 				exportGeolayoutObjectInsertableBinary(obj,
 					finalTransform, context.scene.f3d_type,
 					context.scene.isHWv1,
@@ -2201,7 +2201,7 @@ class SM64_ExportGeolayoutObject(ObjectDataExporter):
 			self.cleanup_temp_object_data()
 			applyRotation([obj], math.radians(-90), 'X')
 
-			if context.scene.geoExportType == 'Binary':
+			if context.scene.fast64.sm64.exportType == 'Binary':
 				if romfileOutput is not None:
 					romfileOutput.close()
 				if tempROM is not None and os.path.exists(bpy.path.abspath(tempROM)):
@@ -2281,7 +2281,7 @@ class SM64_ExportGeolayoutArmature(bpy.types.Operator):
 			bpy.context.view_layer.objects.active = obj
 			bpy.ops.object.transform_apply(location = False, rotation = True,
 				scale = True, properties =  False)
-			if context.scene.geoExportType == 'C':
+			if context.scene.fast64.sm64.exportType == 'C':
 				exportPath, levelName = getPathAndLevel(context.scene.geoCustomExport,
 					context.scene.geoExportPath, context.scene.geoLevelName,
 					context.scene.geoLevelOption)
@@ -2299,7 +2299,7 @@ class SM64_ExportGeolayoutArmature(bpy.types.Operator):
 					context.scene.geoName, context.scene.geoStructName, levelName, context.scene.geoCustomExport, DLFormat.Static)
 				starSelectWarning(self, fileStatus)
 				self.report({'INFO'}, 'Success!')
-			elif context.scene.geoExportType == 'Insertable Binary':
+			elif context.scene.fast64.sm64.exportType == 'Insertable Binary':
 				exportGeolayoutArmatureInsertableBinary(armatureObj, obj,
 					finalTransform, context.scene.f3d_type,
 					context.scene.isHWv1,
@@ -2385,7 +2385,7 @@ class SM64_ExportGeolayoutArmature(bpy.types.Operator):
 			applyRotation([armatureObj] + linkedArmatures,
 				math.radians(-90), 'X')
 
-			if context.scene.geoExportType == 'Binary':
+			if context.scene.fast64.sm64.exportType == 'Binary':
 				if romfileOutput is not None:
 					romfileOutput.close()
 				if tempROM is not None and os.path.exists(bpy.path.abspath(tempROM)):
@@ -2399,6 +2399,7 @@ class SM64_ExportGeolayoutArmature(bpy.types.Operator):
 class SM64_ExportGeolayoutPanel(SM64_Panel):
 	bl_idname = "SM64_PT_export_geolayout"
 	bl_label = "SM64 Geolayout Exporter"
+	goal = 'Export Object/Actor/Anim'
 
 	# called every frame
 	def draw(self, context):
@@ -2406,8 +2407,7 @@ class SM64_ExportGeolayoutPanel(SM64_Panel):
 		propsGeoE = col.operator(SM64_ExportGeolayoutArmature.bl_idname)
 		propsGeoE = col.operator(SM64_ExportGeolayoutObject.bl_idname)
 
-		col.prop(context.scene, 'geoExportType')
-		if context.scene.geoExportType == 'C':
+		if context.scene.fast64.sm64.exportType == 'C':
 			if not bpy.context.scene.ignoreTextureRestrictions and context.scene.saveTextures:
 				if context.scene.geoCustomExport:
 					prop_split(col, context.scene, 'geoTexDir', 'Texture Include Path')	
@@ -2496,7 +2496,7 @@ class SM64_ExportGeolayoutPanel(SM64_Panel):
 					context.scene.geoLevelOption)
 
 			#extendedRAMLabel(col)
-		elif context.scene.geoExportType == 'Insertable Binary':
+		elif context.scene.fast64.sm64.exportType == 'Insertable Binary':
 			col.prop(context.scene, 'geoInsertableBinaryPath')
 		else:
 			prop_split(col, context.scene, 'geoExportStart', 'Start Address')
@@ -2556,8 +2556,6 @@ def sm64_geo_writer_register():
 		name = 'Dump geolayout as text', default = False)
 	bpy.types.Scene.textDumpGeoPath =  bpy.props.StringProperty(
 		name ='Text Dump Path', subtype = 'FILE_PATH')
-	bpy.types.Scene.geoExportType = bpy.props.EnumProperty(
-		items = enumExportType, name = 'Export', default = 'C')
 	bpy.types.Scene.geoExportPath = bpy.props.StringProperty(
 		name = 'Directory', subtype = 'FILE_PATH')
 	bpy.types.Scene.geoUseBank0 = bpy.props.BoolProperty(name = 'Use Bank 0')
@@ -2606,7 +2604,6 @@ def sm64_geo_writer_unregister():
 	del bpy.types.Scene.modelID
 	del bpy.types.Scene.textDumpGeo
 	del bpy.types.Scene.textDumpGeoPath
-	del bpy.types.Scene.geoExportType
 	del bpy.types.Scene.geoExportPath
 	del bpy.types.Scene.geoUseBank0
 	del bpy.types.Scene.geoRAMAddr

--- a/fast64_internal/sm64/sm64_geolayout_writer.py
+++ b/fast64_internal/sm64/sm64_geolayout_writer.py
@@ -17,6 +17,7 @@ from .sm64_utility import *
 
 from ..utility import *
 from ..operators import ObjectDataExporter
+from ..panels import SM64_Panel
 
 def appendSecondaryGeolayout(geoDirPath, geoName1, geoName2, additionalNode = ''):
 	geoPath = os.path.join(geoDirPath, 'geo.inc.c')
@@ -2395,16 +2396,9 @@ class SM64_ExportGeolayoutArmature(bpy.types.Operator):
 			raisePluginError(self, e)
 			return {'CANCELLED'} # must return a set
 
-class SM64_ExportGeolayoutPanel(bpy.types.Panel):
+class SM64_ExportGeolayoutPanel(SM64_Panel):
 	bl_idname = "SM64_PT_export_geolayout"
 	bl_label = "SM64 Geolayout Exporter"
-	bl_space_type = 'VIEW_3D'
-	bl_region_type = 'UI'
-	bl_category = 'SM64'
-
-	@classmethod
-	def poll(cls, context):
-		return True
 
 	# called every frame
 	def draw(self, context):

--- a/fast64_internal/sm64/sm64_level_writer.py
+++ b/fast64_internal/sm64/sm64_level_writer.py
@@ -10,6 +10,7 @@ from .sm64_texscroll import *
 from .sm64_utility import *
 
 from ..utility import *
+from ..panels import SM64_Panel
 from ..operators import ObjectDataExporter
 
 levelDefineArgs = {
@@ -1024,16 +1025,9 @@ class SM64_ExportLevel(ObjectDataExporter):
 			raisePluginError(self, e)
 			return {'CANCELLED'} # must return a set
 
-class SM64_ExportLevelPanel(bpy.types.Panel):
+class SM64_ExportLevelPanel(SM64_Panel):
 	bl_idname = "SM64_PT_export_level"
 	bl_label = "SM64 Level Exporter"
-	bl_space_type = 'VIEW_3D'
-	bl_region_type = 'UI'
-	bl_category = 'SM64'
-
-	@classmethod
-	def poll(cls, context):
-		return True
 
 	# called every frame
 	def draw(self, context):

--- a/fast64_internal/sm64/sm64_level_writer.py
+++ b/fast64_internal/sm64/sm64_level_writer.py
@@ -1028,6 +1028,8 @@ class SM64_ExportLevel(ObjectDataExporter):
 class SM64_ExportLevelPanel(SM64_Panel):
 	bl_idname = "SM64_PT_export_level"
 	bl_label = "SM64 Level Exporter"
+	goal = 'Export Level'
+	decomp_only = True
 
 	# called every frame
 	def draw(self, context):


### PR DESCRIPTION
# Notable code changes
I added property groups for SM64/OOT/General Settings! We should try to migrate over to using these props. I started migration in SM64 by having the C/binary/insertable binary option be in the main file settings. I also have functions in place for migrating over previously chosen options.

Panel base classes! There are base OOT and SM64 panels, they both use the `poll` method to only show if the respective game is selected in the main Fast64 tab.

## Default Fast64 tab
(note: OOT/SM64 Tabs hidden if not the selected game)

![image](https://user-images.githubusercontent.com/79979276/133792038-62adf110-84a4-4bb4-aea3-1114390f706c.png)

___
___

## OOT:
Everything defaults to being closed, except for file settings

![image](https://user-images.githubusercontent.com/79979276/133792329-bc965dc9-8fb7-4d44-b9a4-a9a079b93543.png)


___
___

## SM64:
Like OOT, everything defaults closed except for the top two panels. The first panel controls whether or not the other panels are visible. I did not do this with OOT because there were only 6 pretty straightforward tabs.

![image](https://user-images.githubusercontent.com/79979276/133792571-8b1ad114-bac5-49ad-85bf-d59f00aa543a.png)
