### PR TITLE
Begin OoT skeleton optimizer

### DIFF
--- a/fast64_internal/f3d/f3d_material.py
+++ b/fast64_internal/f3d/f3d_material.py
@@ -401,7 +401,7 @@ def ui_lower_mode(settings, dataHolder, layout: bpy.types.UILayout, useDropdown)
 		prop_split(prim_box, settings.prim_depth, 'z', 'Prim Depth: Z')
 		prop_split(prim_box, settings.prim_depth, 'dz', 'Prim Depth: Delta Z')
 		if settings.prim_depth.dz != 0 and settings.prim_depth.dz & (settings.prim_depth.dz - 1):
-			prim_box.label(text='Warning: DZ should ideally be a power of 2 up to 0x4000', icon='ERROR')
+			prim_box.label(text='Warning: DZ should ideally be a power of 2 up to 0x4000', icon='TEXTURE_DATA')
 
 def ui_other(settings, dataHolder, layout, useDropdown):
 	inputGroup = layout.column()
@@ -492,7 +492,7 @@ class F3DPanel(bpy.types.Panel):
 				prop_input.label(text = "UVs must be in the [0, 1024] pixel range.")
 				prop_input.prop(textureProp, "save_large_texture")
 				if not textureProp.save_large_texture:
-					prop_input.label(text = "Most large textures will take forever to convert.", icon = 'ERROR')
+					prop_input.label(text = "Most large textures will take forever to convert.", icon = 'PREVIEW_RANGE')
 			else:
 				tmemUsageUI(prop_input, textureProp)
 
@@ -805,7 +805,7 @@ class F3DPanel(bpy.types.Panel):
 			if f3dMat.set_fog:
 				inputGroup.prop(f3dMat, 'use_global_fog', text = 'Use Global Fog (SM64)')
 				if f3dMat.use_global_fog:
-					inputGroup.label(text = 'Only applies to levels (area fog settings).', icon = "ERROR")
+					inputGroup.label(text = 'Only applies to levels (area fog settings).', icon = 'INFO')
 				else:
 					fogColorGroup = inputGroup.row().split(factor = 0.5)
 					fogColorGroup.label(text = 'Fog Color')
@@ -837,15 +837,15 @@ class F3DPanel(bpy.types.Panel):
 	def drawVertexColorNotice(self, layout):
 		noticeBox = layout.box().column()
 		noticeBox.label(
-			text = 'There must be two vertex color layers.', icon = "ERROR")
+			text = 'There must be two vertex color layers.', icon = 'LINENUMBERS_ON')
 		noticeBox.label(
 			text = 'They should be called "Col" and "Alpha".')
 
 	def drawShadeAlphaNotice(self, layout):
-		layout.box().column().label(text = "There must be a vertex color layer called \"Alpha\".", icon = "ERROR")
+		layout.box().column().label(text = "There must be a vertex color layer called \"Alpha\".", icon = 'IMAGE_ALPHA')
 
 	def drawCIMultitextureNotice(self, layout):
-		layout.label(text = 'CI textures will break with multitexturing.', icon = "ERROR")
+		layout.label(text = 'CI textures will break with multitexturing.', icon = 'LIBRARY_DATA_BROKEN')
 
 	def draw_simple(self, f3dMat, material, layout, context):
 		self.ui_uvCheck(layout, context)

--- a/fast64_internal/f3d/f3d_writer.py
+++ b/fast64_internal/f3d/f3d_writer.py
@@ -272,6 +272,10 @@ class TileLoad:
 def saveMeshWithLargeTexturesByFaces(material, faces, fModel, fMesh, obj, drawLayer,
 	convertTextureData, currentGroupIndex, triConverterInfo, existingVertData, matRegionDict,
 	lastMaterialName):
+	'''
+	lastMaterialName is for optimization; set it to None to disable optimization.
+	'''
+	
 	if len(faces) == 0:
 		print('0 Faces Provided.')
 		return
