### PR TITLE
Fix bug that made some materials not be possible to import

### DIFF
--- a/fast64_internal/f3d/f3d_parser.py
+++ b/fast64_internal/f3d/f3d_parser.py
@@ -782,6 +782,8 @@ class F3DContext:
 			mat.rdp_settings.g_clipping = value
 	
 	def loadGeoFlags(self, command):
+		mat = self.mat()
+		
 		bitFlags = math_eval(command.params[0], self.f3d)
 
 		mat.rdp_settings.g_zbuffer = bitFlags & self.f3d.G_ZBUFFER != 0


### PR DESCRIPTION
This mainly affected Majora's Mask displaylists