### PR TITLE
Fix OoT skeleton export

### DIFF
--- a/fast64_internal/oot/oot_f3d_writer.py
+++ b/fast64_internal/oot/oot_f3d_writer.py
@@ -29,7 +29,7 @@ def ootProcessVertexGroup(fModel, meshObj, vertexGroup, convertTransformMatrix, 
 
 	if len(vertIndices) == 0:
 		print("No vert indices in " + vertexGroup)
-		return None, False
+		return None, False, lastMaterialName
 
 	bone = armatureObj.data.bones[vertexGroup]
 	
@@ -84,7 +84,7 @@ def ootProcessVertexGroup(fModel, meshObj, vertexGroup, convertTransformMatrix, 
 			meshInfo.vertexGroupInfo.vertexGroupToMatrixIndex[currentGroupIndex] = nextDLIndex
 			return fMesh, False
 		else:
-			return None, False
+			return None, False, lastMaterialName
 	
 	meshInfo.vertexGroupInfo.vertexGroupToMatrixIndex[currentGroupIndex] = nextDLIndex
 	triConverterInfo = OOTTriangleConverterInfo(meshObj, armatureObj.data, fModel.f3d, convertTransformMatrix, meshInfo)

--- a/fast64_internal/oot/oot_level_writer.py
+++ b/fast64_internal/oot/oot_level_writer.py
@@ -130,8 +130,8 @@ def writeOtherSceneProperties(scene, exportInfo):
 	modifySceneTable(scene, exportInfo)
 	modifySegmentSymbols(scene, exportInfo)
 	modifySceneIDs(scene, exportInfo)
-	# modifyDmaMgrFileNames(scene, exportInfo)
-	# modifyDmaTableEntries(scene, exportInfo)
+	modifyDmaMgrFileNames(scene, exportInfo)
+	modifyDmaTableEntries(scene, exportInfo)
 	modifySegmentDefinition(scene, exportInfo)
 	modifySceneFiles(scene, exportInfo)
 
@@ -581,8 +581,8 @@ def ootRemoveSceneC(exportInfo):
 	modifySceneTable(None, exportInfo)
 	modifySegmentSymbols(None, exportInfo)
 	modifySceneIDs(None, exportInfo)
-	# modifyDmaMgrFileNames(None, exportInfo)
-	# modifyDmaTableEntries(None, exportInfo)
+	modifyDmaMgrFileNames(None, exportInfo)
+	modifyDmaTableEntries(None, exportInfo)
 	modifySegmentDefinition(None, exportInfo)
 	deleteSceneFiles(exportInfo)
 

--- a/fast64_internal/oot/oot_level_writer.py
+++ b/fast64_internal/oot/oot_level_writer.py
@@ -130,8 +130,8 @@ def writeOtherSceneProperties(scene, exportInfo):
 	modifySceneTable(scene, exportInfo)
 	modifySegmentSymbols(scene, exportInfo)
 	modifySceneIDs(scene, exportInfo)
-	modifyDmaMgrFileNames(scene, exportInfo)
-	modifyDmaTableEntries(scene, exportInfo)
+	# modifyDmaMgrFileNames(scene, exportInfo)
+	# modifyDmaTableEntries(scene, exportInfo)
 	modifySegmentDefinition(scene, exportInfo)
 	modifySceneFiles(scene, exportInfo)
 
@@ -581,8 +581,8 @@ def ootRemoveSceneC(exportInfo):
 	modifySceneTable(None, exportInfo)
 	modifySegmentSymbols(None, exportInfo)
 	modifySceneIDs(None, exportInfo)
-	modifyDmaMgrFileNames(None, exportInfo)
-	modifyDmaTableEntries(None, exportInfo)
+	# modifyDmaMgrFileNames(None, exportInfo)
+	# modifyDmaTableEntries(None, exportInfo)
 	modifySegmentDefinition(None, exportInfo)
 	deleteSceneFiles(exportInfo)
 


### PR DESCRIPTION
Fixes the "expected 3, got 2" error when exporting skeletons and fixes the "no such file: dmadata.s" error when exporting scenes. Since decomp now automatically generates dmadata from spec, I've just commented modifyDmaMgrFileNames and modifyDmaTableEntries. It may be a good idea to fully oot_dma_manager_c later on down the road.