### PR TITLE
Support non folded skeletons

### DIFF
--- a/fast64_internal/oot/oot_anim.py
+++ b/fast64_internal/oot/oot_anim.py
@@ -55,9 +55,7 @@ class OOTAnimation:
 
 		return data
 
-def ootGetAnimBoneRot(bone, poseBone, convertTransformMatrix, isRoot, frame, boneIndex):
-	# frame and boneIndex are just for debugging
-	# 
+def ootGetAnimBoneRot(bone, poseBone, convertTransformMatrix, isRoot):
 	# OoT draws limbs like this:
 	# limbMatrix = parentLimbMatrix @ limbFixedTranslationMatrix @ animRotMatrix
 	# There is no separate rest position rotation; an animation rotation of 0
@@ -152,7 +150,7 @@ def ootConvertAnimationData(anim, armatureObj, frameInterval, convertTransformMa
 		rootBone = armatureObj.data.bones[animBones[0]]
 		rootPoseBone = armatureObj.pose.bones[animBones[0]]
 
-		# Hacky solution to handle Z-up to Y-up conversion
+		# Convert Z-up to Y-up for root translation animation
 		translation = mathutils.Quaternion((1, 0, 0), math.radians(-90.0)) @ \
 			(convertTransformMatrix @ rootPoseBone.matrix).decompose()[0]
 		saveTranslationFrame(translationData, translation)
@@ -162,20 +160,8 @@ def ootConvertAnimationData(anim, armatureObj, frameInterval, convertTransformMa
 			currentBone = armatureObj.data.bones[boneName]
 			currentPoseBone = armatureObj.pose.bones[boneName]
 			
-			'''
-			rotationValue = \
-				(currentBone.matrix.to_4x4().inverted() @ \
-				currentPoseBone.matrix).to_quaternion()
-			if currentBone.parent is not None:
-				rotationValue = (
-					currentBone.matrix.to_4x4().inverted() @ currentPoseBone.parent.matrix.inverted() @ \
-					currentPoseBone.matrix).to_quaternion()
-			
-			saveQuaternionFrame(rotationData[boneIndex], restPoseRotations[boneName].inverted() @ rotationValue)
-			'''
 			saveQuaternionFrame(rotationData[boneIndex], ootGetAnimBoneRot(
-				currentBone, currentPoseBone, convertTransformMatrix, boneIndex == 0,
-				frame, boneIndex))
+				currentBone, currentPoseBone, convertTransformMatrix, boneIndex == 0))
 	
 	bpy.context.scene.frame_set(currentFrame)
 	squashFramesIfAllSame(translationData)

--- a/fast64_internal/oot/oot_skeleton.py
+++ b/fast64_internal/oot/oot_skeleton.py
@@ -165,30 +165,6 @@ class OOTLimb():
 			self.children[i].setLinks()
 		# self -> child -> sibling
 
-'''
-def setArmatureToNonRotatedPose(armatureObj):
-	restPoseRotations = {}
-	poseBoneName = getStartBone(armatureObj)
-	setBoneNonRotated(armatureObj, poseBoneName, restPoseRotations)
-	return restPoseRotations
-
-def setBoneNonRotated(armatureObj, boneName, restPoseRotations):
-	bone = armatureObj.data.bones[boneName]
-	poseBone = armatureObj.pose.bones[boneName]
-
-	while len(poseBone.constraints) > 0:
-		poseBone.constraints.remove(poseBone.constraints[0])
-
-	rotation = bone.matrix_local.inverted().decompose()[1]
-	armatureObj.pose.bones[boneName].rotation_mode = "QUATERNION"
-	armatureObj.pose.bones[boneName].rotation_quaternion = rotation
-
-	restPoseRotations[boneName] = rotation
-
-	for child in bone.children:
-		setBoneNonRotated(armatureObj, child.name, restPoseRotations)
-'''
-
 def getGroupIndices(meshInfo, armatureObj, meshObj, rootGroupIndex):
 	meshInfo.vertexGroupInfo = OOTVertexGroupInfo()
 	for vertex in meshObj.data.vertices:
@@ -245,9 +221,6 @@ def ootDuplicateArmature(originalArmatureObj):
 		bpy.ops.object.transform_apply(location = False, rotation = False,
 			scale = True, properties = False)
 
-		# convert blender to n64 space, then set all bones to be non-rotated
-		#applyRotation([armatureObj], math.radians(90), 'X')
-			
 		# Apply modifiers/data to mesh objs
 		bpy.ops.object.select_all(action = 'DESELECT')
 		for obj in meshObjs:

--- a/fast64_internal/oot/oot_skeleton.py
+++ b/fast64_internal/oot/oot_skeleton.py
@@ -165,6 +165,7 @@ class OOTLimb():
 			self.children[i].setLinks()
 		# self -> child -> sibling
 
