### PR TITLE
SM64 Added ability to use a custom animated bone

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -257,6 +257,14 @@ class Fast64_Properties(bpy.types.PropertyGroup):
 	oot: bpy.props.PointerProperty(type=OOT_Properties, name="OOT Properties")
 	settings: bpy.props.PointerProperty(type=Fast64Settings_Properties, name="Fast64 Settings")
 
+class Fast64_BoneProperties(bpy.types.PropertyGroup):
+	'''
+	Properties in bone.fast64.
+	All new bone properties should be children of this property group.
+	'''
+	sm64: bpy.props.PointerProperty(type=SM64_BoneProperties, name="SM64 Properties")
+
+
 #def updateGameEditor(scene, context):
 #	if scene.currentGameEditorMode == 'SM64':
 #		sm64_panel_unregister()
@@ -277,6 +285,7 @@ class Fast64_Properties(bpy.types.PropertyGroup):
 classes = (
 	Fast64Settings_Properties,
 	Fast64_Properties,
+	Fast64_BoneProperties,
 
 	ArmatureApplyWithMesh,
 	AddBoneGroups,
@@ -332,6 +341,8 @@ def register():
 	bpy.types.Scene.blenderF3DScale = bpy.props.FloatProperty(name = "F3D Blender Scale", default = 100)
 
 	bpy.types.Scene.fast64 = bpy.props.PointerProperty(type=Fast64_Properties, name="Fast64 Properties")
+	bpy.types.Bone.fast64 = bpy.props.PointerProperty(type=Fast64_BoneProperties, name="Fast64 Bone Properties")
+
 	bpy.app.handlers.load_post.append(after_load)
 
 # called on add-on disabling
@@ -355,6 +366,7 @@ def unregister():
 	del bpy.types.Scene.blenderF3DScale
 
 	del bpy.types.Scene.fast64
+	del bpy.types.Bone.fast64
 
 	for cls in classes:
 		unregister_class(cls)

--- a/__init__.py
+++ b/__init__.py
@@ -259,7 +259,7 @@ class Fast64_Properties(bpy.types.PropertyGroup):
 
 class Fast64_BoneProperties(bpy.types.PropertyGroup):
 	'''
-	Properties in bone.fast64.
+	Properties in bone.fast64 (bpy.types.Bone)
 	All new bone properties should be children of this property group.
 	'''
 	sm64: bpy.props.PointerProperty(type=SM64_BoneProperties, name="SM64 Properties")

--- a/fast64_internal/sm64/sm64_anim.py
+++ b/fast64_internal/sm64/sm64_anim.py
@@ -2,6 +2,7 @@ import bpy, mathutils, math, re, os, copy, shutil
 from .sm64_constants import *
 from .sm64_level_parser import parseLevelAtPointer
 from .sm64_rom_tweaks import ExtendBank0x04
+from .sm64_geolayout_bone import animatableBones
 from math import pi
 from bpy.utils import register_class, unregister_class
 
@@ -324,7 +325,7 @@ def convertAnimationData(anim, armatureObj, frameEnd):
 		bonesToProcess = bonesToProcess[1:]
 
 		# Only handle 0x13 bones for animation
-		if currentBone.geo_cmd == 'DisplayListWithOffset':
+		if currentBone.geo_cmd in animatableBones:
 			animBones.append(boneName)
 
 		# Traverse children in alphabetical order.
@@ -382,7 +383,7 @@ def getNextBone(boneStack, armatureObj):
 	boneStack = sorted([child.name for child in bone.children]) + boneStack
 
 	# Only return 0x13 bone
-	while armatureObj.data.bones[bone.name].geo_cmd != 'DisplayListWithOffset':
+	while armatureObj.data.bones[bone.name].geo_cmd not in animatableBones:
 		if len(boneStack) == 0:
 			raise PluginError("More bones in animation than on armature.")
 		bone = armatureObj.data.bones[boneStack[0]]
@@ -394,7 +395,7 @@ def getNextBone(boneStack, armatureObj):
 def importAnimationToBlender(romfile, startAddress, armatureObj, segmentData, isDMA):
 	boneStack = findStartBones(armatureObj)
 	startBoneName = boneStack[0]
-	if armatureObj.data.bones[startBoneName].geo_cmd != 'DisplayListWithOffset':
+	if armatureObj.data.bones[startBoneName].geo_cmd not in animatableBones:
 		startBone, boneStack = getNextBone(boneStack, armatureObj)
 		startBoneName = startBone.name
 		boneStack = [startBoneName] + boneStack

--- a/fast64_internal/sm64/sm64_anim.py
+++ b/fast64_internal/sm64/sm64_anim.py
@@ -2,7 +2,7 @@ import bpy, mathutils, math, re, os, copy, shutil
 from .sm64_constants import *
 from .sm64_level_parser import parseLevelAtPointer
 from .sm64_rom_tweaks import ExtendBank0x04
-from .sm64_geolayout_bone import animatableBones
+from .sm64_geolayout_bone import animatableBoneTypes
 from math import pi
 from bpy.utils import register_class, unregister_class
 
@@ -325,7 +325,7 @@ def convertAnimationData(anim, armatureObj, frameEnd):
 		bonesToProcess = bonesToProcess[1:]
 
 		# Only handle 0x13 bones for animation
-		if currentBone.geo_cmd in animatableBones:
+		if currentBone.geo_cmd in animatableBoneTypes:
 			animBones.append(boneName)
 
 		# Traverse children in alphabetical order.
@@ -383,7 +383,7 @@ def getNextBone(boneStack, armatureObj):
 	boneStack = sorted([child.name for child in bone.children]) + boneStack
 
 	# Only return 0x13 bone
-	while armatureObj.data.bones[bone.name].geo_cmd not in animatableBones:
+	while armatureObj.data.bones[bone.name].geo_cmd not in animatableBoneTypes:
 		if len(boneStack) == 0:
 			raise PluginError("More bones in animation than on armature.")
 		bone = armatureObj.data.bones[boneStack[0]]
@@ -395,7 +395,7 @@ def getNextBone(boneStack, armatureObj):
 def importAnimationToBlender(romfile, startAddress, armatureObj, segmentData, isDMA):
 	boneStack = findStartBones(armatureObj)
 	startBoneName = boneStack[0]
-	if armatureObj.data.bones[startBoneName].geo_cmd not in animatableBones:
+	if armatureObj.data.bones[startBoneName].geo_cmd not in animatableBoneTypes:
 		startBone, boneStack = getNextBone(boneStack, armatureObj)
 		startBoneName = startBone.name
 		boneStack = [startBoneName] + boneStack

--- a/fast64_internal/sm64/sm64_geolayout_bone.py
+++ b/fast64_internal/sm64/sm64_geolayout_bone.py
@@ -5,28 +5,30 @@ from ..utility import prop_split, PluginError
 from ..f3d.f3d_material import *
 
 enumBoneType = [
-	("Switch", "Switch (0x0E)", "Switch"), 
-	("Start", "Start (0x0B)", "Start"), 
-	("TranslateRotate", "Translate Rotate (0x10)", "Translate Rotate"), 
-	("Translate", "Translate (0x11)", "Translate"), 
-	("Rotate", "Rotate (0x12)", "Rotate"), 
-	("Billboard", "Billboard (0x14)", "Billboard"), 
-	("DisplayList", "Display List (0x15)", "Display List"), 
-	("Shadow", "Shadow (0x16)", "Shadow"), 
-	("Function", "Function (0x18)", "Function"), 
-	("HeldObject", "Held Object (0x1C)", "Held Object"), 
-	("Scale", "Scale (0x1D)", "Scale"), 
-	("StartRenderArea", "Start Render Area (0x20)", "Start Render Area"), 
-	("Ignore", "Ignore", "Ignore bones when exporting."), 
-	("SwitchOption", "Switch Option", "Switch Option"), 
-	("DisplayListWithOffset", "Display List With Offset (0x13)", 
-		"Display List With Offset"), 
+	("Switch", "Switch (0x0E)", "Switch"),
+	("Start", "Start (0x0B)", "Start"),
+	("TranslateRotate", "Translate Rotate (0x10)", "Translate Rotate"),
+	("Translate", "Translate (0x11)", "Translate"),
+	("Rotate", "Rotate (0x12)", "Rotate"),
+	("Billboard", "Billboard (0x14)", "Billboard"),
+	("DisplayList", "Display List (0x15)", "Display List"),
+	("Shadow", "Shadow (0x16)", "Shadow"),
+	("Function", "Function (0x18)", "Function"),
+	("HeldObject", "Held Object (0x1C)", "Held Object"),
+	("Scale", "Scale (0x1D)", "Scale"),
+	("StartRenderArea", "Start Render Area (0x20)", "Start Render Area"),
+	("Ignore", "Ignore", "Ignore bones when exporting."),
+	("SwitchOption", "Switch Option", "Switch Option"),
+	("DisplayListWithOffset", "Animated Part (0x13)", "Animated Part (Animatable Bone)"),
+	("CustomAnimated", "Custom Animated", "Custom Bone used for animation"),
+	("CustomNonAnimated", "Custom (Non-animated)", "Custom geolayout bone, non animated"),
 ]
+
+animatableBones = {"DisplayListWithOffset", "CustomAnimated"}
 
 enumGeoStaticType = [
 	("Billboard", "Billboard (0x14)", "Billboard"), 
-	("DisplayListWithOffset", "Display List With Offset (0x13)", 
-		"Display List With Offset"), 
+	("DisplayListWithOffset", "Animated Part (0x13)", "Animated Part (Animatable Bone)"),
 	("Optimal", "Optimal", "Optimal"),
 ]
 
@@ -60,7 +62,7 @@ enumMatOverrideOptions = [
 	("Specific", 'Specific', 'Only override instances of give material.'),
 ]
 
-def drawGeoInfo(panel, bone):
+def drawGeoInfo(panel: bpy.types.Panel, bone: bpy.types.Bone):
 	
 	panel.layout.box().label(text = 'Geolayout Inspector')
 	if bone is None:
@@ -72,16 +74,16 @@ def drawGeoInfo(panel, bone):
 	prop_split(col, bone, 'geo_cmd', 'Geolayout Command')
 
 	if bone.geo_cmd in ['TranslateRotate', 'Translate', 'Rotate', 
-		'Billboard', 'DisplayList', 'Scale', 'DisplayListWithOffset']:
+		'Billboard', 'DisplayList', 'Scale', 'DisplayListWithOffset', 'CustomAnimated']:
 		drawLayerWarningBox(col, bone, "draw_layer")
 
 	if bone.geo_cmd == 'Scale':
 		prop_split(col, bone, 'geo_scale', 'Scale')
 	
