### PR TITLE
Fixed another animation regex

### DIFF
--- a/fast64_internal/oot/oot_anim.py
+++ b/fast64_internal/oot/oot_anim.py
@@ -265,7 +265,7 @@ def getJointIndices(filepath, animData, jointIndicesName):
 	if matchResult is None:
 		raise PluginError("Cannot find animation joint indices data named " + jointIndicesName + " in " + filepath)
 	data = matchResult.group(1)
-	jointIndicesData = [[hexOrDecInt(match.group(i)) for i in range(1,4)] for match in re.finditer("\{([^,\}]*),([^,\}]*),([^,\}]*)\}", data, re.DOTALL)]
+	jointIndicesData = [[hexOrDecInt(match.group(i)) for i in range(1,4)] for match in re.finditer("\{([^,\}]*),([^,\}]*),([^,\}]*)\s*,?\s*\}", data, re.DOTALL)]
 
 	return jointIndicesData
 


### PR DESCRIPTION
fast64 exports animation joint indices like this:
```
{ 0x0000, 0x0001, 0x0000, },
```
But that format was not accepted for import, due to the trailing comma and space within the braces. This is now fixed and animations can be exported and then re-imported correctly.