### PR TITLE
Fix importing displaylists for OoT

### DIFF
--- a/fast64_internal/f3d/f3d_parser.py
+++ b/fast64_internal/f3d/f3d_parser.py
@@ -1580,7 +1580,7 @@ def parseF3D(dlData, dlName, obj, transformMatrix, limbName, boneName, drawLayer
 	f3dContext.processCommands(dlData, dlName, dlCommands)
 
 def parseDLData(dlData, dlName):
-	matchResult = re.search("Gfx\s*" + re.escape(dlName) + "\s*\[\s*\]\s*=\s*\{([^\}]*)\}", dlData)
+	matchResult = re.search("Gfx\s*" + re.escape(dlName) + "\s*\[\s*\w*\s*\]\s*=\s*\{([^\}]*)\}", dlData)
 	if matchResult is None:
 		raise PluginError("Cannot find display list named " + dlName)
 


### PR DESCRIPTION
For some reason ZAPD made a very strange change regarding displaylists. This new regex makes it so displaylists can be imported again, however I am unsure why ZAPD made the change it did to begin with.