### PR TITLE
Make OoT scene exporter include externs for room rom segments

### DIFF
--- a/fast64_internal/oot/c_writer/oot_level_c.py
+++ b/fast64_internal/oot/c_writer/oot_level_c.py
@@ -444,13 +444,24 @@ def ootTransitionActorListToC(scene, headerIndex):
 	data.source += '};\n\n'
 	return data
 
+def ootRoomExternToC(room):
+	return "extern u8 " + room.roomName() + "SegmentRomStart[];\n" + \
+		"extern u8 " + room.roomName() + "SegmentRomEnd[];\n"
+
 def ootRoomListEntryToC(room):
 	return "{ (u32)_" + room.roomName() + "SegmentRomStart, (u32)_" + room.roomName() + "SegmentRomEnd },\n"
 
 def ootRoomListHeaderToC(scene):
 	data = CData()
-	data.header = "extern RomFile " + scene.roomListName() + "[];\n"
-	data.source = "RomFile " + scene.roomListName() + "[] = {\n"
+
+	# Write externs for rom segments
+	for i in range(len(scene.rooms)):
+		data.source += ootRoomExternToC(scene.rooms[i])
+	data.source += "\n"
+
+	data.header += "extern RomFile " + scene.roomListName() + "[];\n"
+	data.source += "RomFile " + scene.roomListName() + "[] = {\n"
+	
 	for i in range(len(scene.rooms)):
 		data.source += '\t' + ootRoomListEntryToC(scene.rooms[i])
 	data.source += '};\n\n'

--- a/fast64_internal/oot/c_writer/oot_segment_symbols_c.py
+++ b/fast64_internal/oot/c_writer/oot_segment_symbols_c.py
@@ -62,8 +62,4 @@ def modifySegmentSymbols(scene, exportInfo):
 		segmentSymbols.insert(firstIndex, SegmentSymbolEntry("DECLARE_ROM_SEGMENT", scene.name + "_scene"))
 		firstIndex += 1
 
-		for i in range(len(scene.rooms)):
-			segmentSymbols.insert(firstIndex, SegmentSymbolEntry("DECLARE_ROM_SEGMENT", scene.name + "_room_" + str(i)))
-			firstIndex += 1
-
 	writeSegmentSymbols(segmentSymbols, fileData, start, end, exportPath)


### PR DESCRIPTION
This change is being made since eventually `segment_symbols.h` will ideally be removed from decomp, and it makes more sense to just extern these within the scene file.