### PR TITLE
Fix scene header confusion bug introduced in multi-file export changes

### DIFF
--- a/fast64_internal/oot/c_writer/oot_level_c.py
+++ b/fast64_internal/oot/c_writer/oot_level_c.py
@@ -580,34 +580,27 @@ def ootSceneCollisionToC(scene):
 	sceneCollisionC.append(ootCollisionToC(scene.collision))
 	return sceneCollisionC
 
+# scene is either None or an OOTScene. This can either be the main scene itself,
+# or one of the alternate / cutscene headers.
 def ootGetCutsceneC(scene, headerIndex):
-	sceneCutscenesC = []
-
-	if scene.writeCutscene:
+	if scene is not None and scene.writeCutscene:
 		if scene.csWriteType == 'Embedded':
-			sceneCutscenesC.append(ootCutsceneDataToC(scene, scene.cutsceneDataName(headerIndex)))
+			return [ootCutsceneDataToC(scene, scene.cutsceneDataName(headerIndex))]
 		elif scene.csWriteType == 'Object':
-			sceneCutscenesC.append(ootCutsceneDataToC(scene.csWriteObject, scene.csWriteObject.name))
-
-	for ec in scene.extraCutscenes:
-		sceneCutscenesC.append(ootCutsceneDataToC(ec, ec.name))
-	
-	return sceneCutscenesC
+			return [ootCutsceneDataToC(scene.csWriteObject, scene.csWriteObject.name)]
+	return []
 
 def ootSceneCutscenesToC(scene):
-	sceneCutscenes = []
-	if scene.childNightHeader is not None:
-		sceneCutscenes.extend(ootGetCutsceneC(scene, 1))
-
-	if scene.adultDayHeader is not None:
-		sceneCutscenes.extend(ootGetCutsceneC(scene, 2))
-
-	if scene.adultNightHeader is not None:
-		sceneCutscenes.extend(ootGetCutsceneC(scene, 3))
-
+	sceneCutscenes = ootGetCutsceneC(scene, 0)
+	sceneCutscenes.extend(ootGetCutsceneC(scene.childNightHeader, 1))
+	sceneCutscenes.extend(ootGetCutsceneC(scene.adultDayHeader, 2))
+	sceneCutscenes.extend(ootGetCutsceneC(scene.adultNightHeader, 3))
+	
 	for i in range(len(scene.cutsceneHeaders)):
-		sceneCutscenes.extend(ootGetCutsceneC(scene, i + 4))
-
+		sceneCutscenes.extend(ootGetCutsceneC(scene.cutsceneHeaders[i], i + 4))
+	for ec in scene.extraCutscenes:
+		sceneCutscenes.append(ootCutsceneDataToC(ec, ec.name))
+	
 	return sceneCutscenes
 
 def ootLevelToC(scene, textureExportSettings):

--- a/fast64_internal/oot/oot_level_writer.py
+++ b/fast64_internal/oot/oot_level_writer.py
@@ -179,10 +179,11 @@ def readSceneData(scene, sceneHeader, alternateSceneHeaders):
 				raise PluginError('Cutscene empty object should not be parented to anything')
 			else:
 				scene.csWriteObject = convertCutsceneObject(sceneHeader.csWriteObject)
-	for ec in sceneHeader.extraCutscenes:
-		scene.extraCutscenes.append(convertCutsceneObject(ec.csObject))
-
+	
 	if alternateSceneHeaders is not None:
+		for ec in sceneHeader.extraCutscenes:
+			scene.extraCutscenes.append(convertCutsceneObject(ec.csObject))
+		
 		scene.collision.cameraData = OOTCameraData(scene.name)
 
 		if not alternateSceneHeaders.childNightHeader.usePreviousHeader:
@@ -202,6 +203,9 @@ def readSceneData(scene, sceneHeader, alternateSceneHeaders):
 			cutsceneHeader = scene.getAlternateHeaderScene(scene.name)
 			readSceneData(cutsceneHeader, cutsceneHeaderProp, None)
 			scene.cutsceneHeaders.append(cutsceneHeader)
+	else:
+		if len(sceneHeader.extraCutscenes) > 0:
+			raise PluginError("Extra cutscenes (not in any header) only belong in the main scene, not alternate headers")
 
 def getConvertedTransform(transformMatrix, sceneObj, obj, handleOrientation):
 	

--- a/fast64_internal/oot/oot_scene_room.py
+++ b/fast64_internal/oot/oot_scene_room.py
@@ -419,13 +419,14 @@ def drawSceneHeaderProperty(layout, sceneProp, dropdownLabel, headerIndex, objNa
 				for i, p in enumerate(sceneProp.csLists):
 					drawCSListProperty(cutscene, p, i, objName, collectionType)
 				drawCSAddButtons(cutscene, objName, collectionType)
-		cutscene.label(text = "Extra cutscenes (not in any header):")
-		for i in range(len(sceneProp.extraCutscenes)):
-			box = cutscene.box().column()
-			drawCollectionOps(box, i, "extraCutscenes", None, objName, True)
-			box.prop(sceneProp.extraCutscenes[i], "csObject", text = "CS obj")
-		if len(sceneProp.extraCutscenes) == 0:
-			drawAddButton(cutscene, 0, "extraCutscenes", 0, objName)
+		if headerIndex is None or headerIndex == 0:
+			cutscene.label(text = "Extra cutscenes (not in any header):")
+			for i in range(len(sceneProp.extraCutscenes)):
+				box = cutscene.box().column()
+				drawCollectionOps(box, i, "extraCutscenes", None, objName, True)
+				box.prop(sceneProp.extraCutscenes[i], "csObject", text = "CS obj")
+			if len(sceneProp.extraCutscenes) == 0:
+				drawAddButton(cutscene, 0, "extraCutscenes", 0, objName)
 
 	elif menuTab == 'Exits':
 		if headerIndex is None or headerIndex == 0:


### PR DESCRIPTION
The code for making a list of all the cutscenes to be included in a scene was wrong, it ignored the main header and then exported duplicates of the main header cutscene for all other headers.

In the process I also realized that the "extra cutscenes" feature--to enable cutscene data to be included in a scene file, but not referenced from any scene header--could be used from any of the alternate scene headers. This is nonsense because the whole point is that these cutscenes are not associated with any header. So I've added code to ensure this feature is only usable from the main scene.