### PR TITLE
Fix remove trailing frames

### DIFF
--- a/fast64_internal/oot/oot_anim.py
+++ b/fast64_internal/oot/oot_anim.py
@@ -34,7 +34,7 @@ class OOTAnimation:
 				data.source += '\t'
 			data.source += format(value, '#06x') + ", "
 			counter += 1
-			if counter > 14:
+			if counter >= 16: # round number for finding/counting data
 				counter = 0
 				data.source += '\n'
 		data.source += '};\n\n'
@@ -112,9 +112,9 @@ def ootConvertAnimationData(anim, armatureObj, frameInterval, restPoseRotations,
 			saveQuaternionFrame(rotationData[boneIndex], restPoseRotations[boneName].inverted() @ rotationValue)
 	
 	bpy.context.scene.frame_set(currentFrame)
-	removeTrailingFrames(translationData)
+	squashFramesIfAllSame(translationData)
 	for frameData in rotationData:
-		removeTrailingFrames(frameData)
+		squashFramesIfAllSame(frameData)
 
 	# need to deepcopy?
 	armatureFrameData = translationData

--- a/fast64_internal/utility_anim.py
+++ b/fast64_internal/utility_anim.py
@@ -24,6 +24,19 @@ def removeTrailingFrames(frameData):
 			else:
 				break
 		frameData[i].frames = frameData[i].frames[:lastUniqueFrame + 1]
+		
+def squashFramesIfAllSame(frameData):
+	for i in range(3):
+		if len(frameData[i].frames) < 2:
+			continue
+		f0 = frameData[i].frames[0]
+		for j in range(1, len(frameData[i].frames)):
+			d = abs(frameData[i].frames[j] - f0)
+			# Allow a change of +/-1 from original frame due to rounding.
+			if d >= 2 and d != 0xFFFF:
+				break
+		else:
+			frameData[i].frames = frameData[i].frames[0:1]
 
 def saveTranslationFrame(frameData, translation):
 	for i in range(3):


### PR DESCRIPTION
OoT animation export code used to call `removeTrailingFrames`, which would cut down each channel (pitch/roll/yaw) of each bone's frame data (translation for root, otherwise rotation) to only the first unique frames. So, for example, if there were 5 frames and the first 3 were unique but the last two were the same as the previous frame, it would reduce the length of the sequence to 3.

This is simply incorrect. There is no mechanism for handling this kind of early stopping of the frame data in OoT skelanime code. There is a mechanism for frame data which is all the same--i.e. length 1 after the removal of trailing frames. However, if the frame data is more than length 1, OoT assumes it is the length of the animation. Animations exported with fast64 which have some bones not move near the end of the animation (thus leading to a reduced number of frames, but greater than length 1) play back incorrectly in game, with corrupted rotations due to reading off the end of the frame data into other frames' data or whatever is next in memory.

It looks like the use of `removeTrailingFrames` was copied from SM64 animation code.

This PR makes the OoT code call a new function, which checks if all the frames are the same except due to rounding errors, and if so reduces the length to 1. This has the additional benefit of avoiding frame data exported as `0x0000, 0xFFFF, 0x0000, 0xFFFF` due to random rounding errors, where this is practically identical to all zeros. This new version has been tested both in game and by re-importing the animation with fast64, and works in both tests.

Note that this PR is dependent on the regex fix one, simply because it was too much of a hassle for me to repeatedly save an intermediate project, close Blender, change branches, and reopen Blender to test this.