-	if bone.geo_cmd == 'HeldObject':
+	elif bone.geo_cmd == 'HeldObject':
 		prop_split(col, bone, 'geo_func', 'Function')
 	
-	if bone.geo_cmd == 'Switch':
+	elif bone.geo_cmd == 'Switch':
 		prop_split(col, bone, 'geo_func', 'Function')
 		prop_split(col, bone, 'func_param', 'Parameter')
 		col.label(text = 'Switch Option 0 is always this bone\'s children.')
@@ -89,35 +91,35 @@ def drawGeoInfo(panel, bone):
 		for i in range(len(bone.switch_options)):
 			drawSwitchOptionProperty(col, bone.switch_options[i], i)
 
-	if bone.geo_cmd == 'Function':
+	elif bone.geo_cmd == 'Function':
 		prop_split(col, bone, 'geo_func', 'Function')
 		prop_split(col, bone, 'func_param', 'Parameter')
 		infoBox2 = col.box()
 		infoBox2.label(text = 'This affects the next sibling bone in ' +\
 			'alphabetical order.')
 	
-	'''
-	if bone.geo_cmd == 'Function' or \
-		bone.geo_cmd == 'Switch' or \
-		bone.geo_cmd == 'HeldObject':
-		infoBox = col.box()
-		infoBox.label(text = 'For binary, this is a memory address.')
-		infoBox.label(text = 'For C, this is a function name.')
-	'''
-	
-	if bone.geo_cmd == 'TranslateRotate':
+	elif bone.geo_cmd == 'TranslateRotate':
 		prop_split(col, bone, 'field_layout', 'Field Layout')
 
