### PR TITLE
Don't separate OoT limbs into normal and skinned DLs

### DIFF
--- a/fast64_internal/f3d/f3d_writer.py
+++ b/fast64_internal/f3d/f3d_writer.py
@@ -827,7 +827,7 @@ class TriangleConverter:
 
 	def addFace(self, face):
 		triIndices = []
-		existingVerts = []
+		#existingVerts = [] # set but never read
 		addedVerts = [] # verts added to existing vertexBuffer
 		allVerts = [] # all verts not in 'untouched' buffer region
 
@@ -841,10 +841,11 @@ class TriangleConverter:
 				addedVerts.append(bufferVert)
 
 			if bufferVert in self.vertBuffer[:self.bufferStart]:
-				existingVerts.append(bufferVert)
+				#existingVerts.append(bufferVert)
+				pass
 			else:
 				allVerts.append(bufferVert)
-				existingVerts.append(None)
+				#existingVerts.append(None)
 
 		# We care only about load size, since loading is what takes up time.
 		# Even if vert_buffer is larger, its still another load to fill it.

--- a/fast64_internal/f3d/f3d_writer.py
+++ b/fast64_internal/f3d/f3d_writer.py
@@ -827,7 +827,6 @@ class TriangleConverter:
 
 	def addFace(self, face):
 		triIndices = []
-		#existingVerts = [] # set but never read
 		addedVerts = [] # verts added to existing vertexBuffer
 		allVerts = [] # all verts not in 'untouched' buffer region
 
@@ -840,12 +839,8 @@ class TriangleConverter:
 			if not self.vertInBuffer(bufferVert, face.material_index):
 				addedVerts.append(bufferVert)
 
-			if bufferVert in self.vertBuffer[:self.bufferStart]:
-				#existingVerts.append(bufferVert)
-				pass
-			else:
+			if bufferVert not in self.vertBuffer[:self.bufferStart]:
 				allVerts.append(bufferVert)
-				#existingVerts.append(None)
 
 		# We care only about load size, since loading is what takes up time.
 		# Even if vert_buffer is larger, its still another load to fill it.

--- a/fast64_internal/oot/oot_f3d_writer.py
+++ b/fast64_internal/oot/oot_f3d_writer.py
@@ -15,7 +15,7 @@ from .oot_scene_room import *
 # 	mesh, 
 # 	anySkinnedFaces (to determine if skeleton should be flex)
 def ootProcessVertexGroup(fModel, meshObj, vertexGroup, convertTransformMatrix, armatureObj, namePrefix,
-	meshInfo, drawLayerOverride, convertTextureData):
+	meshInfo, drawLayerOverride, convertTextureData, parentGroupIndex):
 
 	mesh = meshObj.data
 	currentGroupIndex = getGroupIndexFromname(meshObj, vertexGroup)
