### PR TITLE
[OoT] addAtStartPosIndex -> addStartPosAtIndex

### DIFF
--- a/fast64_internal/oot/oot_level_classes.py
+++ b/fast64_internal/oot/oot_level_classes.py
@@ -457,7 +457,7 @@ def addStartPosition(scene, index, actor, actorProp, actorObjName):
 		for cutsceneHeader in sceneSetup.cutsceneHeaders:
 			if cutsceneHeader.headerIndex >= len(scene.cutsceneHeaders) + 4:
 				raise PluginError(actorObjName + " uses a cutscene header index that is outside the range of the current number of cutscene headers.")
-			addAtStartPosIndex(scene.cutsceneHeaders[cutsceneHeader.headerIndex - 4].startPositions, index, actor)
+			addStartPosAtIndex(scene.cutsceneHeaders[cutsceneHeader.headerIndex - 4].startPositions, index, actor)
 	else:
 		raise PluginError("Unhandled scene setup preset: " + str(sceneSetup.sceneSetupPreset))
 


### PR DESCRIPTION
From what I understand this is a typo (the parameters match addStartPosAtIndex), randomly found this while looking at the OoT exporter