@@ -622,6 +626,10 @@ def checkIfFlatShaded(material):
 def saveMeshByFaces(material, faces, fModel, fMesh, obj, drawLayer,
 	convertTextureData, currentGroupIndex, triConverterInfo,
 	existingVertData, matRegionDict, lastMaterialName):
+	'''
+	lastMaterialName is for optimization; set it to None to disable optimization.
+	'''
+	
 	if len(faces) == 0:
 		print('0 Faces Provided.')
 		return

--- a/fast64_internal/f3d/f3d_writer.py
+++ b/fast64_internal/f3d/f3d_writer.py
@@ -270,7 +270,8 @@ class TileLoad:
 			abs(self.tl - self.th) + 1]
 
 def saveMeshWithLargeTexturesByFaces(material, faces, fModel, fMesh, obj, drawLayer,
-	convertTextureData, currentGroupIndex, triConverterInfo, existingVertData, matRegionDict):
+	convertTextureData, currentGroupIndex, triConverterInfo, existingVertData, matRegionDict,
+	lastMaterialName):
 	if len(faces) == 0:
 		print('0 Faces Provided.')
 		return
@@ -317,7 +318,8 @@ def saveMeshWithLargeTexturesByFaces(material, faces, fModel, fMesh, obj, drawLa
 
 	tileLoads = list(tileLoads.items())
 
-	fMesh.add_material_call(fMaterial)
+	if material.name != lastMaterialName:
+		fMesh.add_material_call(fMaterial)
 	triGroup = fMesh.tri_group_new(fMaterial)
 	fMesh.draw.commands.append(SPDisplayList(triGroup.triList))
 
@@ -407,10 +409,10 @@ def saveStaticModel(triConverterInfo, fModel, obj, transformMatrix, ownerName, c
 
 		if fMaterial.useLargeTextures:
 			saveMeshWithLargeTexturesByFaces(material, faces, fModel, fMesh, obj, drawLayer, convertTextureData, None,
-				triConverterInfo, None, None)
+				triConverterInfo, None, None, None)
 		else:
 			saveMeshByFaces(material, faces,
-				fModel, fMesh, obj, drawLayer, convertTextureData, None, triConverterInfo, None, None)
+				fModel, fMesh, obj, drawLayer, convertTextureData, None, triConverterInfo, None, None, None)
 
 	for drawLayer, fMesh in fMeshes.items():
 		if revertMatAtEnd:
@@ -619,7 +621,7 @@ def checkIfFlatShaded(material):
 
 def saveMeshByFaces(material, faces, fModel, fMesh, obj, drawLayer,
 	convertTextureData, currentGroupIndex, triConverterInfo,
-	existingVertData, matRegionDict):
+	existingVertData, matRegionDict, lastMaterialName):
 	if len(faces) == 0:
 		print('0 Faces Provided.')
 		return
