### PR TITLE
OoT Scene Export Cleanups

### DIFF
--- a/fast64_internal/oot/c_writer/oot_level_c.py
+++ b/fast64_internal/oot/c_writer/oot_level_c.py
@@ -420,7 +420,7 @@ def ootLightToC(light):
 		ootVectorToC(light.diffuse1) + ', ' +\
 		ootVectorToC(light.fogColor) + ', ' +\
 		light.getBlendFogShort() + ', ' +\
-		"0x{:04X}".format(light.drawDistance) + ' },\n'
+		"0x{:04X}".format(light.fogFar) + ' },\n'
 
 def ootLightSettingsToC(scene, useIndoorLighting, headerIndex):
 	data = CData()

--- a/fast64_internal/oot/oot_collision.py
+++ b/fast64_internal/oot/oot_collision.py
@@ -299,8 +299,8 @@ def ootCollisionPolygonToC(polygon, ignoreCamera, ignoreActor, ignoreProjectile,
 		format(polygon.distance, "#06x") + ' },\n'
 
 def ootPolygonTypeToC(polygonType):
-	return " " + format(polygonType.convertHigh(), "#010x") + ', ' +\
-		format(polygonType.convertLow(), "#010x") + ',\n'
+	return "{ " + format(polygonType.convertHigh(), "#010x") + ', ' +\
+		format(polygonType.convertLow(), "#010x") + ' },\n'
 
 def ootWaterBoxToC(waterBox):
 	return "{ " + str(waterBox.low[0]) + ", " +\
@@ -361,9 +361,9 @@ def ootCollisionToC(collision):
 	data.append(ootCameraDataToC(collision.cameraData))
 	
 	if len(collision.polygonGroups) > 0:
-		data.header += "extern u32 " + collision.polygonTypesName() + "[];\n"
+		data.header += "extern SurfaceType " + collision.polygonTypesName() + "[];\n"
 		data.header += "extern CollisionPoly " + collision.polygonsName() + "[];\n"
-		polygonTypeC = "u32 " + collision.polygonTypesName() + "[] = {\n"
+		polygonTypeC = "SurfaceType " + collision.polygonTypesName() + "[] = {\n"
 		polygonC = "CollisionPoly " + collision.polygonsName() + "[] = {\n"
 		polygonIndex = 0
 		for polygonType, polygons in collision.polygonGroups.items():
@@ -412,24 +412,25 @@ def ootCollisionToC(collision):
 		camDataName = '0'
 
 	data.header += "extern CollisionHeader " + collision.headerName() + ';\n'
-	data.source += "CollisionHeader " + collision.headerName() + ' = { '
+	data.source += "CollisionHeader " + collision.headerName() + ' = {\n'
 
 	if len(collision.bounds) == 2:
 		for bound in range(2): # min, max bound
 			for field in range(3): # x, y, z
-				data.source += str(collision.bounds[bound][field]) + ', '
+				data.source += '\t' + str(collision.bounds[bound][field]) + ',\n'
 	else:
 		data.source += '0, 0, 0, 0, 0, 0, '
 	
 	data.source += \
-		str(len(collision.vertices)) + ', ' +\
-		collisionVerticesName + ', ' +\
-		str(collision.polygonCount()) + ", " +\
-		polygonsName + ', ' +\
-		polygonTypesName + ', ' +\
-		camDataName + ', ' +\
-		str(len(collision.waterBoxes)) + ", " +\
-		waterBoxesName + ' };\n\n'
+		'\t' + str(len(collision.vertices)) + ',\n' +\
+		'\t' + collisionVerticesName + ',\n' +\
+		'\t' + str(collision.polygonCount()) + ',\n' +\
+		'\t' + polygonsName + ',\n' +\
+		'\t' + polygonTypesName + ',\n' +\
+		'\t' + camDataName + ',\n' +\
+		'\t' + str(len(collision.waterBoxes)) + ',\n' +\
+		'\t' + waterBoxesName + '\n' +\
+		'};\n\n'
 
 	return data
 

--- a/fast64_internal/oot/oot_level_classes.py
+++ b/fast64_internal/oot/oot_level_classes.py
@@ -46,7 +46,7 @@ class OOTLight:
 		self.diffuseDir1 = (0,0,0)
 		self.fogColor = (0,0,0)
 		self.fogNear = 0
-		self.drawDistance = 0
+		self.fogFar = 0
 		self.transitionSpeed = 0
 	
 	def getBlendFogShort(self):

--- a/fast64_internal/oot/oot_level_writer.py
+++ b/fast64_internal/oot/oot_level_writer.py
@@ -251,7 +251,7 @@ def getLightData(lightProp):
 	light.fogColor = getLightColor(lightProp.fogColor)
 	light.fogNear = lightProp.fogNear
 	light.transitionSpeed = lightProp.transitionSpeed
-	light.drawDistance = lightProp.drawDistance
+	light.fogFar = lightProp.fogFar
 	return light
 
 def readRoomData(room, roomHeader, alternateRoomHeaders):

--- a/fast64_internal/oot/oot_level_writer.py
+++ b/fast64_internal/oot/oot_level_writer.py
@@ -124,13 +124,13 @@ def ootExportSceneToC(originalSceneObj, transformMatrix,
 		os.path.join(levelPath, scene.sceneName() + '.h'))
 	
 	if not isCustomExport:
-		writeOtherSceneProperties(scene, exportInfo)
+		writeOtherSceneProperties(scene, exportInfo, levelC)
 
-def writeOtherSceneProperties(scene, exportInfo):
+def writeOtherSceneProperties(scene, exportInfo, levelC):
 	modifySceneTable(scene, exportInfo)
 	modifySegmentSymbols(scene, exportInfo)
 	modifySceneIDs(scene, exportInfo)
-	modifySegmentDefinition(scene, exportInfo)
+	modifySegmentDefinition(scene, exportInfo, levelC)
 	modifySceneFiles(scene, exportInfo)
 
 def readSceneData(scene, sceneHeader, alternateSceneHeaders):
@@ -666,7 +666,7 @@ def oot_level_register():
 	bpy.types.Scene.ootSceneExportObj = bpy.props.PointerProperty(type = bpy.types.Object, poll = isSceneObj)
 	bpy.types.Scene.ootSceneSingleFile = bpy.props.BoolProperty(
 		name = "Export as Single File",
-		default = True,
+		default = False,
 		description = "Does not split the scene and rooms into multiple files.")
 
 

--- a/fast64_internal/oot/oot_scene_room.py
+++ b/fast64_internal/oot/oot_scene_room.py
@@ -210,7 +210,7 @@ class OOTLightProperty(bpy.types.PropertyGroup):
 	fogColor : bpy.props.FloatVectorProperty(name = "", size = 4, min = 0, max = 1, default = (140/255, 120/255, 110/255 ,1), subtype = 'COLOR')
 	fogNear : bpy.props.IntProperty(name = "", default = 993, min = 0, max = 2**10 - 1)
 	transitionSpeed : bpy.props.IntProperty(name = "", default = 1, min = 0, max = 63)
-	drawDistance : bpy.props.IntProperty(name = "", default = 0x3200, min = 0, max = 2**16 - 1)
+	fogFar : bpy.props.IntProperty(name = "", default = 0x3200, min = 0, max = 2**16 - 1)
 	expandTab : bpy.props.BoolProperty(name = "Expand Tab")
 
 class OOTLightGroupProperty(bpy.types.PropertyGroup):
@@ -268,7 +268,7 @@ def drawLightProperty(layout, lightProp, name, showExpandTab, index, sceneHeader
 		
 		prop_split(box, lightProp, 'fogColor', 'Fog Color')
 		prop_split(box, lightProp, 'fogNear', 'Fog Near')
-		prop_split(box, lightProp, 'drawDistance', 'Draw Distance')
+		prop_split(box, lightProp, 'fogFar', 'Fog Far')
 		prop_split(box, lightProp, 'transitionSpeed', 'Transition Speed')
 
 


### PR DESCRIPTION
- Rename "draw distance" to "fog far," because this is what the field is actually for.
- Fix a compiler warning in collision data
- Improve the formatting of collision data
- Made it so that multi-file scene export is compatible with the Export Scene button (no longer requires custom path)