-	if bone.geo_cmd == 'Shadow':
+	elif bone.geo_cmd == 'Shadow':
 		prop_split(col, bone, 'shadow_type', 'Type')
 		prop_split(col, bone, 'shadow_solidity', 'Alpha')
 		prop_split(col, bone, 'shadow_scale', 'Scale')
 	
-	if bone.geo_cmd == 'StartRenderArea':
+	elif bone.geo_cmd == 'StartRenderArea':
 		infoBoxRenderArea = col.box()
 		infoBoxRenderArea.label(text = "WARNING: This command is deprecated for bones.")
 		infoBoxRenderArea.label(text = 'See the object properties window for the armature instead.')
 		prop_split(col, bone, 'culling_radius', 'Culling Radius')
+	
+	elif bone.geo_cmd in {'CustomAnimated', 'CustomNonAnimated'}:
+		prop_split(col, bone.fast64.sm64, 'custom_geo_cmd_macro', 'Geo Command Macro')
+		if bone.geo_cmd == 'CustomNonAnimated':
+			prop_split(col, bone.fast64.sm64, 'custom_geo_cmd_args', 'Geo Command Args')
+		else: # It's animated
+			infobox = col.box()
+			infobox.label(text = "Command's args will be filled with layer, translate, and rotate", icon = "ERROR")
+			infobox.label(text = "e.g. `GEO_CUSTOM(layer, tX, tY, tZ, rX, rY, rZ, displayList)`")
 	
 	#if bone.geo_cmd == 'SwitchOption':
 	#	prop_split(col, bone, 'switch_bone', 'Switch Bone')