@@ -630,7 +632,8 @@ def saveMeshByFaces(material, faces, fModel, fMesh, obj, drawLayer,
 	uv_data = obj.data.uv_layers['UVMap'].data
 	convertInfo = LoopConvertInfo(uv_data, obj, exportVertexColors)
 
-	fMesh.add_material_call(fMaterial)
+	if material.name != lastMaterialName:
+		fMesh.add_material_call(fMaterial)
 	triGroup = fMesh.tri_group_new(fMaterial)
 	fMesh.draw.commands.append(SPDisplayList(triGroup.triList))
 

--- a/fast64_internal/oot/oot_actor.py
+++ b/fast64_internal/oot/oot_actor.py
@@ -82,7 +82,7 @@ def drawActorHeaderItemProperty(layout, propUser, headerItemProp, index, altProp
 		drawCollectionOps(box, index, propUser, None, objName)
 		prop_split(box, headerItemProp, 'headerIndex', 'Header Index')
 		if altProp is not None and headerItemProp.headerIndex >= len(altProp.cutsceneHeaders) + 4:
-			box.label(text = "Header does not exist.", icon = "ERROR")
+			box.label(text = "Header does not exist.", icon = 'QUESTION')
 		
 class OOTActorProperty(bpy.types.PropertyGroup):
 	actorID : bpy.props.EnumProperty(name = 'Actor', items = ootEnumActorID, default = 'ACTOR_PLAYER')
@@ -150,11 +150,11 @@ def drawTransitionActorProperty(layout, transActorProp, altSceneProp, roomObj, o
 	prop_split(actorIDBox, transActorProp.actor, "actorParam", 'Actor Parameter')
 
 	if roomObj is None:
-		actorIDBox.label(text = "This must be part of a Room empty's hierarchy.", icon = "ERROR")
+		actorIDBox.label(text = "This must be part of a Room empty's hierarchy.", icon = 'OUTLINER')
 	else:
 		label_split(actorIDBox, "Room To Transition From", str(roomObj.ootRoomHeader.roomIndex))
 	prop_split(actorIDBox, transActorProp, "roomIndex", "Room To Transition To")
-	actorIDBox.label(text = "Y+ side of door faces toward the \"from\" room.", icon = "ERROR")
+	actorIDBox.label(text = "Y+ side of door faces toward the \"from\" room.", icon = 'ORIENTATION_NORMAL')
 	drawEnumWithCustom(actorIDBox, transActorProp, "cameraTransitionFront", "Camera Transition Front", "")
 	drawEnumWithCustom(actorIDBox, transActorProp, "cameraTransitionBack", "Camera Transition Back", "")
 
@@ -175,7 +175,7 @@ def drawEntranceProperty(layout, obj, altSceneProp, objName):
 		split.label(text = "Room Index")
 		split.label(text = str(roomObj.ootRoomHeader.roomIndex))
 	else:
-		box.label(text = "This must be part of a Room empty's hierarchy.", icon = "ERROR")
+		box.label(text = "This must be part of a Room empty's hierarchy.", icon = 'OUTLINER')
 
 	entranceProp = obj.ootEntranceProperty
 	prop_split(box, entranceProp, "spawnIndex", "Spawn Index")

--- a/fast64_internal/oot/oot_f3d_writer.py
+++ b/fast64_internal/oot/oot_f3d_writer.py
@@ -101,6 +101,20 @@ def ootProcessVertexGroup(fModel, meshObj, vertexGroup, convertTransformMatrix, 
 	fMeshes = {}
 	triConverterInfo = OOTTriangleConverterInfo(meshObj, armatureObj.data, fModel.f3d, convertTransformMatrix, meshInfo)
 
+	if optimize:
+		# If one of the materials we need to draw is the currently loaded material,
+		# do this one first.
+		newGroupFaces = {}
+		for material_index, faces in groupFaces.items():
+			material = meshObj.material_slots[material_index].material
+			if material.name == lastMaterialName:
+				newGroupFaces[material_index] = faces
+				del groupFaces[material_index]
+				break
+		for material_index, faces in groupFaces.items():
+			newGroupFaces[material_index] = faces
+		groupFaces = newGroupFaces
+
 	# Usually we would separate DLs into different draw layers.
 	# however it seems like OOT skeletons don't have this ability.
 	# Therefore we always use the drawLayerOverride as the draw layer key.

--- a/fast64_internal/oot/oot_f3d_writer.py
+++ b/fast64_internal/oot/oot_f3d_writer.py
@@ -92,16 +92,11 @@ def ootProcessVertexGroup(fModel, meshObj, vertexGroup, convertTransformMatrix, 
 	if optimize:
 		# If one of the materials we need to draw is the currently loaded material,
 		# do this one first.
-		newGroupFaces = {}
-		for material_index, faces in groupFaces.items():
-			material = meshObj.material_slots[material_index].material
-			if material.name == lastMaterialName:
-				newGroupFaces[material_index] = faces
-				del groupFaces[material_index]
-				break
-		# add the rest of them
-		for material_index, faces in groupFaces.items():
-			newGroupFaces[material_index] = faces
+		newGroupFaces = {
+			material_index: faces for material_index, faces in groupFaces.items()
+			if meshObj.material_slots[material_index].material.name == lastMaterialName
+		}
+		newGroupFaces.update(groupFaces)
 		groupFaces = newGroupFaces
 
 	# Usually we would separate DLs into different draw layers.
@@ -390,7 +385,7 @@ class OOT_MaterialPanel(bpy.types.Panel):
 			context.object.parent is not None and isinstance(context.object.parent.data, bpy.types.Armature):
 			drawLayer = context.object.parent.ootDrawLayer
 			if drawLayer != mat.f3d_mat.draw_layer.oot:
-				col.label(text = "Draw layer is being overriden by skeleton.", icon = "ERROR")
+				col.label(text = "Draw layer is being overriden by skeleton.", icon = 'OUTLINER_DATA_ARMATURE')
 		else:
 			drawLayer = mat.f3d_mat.draw_layer.oot
 

--- a/fast64_internal/oot/oot_f3d_writer.py
+++ b/fast64_internal/oot/oot_f3d_writer.py
@@ -15,7 +15,11 @@ from .oot_scene_room import *
 # 	mesh, 
 # 	anySkinnedFaces (to determine if skeleton should be flex)
 def ootProcessVertexGroup(fModel, meshObj, vertexGroup, convertTransformMatrix, armatureObj, namePrefix,
-	meshInfo, drawLayerOverride, convertTextureData):
+	meshInfo, drawLayerOverride, convertTextureData, lastMaterialName):
+
+	optimize = bpy.context.scene.ootSkeletonExportOptimize
+	if not optimize:
+		lastMaterialName = None
 
 	mesh = meshObj.data
 	currentGroupIndex = getGroupIndexFromname(meshObj, vertexGroup)
@@ -120,10 +124,12 @@ def ootProcessVertexGroup(fModel, meshObj, vertexGroup, convertTransformMatrix, 
 
 		if fMaterial.useLargeTextures:
 			currentGroupIndex = saveMeshWithLargeTexturesByFaces(material, faces, fModel, fMeshes[drawLayer],
-				meshObj, drawLayer, convertTextureData, currentGroupIndex, triConverterInfo, None, None)
+				meshObj, drawLayer, convertTextureData, currentGroupIndex, triConverterInfo, None, None, lastMaterialName)
 		else:
 			currentGroupIndex = saveMeshByFaces(material, faces, fModel, fMeshes[drawLayer], 
-				meshObj, drawLayer, convertTextureData, currentGroupIndex, triConverterInfo, None, None)
+				meshObj, drawLayer, convertTextureData, currentGroupIndex, triConverterInfo, None, None, lastMaterialName)
+		
+		lastMaterialName = material.name if optimize else None
 
 	for groupTuple, materialFaces in skinnedFaces.items():
 		for material_index, faces in materialFaces.items():
@@ -144,15 +150,17 @@ def ootProcessVertexGroup(fModel, meshObj, vertexGroup, convertTransformMatrix, 
 				saveOrGetF3DMaterial(material, fModel, meshObj, drawLayer, convertTextureData)
 			if fMaterial.useLargeTextures:
 				currentGroupIndex = saveMeshWithLargeTexturesByFaces(material, faces, fModel, fMeshes[drawLayer], 
-					meshObj, drawLayer, convertTextureData, currentGroupIndex, triConverterInfo, None, None)
+					meshObj, drawLayer, convertTextureData, currentGroupIndex, triConverterInfo, None, None, lastMaterialName)
 			else:
 				currentGroupIndex = saveMeshByFaces(material, faces, fModel, fMeshes[drawLayer], 
-					meshObj, drawLayer, convertTextureData, currentGroupIndex, triConverterInfo, None, None)
+					meshObj, drawLayer, convertTextureData, currentGroupIndex, triConverterInfo, None, None, lastMaterialName)
+			
+			lastMaterialName = material.name if optimize else None
 
 	for drawLayer, fMesh in fMeshes.items():
 		fModel.endDraw(fMesh, bone)
 
-	return fMeshes[drawLayerKey], len(skinnedFaces) > 0
+	return fMeshes[drawLayerKey], len(skinnedFaces) > 0, lastMaterialName
 
 ootEnumObjectMenu = [
 	("Scene", "Parent Scene Settings", "Scene"),

--- a/fast64_internal/oot/oot_scene_room.py
+++ b/fast64_internal/oot/oot_scene_room.py
@@ -137,7 +137,7 @@ def drawAlternateRoomHeaderProperty(layout, headerProp, objName):
 		if index - 4 < len(headerProp.cutsceneHeaders):
 			drawRoomHeaderProperty(headerSetup, headerProp.cutsceneHeaders[index - 4], None, index, objName)
 		else:
-			headerSetup.label(text = "No cutscene header for this index.", icon = "ERROR")
+			headerSetup.label(text = "No cutscene header for this index.", icon = 'QUESTION')
 
 class OOTExitProperty(bpy.types.PropertyGroup):
 	expandTab : bpy.props.BoolProperty(name = "Expand Tab")
@@ -254,14 +254,14 @@ def drawLightProperty(layout, lightProp, name, showExpandTab, index, sceneHeader
 		
 		if lightProp.useCustomDiffuse0:
 			prop_split(box, lightProp, 'diffuse0Custom', 'Diffuse 0')
-			box.label(text = "Make sure light is not part of scene hierarchy.", icon = "ERROR")
+			box.label(text = "Make sure light is not part of scene hierarchy.", icon = 'FILE_PARENT')
 		else:
 			prop_split(box, lightProp, 'diffuse0', 'Diffuse 0')
 		box.prop(lightProp, "useCustomDiffuse0")
 		
 		if lightProp.useCustomDiffuse1:
 			prop_split(box, lightProp, 'diffuse1Custom', 'Diffuse 1')
-			box.label(text = "Make sure light is not part of scene hierarchy.", icon = "ERROR")
+			box.label(text = "Make sure light is not part of scene hierarchy.", icon = 'FILE_PARENT')
 		else:
 			prop_split(box, lightProp, 'diffuse1', 'Diffuse 1')
 		box.prop(lightProp, "useCustomDiffuse1")
@@ -580,7 +580,7 @@ def drawAlternateSceneHeaderProperty(layout, headerProp, objName):
 		if index - 4 < len(headerProp.cutsceneHeaders):
 			drawSceneHeaderProperty(headerSetup, headerProp.cutsceneHeaders[index - 4], None, index, objName)
 		else:
-			headerSetup.label(text = "No cutscene header for this index.", icon = "ERROR")
+			headerSetup.label(text = "No cutscene header for this index.", icon = 'QUESTION')
 
 class OOTAlternateRoomHeaderProperty(bpy.types.PropertyGroup):
 	childNightHeader : bpy.props.PointerProperty(name = "Child Night Header", type = OOTRoomHeaderProperty)
@@ -605,7 +605,7 @@ def drawParentSceneRoom(box, obj):
 			if sceneObj.ootSceneHeader.menuTab == 'Alternate':
 				drawAlternateSceneHeaderProperty(box, sceneObj.ootAlternateSceneHeaders, sceneObj.name)
 		else:
-			box.label(text = "This object is not part of any Scene hierarchy.", icon = "ERROR")
+			box.label(text = "This object is not part of any Scene hierarchy.", icon = 'OUTLINER')
 	
 	elif obj.ootObjectMenu == "Room":
 		if roomObj is not None:
@@ -613,4 +613,4 @@ def drawParentSceneRoom(box, obj):
 			if roomObj.ootRoomHeader.menuTab == 'Alternate':
 				drawAlternateRoomHeaderProperty(box, roomObj.ootAlternateRoomHeaders, roomObj.name)
 		else:
-			box.label(text = "This object is not part of any Room hierarchy.", icon = "ERROR")
+			box.label(text = "This object is not part of any Room hierarchy.", icon = 'OUTLINER')

--- a/fast64_internal/oot/oot_skeleton.py
+++ b/fast64_internal/oot/oot_skeleton.py
@@ -797,7 +797,7 @@ class OOT_ExportSkeletonPanel(OOT_Panel):
 		col.prop(context.scene, "ootSkeletonExportOptimize")
 		if context.scene.ootSkeletonExportOptimize:
 			b = col.box().column()
-			b.label(icon = 'ERROR', text = "Do not draw anything in SkelAnime")
+			b.label(icon = 'LIBRARY_DATA_BROKEN', text = "Do not draw anything in SkelAnime")
 			b.label(text = "callbacks or cull limbs, will be corrupted.")
 
 		col.operator(OOT_ImportSkeleton.bl_idname)
@@ -835,7 +835,7 @@ class OOT_SkeletonPanel(bpy.types.Panel):
 		prop_split(col, context.object, "ootDrawLayer", "Draw Layer")
 		prop_split(col, context.object, "ootFarLOD", "LOD Skeleton")
 		if context.object.ootFarLOD is not None:
-			col.label(text = "Make sure LOD has same bone structure.", icon = "ERROR")
+			col.label(text = "Make sure LOD has same bone structure.", icon = 'BONE_DATA')
 
 class OOT_BonePanel(bpy.types.Panel):
 	bl_idname = "OOT_PT_bone"
@@ -858,7 +858,7 @@ class OOT_BonePanel(bpy.types.Panel):
 			prop_split(col, context.bone, "ootCustomDLName", "DL Name")
 		if context.bone.ootBoneType == "Custom DL" or\
 			context.bone.ootBoneType == "Ignore":
-			col.label(text = "Make sure no geometry is skinned to this bone.", icon = "ERROR")
+			col.label(text = "Make sure no geometry is skinned to this bone.", icon = 'BONE_DATA')
 		
 		if context.bone.ootBoneType != "Ignore":
 			col.prop(context.bone.ootDynamicTransform, 'billboard')

--- a/fast64_internal/sm64/sm64_geolayout_bone.py
+++ b/fast64_internal/sm64/sm64_geolayout_bone.py
@@ -173,7 +173,7 @@ class GeolayoutArmaturePanel(bpy.types.Panel):
 def drawLayerWarningBox(layout, prop, data):
 	warningBox = layout.box().column()
 	prop_split(warningBox, prop, data, 'Draw Layer (v3)')
-	warningBox.label(text = "This applies to v3 materials and down only.", icon = "ERROR")
+	warningBox.label(text = "This applies to v3 materials and down only.", icon = 'LOOP_FORWARDS')
 	warningBox.label(text = "This is moved to material settings in v4+.")
 
 class GeolayoutObjectPanel(bpy.types.Panel):


### PR DESCRIPTION
This begins a set of features for optimizing OoT skeletons. The optimizer can be turned on or off at skeleton export time; if it is off, the export process is like it has been in the past, and the assumptions below don't apply.

The optimizing features rely on maintaining state in the RSP and/or RDP between limbs of a skeleton. If optimization is enabled, drawing other DLs within the SkelAnime callbacks (OverrideLimbDraw or PostLimbDraw) will corrupt the graphics state. Limbs also can't be culled in software, though since there is no built-in culling mechanism, the user would have to write the culling themselves. (Actually, they can be culled, just very carefully.)

This PR provides one very basic optimization feature: not running the material setup DL when the material was already set up correctly by the last limb. In a basic case with N limbs all using the same material, this saves N-1 superfluous material executions, including N-1 superfluous texture loads (or 2N-2 superfluous loads if using CI textures). If a limb uses multiple materials but one of them is the last material, it will draw those tris first so it still saves one material setup.