### PR TITLE
Fixed skeleton regex

### DIFF
--- a/fast64_internal/oot/oot_skeleton.py
+++ b/fast64_internal/oot/oot_skeleton.py
@@ -442,7 +442,7 @@ class OOTDLEntry:
 def ootGetSkeleton(skeletonData, skeletonName, continueOnError):
 	# TODO: Does this handle non flex skeleton?
 	matchResult = re.search("(Flex)?SkeletonHeader\s*" + re.escape(skeletonName) + \
-		"\s*=\s*\{\s*([^,\s]*)\s*,\s*([^,\s]*)\s*(,\s*([^,\s]*))?\s*\}\s*;\s*", skeletonData)
+		"\s*=\s*\{\s*\{?\s*([^,\s]*)\s*,\s*([^,\s\}]*)\s*\}?\s*(,\s*([^,\s]*))?\s*\}\s*;\s*", skeletonData)
 	if matchResult is None:
 		if continueOnError:
 			return None


### PR DESCRIPTION
fast64 uses a regex to detect and parse a skeleton header definition from C. The existing regex matches only old decomp formatting which is missing braces from the struct definition. The new regex matches both the old style and the new style.