@@ -405,12 +407,19 @@ def updateBone(self, context):
 	armatureObj = context.object
 
 	createBoneGroups(armatureObj)
-	if context.bone.geo_cmd != 'DisplayListWithOffset':
+	if context.bone.geo_cmd not in animatableBones:
 		addBoneToGroup(armatureObj, context.bone.name, context.bone.geo_cmd)
 		bpy.ops.object.mode_set(mode="POSE")
 	else:
 		addBoneToGroup(armatureObj, context.bone.name, None)
 		bpy.ops.object.mode_set(mode="POSE")
+
+class SM64_BoneProperties(bpy.types.PropertyGroup):
+	version: bpy.props.IntProperty(name="SM64_BoneProperties Version", default=0)
+
+	custom_geo_cmd_macro: bpy.props.StringProperty(name="Geo Command Macro", default="GEO_BONE")
+	custom_geo_cmd_args: bpy.props.StringProperty(name="Geo Command Args", default="")
+
 
 sm64_bone_classes = (
 	AddSwitchOption,
@@ -420,6 +429,7 @@ sm64_bone_classes = (
 	MoveSwitchOption,
 	MaterialPointerProperty,
 	SwitchOptionProperty,
+	SM64_BoneProperties,
 )
 
 sm64_bone_panel_classes = (

--- a/fast64_internal/sm64/sm64_geolayout_bone.py
+++ b/fast64_internal/sm64/sm64_geolayout_bone.py
@@ -118,7 +118,7 @@ def drawGeoInfo(panel: bpy.types.Panel, bone: bpy.types.Bone):
 			prop_split(col, bone.fast64.sm64, 'custom_geo_cmd_args', 'Geo Command Args')
 		else: # It's animated
 			infobox = col.box()
-			infobox.label(text = "Command's args will be filled with layer, translate, and rotate", icon = "ERROR")
+			infobox.label(text = "Command's args will be filled with layer, translate, and rotate", icon = "INFO")
 			infobox.label(text = "e.g. `GEO_CUSTOM(layer, tX, tY, tZ, rX, rY, rZ, displayList)`")
 	
 	#if bone.geo_cmd == 'SwitchOption':

--- a/fast64_internal/sm64/sm64_geolayout_bone.py
+++ b/fast64_internal/sm64/sm64_geolayout_bone.py
@@ -24,7 +24,7 @@ enumBoneType = [
 	("CustomNonAnimated", "Custom (Non-animated)", "Custom geolayout bone, non animated"),
 ]
 
-animatableBones = {"DisplayListWithOffset", "CustomAnimated"}
+animatableBoneTypes = {"DisplayListWithOffset", "CustomAnimated"}
 
 enumGeoStaticType = [
 	("Billboard", "Billboard (0x14)", "Billboard"), 
@@ -407,7 +407,7 @@ def updateBone(self, context):
 	armatureObj = context.object
 
 	createBoneGroups(armatureObj)
-	if context.bone.geo_cmd not in animatableBones:
+	if context.bone.geo_cmd not in animatableBoneTypes:
 		addBoneToGroup(armatureObj, context.bone.name, context.bone.geo_cmd)
 		bpy.ops.object.mode_set(mode="POSE")
 	else:

--- a/fast64_internal/sm64/sm64_geolayout_classes.py
+++ b/fast64_internal/sm64/sm64_geolayout_classes.py
@@ -1095,6 +1095,37 @@ class CustomNode:
 	def to_c(self):
 		return f"{self.command}({self.args}),"
 
+class CustomAnimatedNode(BaseDisplayListNode):
+	def __init__(self, command: str, drawLayer, translate, rotate, dlRef: str = None):
+		self.command = command
+		self.drawLayer = drawLayer
+		self.hasDL = True
+		self.translate = translate
+		self.rotate = rotate
+		self.fMesh = None
+		self.DLmicrocode = None
+		self.dlRef = dlRef
+
+	def size(self):
+		return 16
+
+	def get_ptr_offsets(self):
+		return []
+
+	def to_binary(self, segmentData):
+		raise PluginError('Custom Geo Nodes are not supported for binary exports.')
+
+	def to_c(self):
+		args = [
+			getDrawLayerName(self.drawLayer),
+			str(convertFloatToShort(self.translate[0])),
+			str(convertFloatToShort(self.translate[1])),
+			str(convertFloatToShort(self.translate[2])),
+			*(str(radians_to_s16(r)) for r in self.rotate.to_euler('XYZ')),
+			self.get_dl_name() # This node requires 'NULL' if there is no DL
+		]
+		return f"{self.command}({join_c_args(args)}),"
+
 nodeGroupClasses = [
 	StartNode,
 	SwitchNode,
@@ -1112,7 +1143,8 @@ nodeGroupClasses = [
 	ZBufferNode,
 	CameraNode,
 	RenderRangeNode,
-	CustomNode
+	CustomNode,
+	CustomAnimatedNode
 ]
 
 DLNodes = [
@@ -1122,5 +1154,6 @@ DLNodes = [
 	RotateNode,
 	ScaleNode,
 	DisplayListNode,
-	DisplayListWithOffsetNode
+	DisplayListWithOffsetNode,
+	CustomAnimatedNode
 ]

--- a/fast64_internal/sm64/sm64_geolayout_utility.py
+++ b/fast64_internal/sm64/sm64_geolayout_utility.py
@@ -1,3 +1,4 @@
+from ..utility import PluginError
 import bpy
 
 def getBoneGroupByName(armatureObj, name):

--- a/fast64_internal/sm64/sm64_geolayout_writer.py
+++ b/fast64_internal/sm64/sm64_geolayout_writer.py
@@ -5,7 +5,7 @@ from os.path import basename
 from io import BytesIO
 
 from .sm64_objects import InlineGeolayoutObjConfig, inlineGeoLayoutObjects
-from .sm64_geolayout_bone import getSwitchOptionBone, animatableBones
+from .sm64_geolayout_bone import getSwitchOptionBone, animatableBoneTypes
 from .sm64_geolayout_constants import *
 from .sm64_geolayout_utility import *
 from .sm64_constants import *
@@ -1158,7 +1158,7 @@ def processBone(fModel, boneName, obj, armatureObj, transformMatrix,
 
 	#hasDL = bone.use_deform
 	hasDL = True
-	if bone.geo_cmd in animatableBones:
+	if bone.geo_cmd in animatableBoneTypes:
 		if bone.geo_cmd == 'CustomAnimated':
 			if not bone.fast64.sm64.custom_geo_cmd_macro:
 				raise PluginError(f'Bone "{boneName}" needs a geo command macro.')

--- a/fast64_internal/sm64/sm64_geolayout_writer.py
+++ b/fast64_internal/sm64/sm64_geolayout_writer.py
@@ -1161,7 +1161,7 @@ def processBone(fModel, boneName, obj, armatureObj, transformMatrix,
 	if bone.geo_cmd in animatableBoneTypes:
 		if bone.geo_cmd == 'CustomAnimated':
 			if not bone.fast64.sm64.custom_geo_cmd_macro:
-				raise PluginError(f'Bone "{boneName}" needs a geo command macro.')
+				raise PluginError(f'Bone "{boneName}" on armature "{armatureObj.name}" needs a geo command macro.')
 			node = CustomAnimatedNode(bone.fast64.sm64.custom_geo_cmd_macro, int(bone.draw_layer), translate, rotate)
 			lastTranslateName = boneName
 			lastRotateName = boneName
@@ -1184,7 +1184,7 @@ def processBone(fModel, boneName, obj, armatureObj, transformMatrix,
 
 	elif bone.geo_cmd == 'CustomNonAnimated':
 		if bone.fast64.sm64.custom_geo_cmd_macro == '':
-			raise PluginError(f'Bone "{boneName}" needs a geo command macro.')
+			raise PluginError(f'Bone "{boneName}" on armature "{armatureObj.name}" needs a geo command macro.')
 		node = CustomNode(bone.fast64.sm64.custom_geo_cmd_macro, bone.fast64.sm64.custom_geo_cmd_args)
 	elif bone.geo_cmd == 'Function':
 		if bone.geo_func == '':

--- a/fast64_internal/sm64/sm64_geolayout_writer.py
+++ b/fast64_internal/sm64/sm64_geolayout_writer.py
@@ -5,7 +5,7 @@ from os.path import basename
 from io import BytesIO
 
 from .sm64_objects import InlineGeolayoutObjConfig, inlineGeoLayoutObjects
-from .sm64_geolayout_bone import getSwitchOptionBone
+from .sm64_geolayout_bone import getSwitchOptionBone, animatableBones
 from .sm64_geolayout_constants import *
 from .sm64_geolayout_utility import *
 from .sm64_constants import *
@@ -1158,23 +1158,34 @@ def processBone(fModel, boneName, obj, armatureObj, transformMatrix,
 
 	#hasDL = bone.use_deform
 	hasDL = True
-	if bone.geo_cmd == 'DisplayListWithOffset':
-		if not zeroRotation:
-			node = DisplayListWithOffsetNode(int(bone.draw_layer),
-				hasDL, mathutils.Vector((0,0,0)))
-
-			parentTransformNode = addParentNode(parentTransformNode,
-				TranslateRotateNode(1, 0, False, translate, rotate))
-
+	if bone.geo_cmd in animatableBones:
+		if bone.geo_cmd == 'CustomAnimated':
+			if not bone.fast64.sm64.custom_geo_cmd_macro:
+				raise PluginError(f'Bone "{boneName}" needs a geo command macro.')
+			node = CustomAnimatedNode(bone.fast64.sm64.custom_geo_cmd_macro, int(bone.draw_layer), translate, rotate)
 			lastTranslateName = boneName
 			lastRotateName = boneName
-		else:
-			node = DisplayListWithOffsetNode(int(bone.draw_layer),
-				hasDL, translate)
-			lastTranslateName = boneName
+		else: # DisplayListWithOffset
+			if not zeroRotation:
+				node = DisplayListWithOffsetNode(int(bone.draw_layer),
+					hasDL, mathutils.Vector((0,0,0)))
+
+				parentTransformNode = addParentNode(parentTransformNode,
+					TranslateRotateNode(1, 0, False, translate, rotate))
+
+				lastTranslateName = boneName
+				lastRotateName = boneName
+			else:
+				node = DisplayListWithOffsetNode(int(bone.draw_layer),
+					hasDL, translate)
+				lastTranslateName = boneName
 
 		finalTransform = transformMatrix @ translation
 
+	elif bone.geo_cmd == 'CustomNonAnimated':
+		if bone.fast64.sm64.custom_geo_cmd_macro == '':
+			raise PluginError(f'Bone "{boneName}" needs a geo command macro.')
+		node = CustomNode(bone.fast64.sm64.custom_geo_cmd_macro, bone.fast64.sm64.custom_geo_cmd_args)
 	elif bone.geo_cmd == 'Function':
 		if bone.geo_func == '':
 			raise PluginError('Function bone ' + boneName + ' function value is empty.')

--- a/fast64_internal/utility.py
+++ b/fast64_internal/utility.py
@@ -401,6 +401,14 @@ def convertRadiansToS16(value):
 	value = 360 - (value % 360)
 	return hex(round(value / 360 * 0xFFFF))
 
+def correct_to_bits(value: int, bits: int, signed: bool):
+    base = 1 << bits
+    value %= base
+    return value - base if signed and value.bit_length() == bits else value
+
+to_s16 = lambda x: correct_to_bits(round(x), 16, True)
+radians_to_s16 = lambda d: to_s16(math.degrees(d) * 0x10000 / 360)
+
 def decompFolderMessage(layout):
 	layout.box().label(text = 'This will export to your decomp folder.')
 

--- a/fast64_internal/utility.py
+++ b/fast64_internal/utility.py
@@ -401,12 +401,12 @@ def convertRadiansToS16(value):
 	value = 360 - (value % 360)
 	return hex(round(value / 360 * 0xFFFF))
 
-def correct_to_bits(value: int, bits: int, signed: bool):
+def correct_to_size(value: int, bits: int, signed: bool):
     base = 1 << bits
     value %= base
     return value - base if signed and value.bit_length() == bits else value
 
-to_s16 = lambda x: correct_to_bits(round(x), 16, True)
+to_s16 = lambda x: correct_to_size(round(x), 16, True)
 radians_to_s16 = lambda d: to_s16(math.degrees(d) * 0x10000 / 360)
 
 def decompFolderMessage(layout):

--- a/fast64_internal/utility.py
+++ b/fast64_internal/utility.py
@@ -401,13 +401,13 @@ def convertRadiansToS16(value):
 	value = 360 - (value % 360)
 	return hex(round(value / 360 * 0xFFFF))
 
-def correct_to_size(value: int, bits: int, signed: bool):
-    base = 1 << bits
-    value %= base
-    return value - base if signed and value.bit_length() == bits else value
+def cast_integer(value: int, bits: int, signed: bool):
+    wrap = 1 << bits
+    value %= wrap
+    return value - wrap if signed and value & (1 << (bits - 1)) else value
 
-to_s16 = lambda x: correct_to_size(round(x), 16, True)
-radians_to_s16 = lambda d: to_s16(math.degrees(d) * 0x10000 / 360)
+to_s16 = lambda x: cast_integer(round(x), 16, True)
+radians_to_s16 = lambda d: to_s16(d * 0x10000 / (2 * math.pi))
 
 def decompFolderMessage(layout):
 	layout.box().label(text = 'This will export to your decomp folder.')


### PR DESCRIPTION
Also added general props for SM64 Bones.

So the new Custom Animated Bone.
It allows you to specify a bone's geo command macro, and defaults to `GEO_BONE`. The params are automatically filled out with layer, translation, rotation, and DL. a custom bone like this can reduce the number of matrix calculations in an armature by half, so a massive performance boost for those who use or create a custom geolayout command to work with this. I created one myself, and its currently in a [couple hacking sm64 repos](https://github.com/CrashOveride95/ultrasm64/pull/23)