### PR TITLE
Add support for multitextures where both texels fill tmem

### DIFF
--- a/fast64_internal/f3d/f3d_writer.py
+++ b/fast64_internal/f3d/f3d_writer.py
@@ -1273,6 +1273,13 @@ def saveOrGetF3DMaterial(material, fModel, obj, drawLayer, convertTextureData):
 		texDimensions0, nextTmem = saveTextureIndex(material.name, fModel,
 			fMaterial, fMaterial.material, fMaterial.revert, f3dMat.tex0, 0, nextTmem, None, convertTextureData,
 			None, loadTextures, True)
+	
+	# If the texture in both texels is the same then it can be rewritten to the same location in tmem
+	# This allows for a texture that fills tmem to still be used for both texel0 and texel1
+	if f3dMat.tex0.tex == f3dMat.tex1.tex:
+		if nextTmem >= (512 if f3dMat.tex0.tex_format[:2] != 'CI' else 256):
+			nextTmem = 0
+	
 	if useDict['Texture 1'] and f3dMat.tex1.tex_set:
 		if f3dMat.tex1.tex is None and not f3dMat.tex1.use_tex_reference:
 			raise PluginError('In material \"' + material.name + '\", a texture has not been set.')


### PR DESCRIPTION
This pull request adds support for a "hack" that Majora's Mask does which allows you to have a texture that fills all of tmem (for example 32x64 rgba16) and load it into both Texel 0 and Texel 1. It is somewhat experimental but from the testing that I have done it seems to work. Essentially it just loads the texture into the same location in tmem for both texels.