@@ -32,8 +32,7 @@ def ootProcessVertexGroup(fModel, meshObj, vertexGroup, convertTransformMatrix, 
 	# dict of material_index keys to face array values
 	groupFaces = {}
 	
-	# dict of material_index keys to SkinnedFace objects
-	skinnedFaces = {}
+	hasSkinnedFaces = False
 
 	handledFaces = []
 	anyConnectedToUnhandledBone = False
@@ -45,41 +44,36 @@ def ootProcessVertexGroup(fModel, meshObj, vertexGroup, convertTransformMatrix, 
 			if face in handledFaces:
 				continue
 
-			sortedLoops = {} # (group tuple) : []
 			connectedToUnhandledBone = False
 
-			# loop is interpreted as face + loop index
-			groupTuple = []
+			# A Blender loop is interpreted as face + loop index
 			for i in range(3):
 				faceVertIndex = face.vertices[i]
 				vertGroupIndex = meshInfo.vertexGroupInfo.vertexGroups[faceVertIndex]
-				if vertGroupIndex not in groupTuple:
-					groupTuple.append(vertGroupIndex)
-				if vertGroupIndex not in meshInfo.vertexGroupInfo.vertexGroupToLimb:
-					# Only want to handle skinned faces connected to parent
+				if vertGroupIndex != currentGroupIndex:
+					hasSkinnedFaces = True
+				if vertGroupIndex in meshInfo.vertexGroupInfo.vertexGroupToLimb:
+					# Self or some parent
+					if vertGroupIndex not in {currentGroupIndex, parentGroupIndex}:
+						raise PluginError('Vertex group ' + vertexGroup 
+							+ ' has faces connected to groups besides its immediate parent!')
+				else:
+					# Connected to a bone not processed yet (hopefully, a child)
+					# These skinned faces will be handled by the child
 					connectedToUnhandledBone = True
 					anyConnectedToUnhandledBone = True
 					break
 			
 			if connectedToUnhandledBone:
 				continue
-			groupTuple = tuple(sorted(groupTuple))
 
-			if groupTuple == tuple([currentGroupIndex]):
-				if face.material_index not in groupFaces:
-					groupFaces[face.material_index] = []
-				groupFaces[face.material_index].append(face)
-			else:
-				if groupTuple not in skinnedFaces:
-					skinnedFaces[groupTuple] = {}
-				skinnedFacesGroup = skinnedFaces[groupTuple]
-				if face.material_index not in skinnedFacesGroup:
-					skinnedFacesGroup[face.material_index] = []
-				skinnedFacesGroup[face.material_index].append(face)
+			if face.material_index not in groupFaces:
+				groupFaces[face.material_index] = []
+			groupFaces[face.material_index].append(face)
 			
 			handledFaces.append(face)
 
-	if not (len(groupFaces) > 0 or len(skinnedFaces) > 0):
+	if len(groupFaces) == 0:
 		print("No faces in " + vertexGroup)
 
 		# OOT will only allocate matrix if DL exists.
@@ -94,65 +88,30 @@ def ootProcessVertexGroup(fModel, meshObj, vertexGroup, convertTransformMatrix, 
 			return None, False
 	
 	meshInfo.vertexGroupInfo.vertexGroupToMatrixIndex[currentGroupIndex] = nextDLIndex
-	fMeshes = {}
 	triConverterInfo = OOTTriangleConverterInfo(meshObj, armatureObj.data, fModel.f3d, convertTransformMatrix, meshInfo)
 
 	# Usually we would separate DLs into different draw layers.
 	# however it seems like OOT skeletons don't have this ability.
 	# Therefore we always use the drawLayerOverride as the draw layer key.
 	# This means everything will be saved to one mesh. 
-	drawLayerKey = drawLayerOverride
+	fMesh = fModel.addMesh(vertexGroup, namePrefix, drawLayerOverride, False, bone)
+	
 	for material_index, faces in groupFaces.items():
 		material = meshObj.material_slots[material_index].material
-		#if material.mat_ver > 3:
-		#	drawLayer = material.f3d_mat.draw_layer.oot
-		#else:
-		#	drawLayer = drawLayerOverride
-		drawLayer = drawLayerOverride
-		
-		if drawLayerKey not in fMeshes:
-			fMesh = fModel.addMesh(vertexGroup, namePrefix, drawLayer, False, bone)
-			fMeshes[drawLayerKey] = fMesh
-			
 		checkForF3dMaterialInFaces(meshObj, material)
 		fMaterial, texDimensions = \
-			saveOrGetF3DMaterial(material, fModel, meshObj, drawLayer, convertTextureData)
+			saveOrGetF3DMaterial(material, fModel, meshObj, drawLayerOverride, convertTextureData)
 
 		if fMaterial.useLargeTextures:
-			currentGroupIndex = saveMeshWithLargeTexturesByFaces(material, faces, fModel, fMeshes[drawLayer],
-				meshObj, drawLayer, convertTextureData, currentGroupIndex, triConverterInfo, None, None)
+			currentGroupIndex = saveMeshWithLargeTexturesByFaces(material, faces, fModel, fMesh,
+				meshObj, drawLayerOverride, convertTextureData, currentGroupIndex, triConverterInfo, None, None)
 		else:
-			currentGroupIndex = saveMeshByFaces(material, faces, fModel, fMeshes[drawLayer], 
-				meshObj, drawLayer, convertTextureData, currentGroupIndex, triConverterInfo, None, None)
+			currentGroupIndex = saveMeshByFaces(material, faces, fModel, fMesh, 
+				meshObj, drawLayerOverride, convertTextureData, currentGroupIndex, triConverterInfo, None, None)
 
-	for groupTuple, materialFaces in skinnedFaces.items():
-		for material_index, faces in materialFaces.items():
-			material = meshObj.material_slots[material_index].material
-			#if material.mat_ver > 3:
-			#	drawLayer = material.f3d_mat.draw_layer.oot
-			#else:
-			#	drawLayer = drawLayerOverride
-			drawLayer = drawLayerOverride
+	fModel.endDraw(fMesh, bone)
 
-			if drawLayerKey not in fMeshes:
-				# technically skinned, but for oot we don't have separate skinned/unskinned meshes.
-				fMesh = fModel.addMesh(vertexGroup, namePrefix, drawLayer, False, bone)
-				fMeshes[drawLayerKey] = fMesh
-
-			checkForF3dMaterialInFaces(meshObj, material)
-			fMaterial, texDimensions = \
-				saveOrGetF3DMaterial(material, fModel, meshObj, drawLayer, convertTextureData)
-			if fMaterial.useLargeTextures:
-				currentGroupIndex = saveMeshWithLargeTexturesByFaces(material, faces, fModel, fMeshes[drawLayer], 
-					meshObj, drawLayer, convertTextureData, currentGroupIndex, triConverterInfo, None, None)
-			else:
-				currentGroupIndex = saveMeshByFaces(material, faces, fModel, fMeshes[drawLayer], 
-					meshObj, drawLayer, convertTextureData, currentGroupIndex, triConverterInfo, None, None)
-
-	for drawLayer, fMesh in fMeshes.items():
-		fModel.endDraw(fMesh, bone)
-
-	return fMeshes[drawLayerKey], len(skinnedFaces) > 0
+	return fMesh, hasSkinnedFaces
 
 ootEnumObjectMenu = [
 	("Scene", "Parent Scene Settings", "Scene"),

--- a/fast64_internal/oot/oot_skeleton.py
+++ b/fast64_internal/oot/oot_skeleton.py
@@ -316,7 +316,8 @@ def ootConvertArmatureToSkeleton(originalArmatureObj, convertTransformMatrix,
 		#for i in range(len(startBoneNames)):
 		#	startBoneName = startBoneNames[i]
 		ootProcessBone(fModel, startBoneName, skeleton, 0,
-			meshObj, armatureObj, convertTransformMatrix, meshInfo, convertTextureData, name, skeletonOnly, drawLayer)
+			meshObj, armatureObj, convertTransformMatrix, meshInfo, convertTextureData,
+			name, skeletonOnly, drawLayer, -1)
 
 		cleanupDuplicatedObjects(meshObjs + [armatureObj])
 		originalArmatureObj.select_set(True)
@@ -330,7 +331,8 @@ def ootConvertArmatureToSkeleton(originalArmatureObj, convertTransformMatrix,
 		raise Exception(str(e))
 
 def ootProcessBone(fModel, boneName, parentLimb, nextIndex, meshObj, armatureObj, 
-	convertTransformMatrix, meshInfo, convertTextureData, namePrefix, skeletonOnly, drawLayer):
+	convertTransformMatrix, meshInfo, convertTextureData, namePrefix, skeletonOnly, 
+	drawLayer, parentGroupIndex):
 	bone = armatureObj.data.bones[boneName]
 	if bone.parent is not None:
 		transform = convertTransformMatrix @ bone.parent.matrix_local.inverted() @ bone.matrix_local
@@ -349,7 +351,7 @@ def ootProcessBone(fModel, boneName, parentLimb, nextIndex, meshObj, armatureObj
 	else:
 		mesh, hasSkinnedFaces = ootProcessVertexGroup(fModel, meshObj, boneName, 
 			convertTransformMatrix, armatureObj, namePrefix,
-			meshInfo, drawLayer, convertTextureData)
+			meshInfo, drawLayer, convertTextureData, parentGroupIndex)
 
 	if bone.ootBoneType == "Custom DL":
 		if mesh is not None:
@@ -378,7 +380,8 @@ def ootProcessBone(fModel, boneName, parentLimb, nextIndex, meshObj, armatureObj
 	childrenNames = getSortedChildren(armatureObj, bone)
 	for childName in childrenNames:
 		nextIndex = ootProcessBone(fModel, childName, limb, nextIndex, meshObj, armatureObj, 
-			convertTransformMatrix, meshInfo, convertTextureData, namePrefix, skeletonOnly, drawLayer)
+			convertTransformMatrix, meshInfo, convertTextureData, namePrefix, skeletonOnly, 
+			drawLayer, groupIndex)
 
 	return nextIndex
 


### PR DESCRIPTION
`ootProcessVertexGroup` had code which separated the faces of a limb into one group for normal tris (all verts from the tri's vertex group), and separate groups for each different set of skinned tris based on which vertex groups were involved. Then, it would create separate DLs for each of these groups. This is superfluous for several reasons:
- It looks like it's a holdover from SM64 code which treats non-flex and flex/skinned portions differently. The sets of vertex groups which form these groups were not actually used in the OoT code. (For example, for limb 2, non-flex triangles use vertex groups `(2,)` and flex triangles use vertex groups `(1,2)`, but these actual tuples were never used after being created.)
- Often leads to vertices being loaded (and transformed by the RSP) twice.
- If there are multiple materials used by the non-flex tris and the same set of materials being used by flex tris, runs each of those material definitions twice, including loading the textures twice.
- Even in the best case, still produces a couple extra `gsSPDisplayList` and `gsSPEndDisplayList` commands.