### PR TITLE
SM64 ability to disable rendering backgrounds in geolayout

### DIFF
--- a/fast64_internal/sm64/sm64_camera.py
+++ b/fast64_internal/sm64/sm64_camera.py
@@ -72,24 +72,24 @@ def saveCameraSettingsToGeolayout(geolayoutGraph, areaObj, rootObj, meshGeolayou
 		areaObj.useDefaultScreenRect, 0xA, areaObj.screenPos, areaObj.screenSize))
 	geolayout.nodes.insert(0, screenAreaNode)
 	
-	zBufferDisable = TransformNode(ZBufferNode(False))
-	screenAreaNode.children.append(zBufferDisable)
+	if not areaObj.fast64.sm64.area.disable_background:
+		zBufferDisable = TransformNode(ZBufferNode(False))
+		screenAreaNode.children.append(zBufferDisable)
 
-	orthoNode = TransformNode(OrthoNode(0x64))
-	zBufferDisable.children.append(orthoNode)
+		orthoNode = TransformNode(OrthoNode(0x64))
+		zBufferDisable.children.append(orthoNode)
 
-
-	# Uses Level Root here
-	bgColor = colorTo16bitRGBA(gammaCorrect(areaObj.areaBGColor if \
-		areaObj.areaOverrideBG else rootObj.backgroundColor) + [1])
-	if areaObj.areaOverrideBG:
-		bgNode = TransformNode(BackgroundNode(
-			True, bgColor))
-	else:
-		bgNode = TransformNode(BackgroundNode(
-			rootObj.useBackgroundColor, bgColor if rootObj.useBackgroundColor \
-			else ('BACKGROUND_' + rootObj.background)))
-	orthoNode.children.append(bgNode)
+		# Uses Level Root here
+		bgColor = colorTo16bitRGBA(gammaCorrect(areaObj.areaBGColor if \
+			areaObj.areaOverrideBG else rootObj.backgroundColor) + [1])
+		if areaObj.areaOverrideBG:
+			bgNode = TransformNode(BackgroundNode(
+				True, bgColor))
+		else:
+			bgNode = TransformNode(BackgroundNode(
+				rootObj.useBackgroundColor, bgColor if rootObj.useBackgroundColor \
+				else ('BACKGROUND_' + rootObj.background)))
+		orthoNode.children.append(bgNode)
 
 	zBufferEnable = TransformNode(ZBufferNode(True))
 	screenAreaNode.children.append(zBufferEnable)

--- a/fast64_internal/sm64/sm64_objects.py
+++ b/fast64_internal/sm64/sm64_objects.py
@@ -1002,9 +1002,14 @@ class SM64ObjectPanel(bpy.types.Panel):
 			if obj.areaIndex == 1 or obj.areaIndex == 2 or obj.areaIndex == 3 or obj.areaIndex == 4:
 				box.prop(obj, 'zoomOutOnPause')
 
-			box.prop(obj, 'areaOverrideBG')
+			box.prop(obj.fast64.sm64.area, 'disable_background')
+
+			areaLayout = box.box()
+			areaLayout.enabled = not obj.fast64.sm64.area.disable_background
+			areaLayout.prop(obj, 'areaOverrideBG')
 			if obj.areaOverrideBG:
-				prop_split(box, obj, 'areaBGColor', 'Background Color')
+				prop_split(areaLayout, obj, 'areaBGColor', 'Background Color')
+
 			box.prop(obj, 'showStartDialog')
 			if obj.showStartDialog:
 				prop_split(box, obj, 'startDialog', "Start Dialog")
@@ -1373,12 +1378,16 @@ class SM64_GeoASMProperties(bpy.types.PropertyGroup):
 		param = obj.get("geoASMParam") or obj.get("func_param") or 0
 		geo_asm.param = str(param)
 
+class SM64_AreaProperties(bpy.types.PropertyGroup):
+	name = "Area Properties"
+	disable_background: bpy.props.BoolProperty(name = "Disable Background", default=False, description="Disable rendering background. Ideal for interiors or areas that should never see a background.")
 
 class SM64_ObjectProperties(bpy.types.PropertyGroup):
 	version: bpy.props.IntProperty(name="SM64_ObjectProperties Version", default=0)
 	cur_version = 1 # version after property migration
 
 	geo_asm: bpy.props.PointerProperty(type=SM64_GeoASMProperties)
+	area: bpy.props.PointerProperty(type=SM64_AreaProperties)
 
 	@staticmethod
 	def upgrade_changed_props():
@@ -1403,6 +1412,7 @@ sm64_obj_classes = (
 	PuppycamSetupCamera,
 
 	SM64_GeoASMProperties,
+	SM64_AreaProperties,
 	SM64_ObjectProperties,
 )
 


### PR DESCRIPTION
Sometimes you dont want the game to render a background! especially if you're doing a custom 3D background. No need for that extra fill rate am i rite?