### PR TITLE
Fix different actors per room header

### DIFF
--- a/fast64_internal/oot/oot_actor.py
+++ b/fast64_internal/oot/oot_actor.py
@@ -57,17 +57,31 @@ def drawActorHeaderProperty(layout, headerProp, propUser, altProp, objName):
 	if headerProp.sceneSetupPreset == "Custom":
 		headerSetupBox = headerSetup.column()
 		headerSetupBox.prop(headerProp, 'childDayHeader', text = "Child Day")
+		prevHeaderName = 'childDayHeader'
 		childNightRow = headerSetupBox.row()
-		childNightRow.prop(headerProp, 'childNightHeader', text = "Child Night")
+		if altProp is None or altProp.childNightHeader.usePreviousHeader:
+			# Draw previous header checkbox (so get previous state), but labeled
+			# as current one and grayed out
+			childNightRow.prop(headerProp, prevHeaderName, text = "Child Night") 
+			childNightRow.enabled = False
+		else:
+			childNightRow.prop(headerProp, 'childNightHeader', text = "Child Night")
+			prevHeaderName = 'childNightHeader'
 		adultDayRow = headerSetupBox.row()
-		adultDayRow.prop(headerProp, 'adultDayHeader', text = "Adult Day")
+		if altProp is None or altProp.adultDayHeader.usePreviousHeader:
+			adultDayRow.prop(headerProp, prevHeaderName, text = "Adult Day")
+			adultDayRow.enabled = False
+		else:
+			adultDayRow.prop(headerProp, 'adultDayHeader', text = "Adult Day")
+			prevHeaderName = 'adultDayHeader'
 		adultNightRow = headerSetupBox.row()
-		adultNightRow.prop(headerProp, 'adultNightHeader', text = "Adult Night")
+		if altProp is None or altProp.adultNightHeader.usePreviousHeader:
+			adultNightRow.prop(headerProp, prevHeaderName, text = "Adult Night")
+			adultNightRow.enabled = False
+		else:
+			adultNightRow.prop(headerProp, 'adultNightHeader', text = "Adult Night")
 
-		childNightRow.enabled = not altProp.childNightHeader.usePreviousHeader if altProp is not None else True
-		adultDayRow.enabled = not altProp.adultDayHeader.usePreviousHeader if altProp is not None else True
-		adultNightRow.enabled = not altProp.adultNightHeader.usePreviousHeader if altProp is not None else True
-
+		headerSetupBox.row().label(text = 'Cutscene headers to include this actor in:')
 		for i in range(len(headerProp.cutsceneHeaders)):
 			drawActorHeaderItemProperty(headerSetup, propUser, headerProp.cutsceneHeaders[i], i, altProp, objName)
 		drawAddButton(headerSetup, len(headerProp.cutsceneHeaders), propUser, None, objName)

--- a/fast64_internal/oot/oot_level_classes.py
+++ b/fast64_internal/oot/oot_level_classes.py
@@ -379,7 +379,6 @@ class OOTRoom:
 
 	def getAlternateHeaderRoom(self, name):
 		room = OOTRoom(self.index, name, self.mesh.model, self.mesh.meshType)
-		room.actorList = self.actorList
 		room.mesh = self.mesh
 		return room
 
@@ -427,7 +426,7 @@ def addActor(owner, actor, actorProp, propName, actorObjName):
 		for cutsceneHeader in sceneSetup.cutsceneHeaders:
 			if cutsceneHeader.headerIndex >= len(owner.cutsceneHeaders) + 4:
 				raise PluginError(actorObjName + " uses a cutscene header index that is outside the range of the current number of cutscene headers.")
-			getattr(owner.cutsceneHeaders[cutsceneHeader.headerIndex - 4]).add(actor)
+			getattr(owner.cutsceneHeaders[cutsceneHeader.headerIndex - 4], propName).add(actor)
 	else:
 		raise PluginError("Unhandled scene setup preset: " + str(sceneSetup.sceneSetupPreset))
 


### PR DESCRIPTION
Previously, having actors only in some room headers did not work correctly. There was a syntax error caused by an omitted parameter, but even after fixing that, all actors were put in all room headers regardless of their settings. This was because the line `room.actorList = self.actorList` assigned the same `set` to all room headers, so that actors added to any of them would be added to all of them. It's not clear why the code was wrong like this, or why it uses a set in the first place; maybe someone should look at the corresponding SM64 code to see if that's also broken.

This commit also improves the GUI for custom header settings for actors, so that the grayed-out rows (for headers set to use previous headers) show the state of the referenced header, rather than showing the true value of the parameter for those disabled headers (default true, even if the referenced header was false). Now, checking or unchecking the box for the main header appears to check or uncheck the boxes for the other headers, though the other headers are actually just showing the main header parameter again.