+'''
 def setArmatureToNonRotatedPose(armatureObj):
 	restPoseRotations = {}
 	poseBoneName = getStartBone(armatureObj)
@@ -186,6 +187,7 @@ def setBoneNonRotated(armatureObj, boneName, restPoseRotations):
 
 	for child in bone.children:
 		setBoneNonRotated(armatureObj, child.name, restPoseRotations)
+'''
 
 def getGroupIndices(meshInfo, armatureObj, meshObj, rootGroupIndex):
 	meshInfo.vertexGroupInfo = OOTVertexGroupInfo()
@@ -244,8 +246,7 @@ def ootDuplicateArmature(originalArmatureObj):
 			scale = True, properties = False)
 
 		# convert blender to n64 space, then set all bones to be non-rotated
-		applyRotation([armatureObj], math.radians(90), 'X')
-		restPoseRotations = setArmatureToNonRotatedPose(armatureObj)
+		#applyRotation([armatureObj], math.radians(90), 'X')
 			
 		# Apply modifiers/data to mesh objs
 		bpy.ops.object.select_all(action = 'DESELECT')
@@ -271,7 +272,7 @@ def ootDuplicateArmature(originalArmatureObj):
 		bpy.ops.pose.armature_apply()
 		bpy.ops.object.mode_set(mode = "OBJECT")
 
-		return armatureObj, meshObjs, restPoseRotations
+		return armatureObj, meshObjs
 	except Exception as e:
 		cleanupDuplicatedObjects(meshObjs + [armatureObj])
 		originalArmatureObj.select_set(True)
@@ -279,21 +280,19 @@ def ootDuplicateArmature(originalArmatureObj):
 		raise Exception(str(e))
 
 def ootConvertArmatureToSkeletonWithoutMesh(originalArmatureObj, convertTransformMatrix, name):
-	skeleton, fModel, restPoseRotations = ootConvertArmatureToSkeleton(originalArmatureObj, convertTransformMatrix, 
+	skeleton, fModel = ootConvertArmatureToSkeleton(originalArmatureObj, convertTransformMatrix, 
 		None, name, False, True, "Opaque")
-	return skeleton, restPoseRotations
+	return skeleton
 
 def ootConvertArmatureToSkeletonWithMesh(originalArmatureObj, convertTransformMatrix, fModel, name, convertTextureData, drawLayer):
-	
-	skeleton, fModel, restPoseRotations = ootConvertArmatureToSkeleton(originalArmatureObj, convertTransformMatrix, 
+	return ootConvertArmatureToSkeleton(originalArmatureObj, convertTransformMatrix, 
 		fModel, name, convertTextureData, False, drawLayer)
-	return skeleton, fModel
 
 def ootConvertArmatureToSkeleton(originalArmatureObj, convertTransformMatrix, 
 	fModel, name, convertTextureData, skeletonOnly, drawLayer):
 	checkEmptyName(name)
 
-	armatureObj, meshObjs, restPoseRotations = ootDuplicateArmature(originalArmatureObj)
+	armatureObj, meshObjs = ootDuplicateArmature(originalArmatureObj)
 	
 	try:
 		skeleton = OOTSkeleton(name)
@@ -323,7 +322,7 @@ def ootConvertArmatureToSkeleton(originalArmatureObj, convertTransformMatrix,
 		originalArmatureObj.select_set(True)
 		bpy.context.view_layer.objects.active = originalArmatureObj
 
-		return skeleton, fModel, restPoseRotations
+		return skeleton, fModel
 	except Exception as e:
 		cleanupDuplicatedObjects(meshObjs + [armatureObj])
 		originalArmatureObj.select_set(True)


### PR DESCRIPTION
fast64 previously produced corrupted SkelAnime results when the mesh in Blender didn't have all the bones pointing the same direction in "rest position" (edit mode position). This was known as a "folded" skeleton because of the way imported meshes looked.

This issue was caused by the animation export code being overcomplicated and wrong. There is an explanation in the comments below of why the new version should work, so it's actually theoretically based, not just it happens to work.

This is tested and works with a complicated custom flex skel mesh which has many bones not pointing the same direction as well as with translation offsets. This has NOT yet been tested with creating custom animations on a mesh imported from the game. However, the changes made only impact the animation export codepath, not the skeleton / dlist export codepath, so I think they should work with vanilla skeletons.

I will mention in particular that there were several issues with `setArmatureToNonRotatedPose`, which is used on the skeleton / dlist export codepath, and which has been removed. So you might think this would affect those results. However, this code only changed pose bone rotations, and pose bones are always ignored by the skeleton / dlist export codepath. The latter also ignored the returned `restPoseRotations`. So, there are no changes to this codepath. The other issues were:
- the new pose set up is immediately overwritten when the scene animation frame is changed
- the rotations returned are just the edit-mode / "rest position" rotations of the bones, which are always accessible regardless of the pose. They are not, as it appears they might be, some sort of rotations built up incrementally from the parent bones.
- this function removed all animation drivers and constraints from the bones, and obviously if the user has applied these, they are needed for the results to be what the user created.