### PR TITLE
Make Fast64 use LoadGeometryMode when Write All material mode is used

### DIFF
--- a/fast64_internal/f3d/f3d_gbi.py
+++ b/fast64_internal/f3d/f3d_gbi.py
@@ -3768,6 +3768,37 @@ def geoFlagListToWord(flagList, f3d):
 	
 	return word
 
+class SPGeometryMode:
+	# Note: SPGeometryMode can only be used with GBI 2
+	def __init__(self, clearFlagList, setFlagList):
+		self.clearFlagList = clearFlagList
+		self.setFlagList = setFlagList
+    
+	def to_binary(self, f3d, segments):
+		wordClear = geoFlagListToWord(self.clearFlagList, f3d)
+		wordSet = geoFlagListToWord(self.setFlagList, f3d)
+
+		return gsSPGeometryMode_F3DEX_GBI_2(wordClear, wordSet, f3d)
+
+	def to_c(self, static = True):
+		data = 'gsSPGeometryMode(' if static else \
+			'gSPGeometryMode(glistp++, '
+		data += ((' | '.join(self.clearFlaglist)) if len(self.clearFlagList) > 0 else '0') + ', '
+		data += ((' | '.join(self.setFlagList)) if len(self.setFlagList) > 0 else '0') + ')'
+		return data
+
+	def to_sm64_decomp_s(self):
+		data = 'gsSPGeometryMode '
+		for flag in self.clearFlagList:
+			data += flag + ' | '
+		data = data[:-3] + ', '
+		for flag in self.setFlagList:
+			data += flag + ' | '
+		return data[:-3]
+	
+	def size(self, f3d):
+		return GFX_SIZE
+
 class SPSetGeometryMode:
 	def __init__(self, flagList):
 		self.flagList = flagList

--- a/fast64_internal/f3d/f3d_gbi.py
+++ b/fast64_internal/f3d/f3d_gbi.py
@@ -3769,16 +3769,18 @@ def geoFlagListToWord(flagList, f3d):
 	return word
 
 class SPGeometryMode:
-	# Note: SPGeometryMode can only be used with GBI 2
 	def __init__(self, clearFlagList, setFlagList):
 		self.clearFlagList = clearFlagList
 		self.setFlagList = setFlagList
     
 	def to_binary(self, f3d, segments):
-		wordClear = geoFlagListToWord(self.clearFlagList, f3d)
-		wordSet = geoFlagListToWord(self.setFlagList, f3d)
+		if f3d.F3DEX_GBI_2:
+			wordClear = geoFlagListToWord(self.clearFlagList, f3d)
+			wordSet = geoFlagListToWord(self.setFlagList, f3d)
 
-		return gsSPGeometryMode_F3DEX_GBI_2(wordClear, wordSet, f3d)
+			return gsSPGeometryMode_F3DEX_GBI_2(wordClear, wordSet, f3d)
+		else:
+			raise PluginError("LoadGeometryMode only available in F3DEX_GBI_2.")
 
 	def to_c(self, static = True):
 		data = 'gsSPGeometryMode(' if static else \

--- a/fast64_internal/f3d/f3d_gbi.py
+++ b/fast64_internal/f3d/f3d_gbi.py
@@ -3780,7 +3780,7 @@ class SPGeometryMode:
 
 			return gsSPGeometryMode_F3DEX_GBI_2(wordClear, wordSet, f3d)
 		else:
-			raise PluginError("LoadGeometryMode only available in F3DEX_GBI_2.")
+			raise PluginError("GeometryMode only available in F3DEX_GBI_2.")
 
 	def to_c(self, static = True):
 		data = 'gsSPGeometryMode(' if static else \

--- a/fast64_internal/f3d/f3d_writer.py
+++ b/fast64_internal/f3d/f3d_writer.py
@@ -1248,7 +1248,7 @@ def saveOrGetF3DMaterial(material, fModel, obj, drawLayer, convertTextureData):
 
 	defaults = bpy.context.scene.world.rdp_defaults
 	if bpy.context.scene.f3d_type == 'F3DEX_GBI_2':
-		saveGeoModeDefinitionGBI2(fMaterial, f3dMat.rdp_settings, defaults, fModel.matWriteMethod)
+		saveGeoModeDefinitionF3DEX2(fMaterial, f3dMat.rdp_settings, defaults, fModel.matWriteMethod)
 	else:
 		saveGeoModeDefinition(fMaterial, f3dMat.rdp_settings, defaults, fModel.matWriteMethod)
 	saveOtherModeHDefinition(fMaterial, f3dMat.rdp_settings, defaults, fModel.f3d._HW_VERSION_1, fModel.matWriteMethod)
@@ -2027,39 +2027,37 @@ def normToSigned8Vector(normal):
 	return [int.from_bytes(int(value * 127).to_bytes(1, 'big',
 		signed = True), 'big') for value in normal]
 
-def saveBitGeoGBI2(value, defaultValue, flagName, geo, matWriteMethod):
+def saveBitGeoF3DEX2(value, defaultValue, flagName, geo, matWriteMethod):
 	if value != defaultValue or matWriteMethod == GfxMatWriteMethod.WriteAll:
 		if value:
 			geo.setFlagList.append(flagName)
 		else:
 			geo.clearFlagList.append(flagName)
 
-def saveGeoModeDefinitionGBI2(fMaterial, settings, defaults, matWriteMethod):
+def saveGeoModeDefinitionF3DEX2(fMaterial, settings, defaults, matWriteMethod):
 	geo = SPGeometryMode([],[])
 
-	saveBitGeoGBI2(settings.g_zbuffer, defaults.g_zbuffer, 'G_ZBUFFER',
+	saveBitGeoF3DEX2(settings.g_zbuffer, defaults.g_zbuffer, 'G_ZBUFFER',
 		geo, matWriteMethod)
-	saveBitGeoGBI2(settings.g_shade, defaults.g_shade, 'G_SHADE',
+	saveBitGeoF3DEX2(settings.g_shade, defaults.g_shade, 'G_SHADE',
 		geo, matWriteMethod)
-	saveBitGeoGBI2(settings.g_cull_front, defaults.g_cull_front, 'G_CULL_FRONT',
+	saveBitGeoF3DEX2(settings.g_cull_front, defaults.g_cull_front, 'G_CULL_FRONT',
 		geo, matWriteMethod)
-	saveBitGeoGBI2(settings.g_cull_back,  defaults.g_cull_back, 'G_CULL_BACK',
+	saveBitGeoF3DEX2(settings.g_cull_back,  defaults.g_cull_back, 'G_CULL_BACK',
 		geo, matWriteMethod)
-	saveBitGeoGBI2(settings.g_fog, defaults.g_fog, 'G_FOG', geo, matWriteMethod)
-	saveBitGeoGBI2(settings.g_lighting, defaults.g_lighting, 'G_LIGHTING',
+	saveBitGeoF3DEX2(settings.g_fog, defaults.g_fog, 'G_FOG', geo, matWriteMethod)
+	saveBitGeoF3DEX2(settings.g_lighting, defaults.g_lighting, 'G_LIGHTING',
 		geo, matWriteMethod)
 
 	# make sure normals are saved correctly.
-	saveBitGeoGBI2(settings.g_tex_gen, defaults.g_tex_gen, 'G_TEXTURE_GEN',
+	saveBitGeoF3DEX2(settings.g_tex_gen, defaults.g_tex_gen, 'G_TEXTURE_GEN',
 		geo, matWriteMethod)
-	saveBitGeoGBI2(settings.g_tex_gen_linear, defaults.g_tex_gen_linear,
+	saveBitGeoF3DEX2(settings.g_tex_gen_linear, defaults.g_tex_gen_linear,
 		'G_TEXTURE_GEN_LINEAR', geo, matWriteMethod)
-	saveBitGeoGBI2(settings.g_shade_smooth, defaults.g_shade_smooth,
+	saveBitGeoF3DEX2(settings.g_shade_smooth, defaults.g_shade_smooth,
 		'G_SHADING_SMOOTH', geo, matWriteMethod)
-	if bpy.context.scene.f3d_type == 'F3DEX_GBI_2' or \
-		bpy.context.scene.f3d_type == 'F3DEX_GBI':
-		saveBitGeoGBI2(settings.g_clipping, defaults.g_clipping, 'G_CLIPPING',
-			geo, matWriteMethod)
+	saveBitGeoF3DEX2(settings.g_clipping, defaults.g_clipping, 'G_CLIPPING',
+		geo, matWriteMethod)
 
 	if len(geo.clearFlagList) == 0:
 		geo.clearFlagList.append('0')
@@ -2070,8 +2068,6 @@ def saveGeoModeDefinitionGBI2(fMaterial, settings, defaults, matWriteMethod):
 		fMaterial.material.commands.append(SPLoadGeometryMode(geo.setFlagList))
 	else:
 		fMaterial.material.commands.append(geo)
-
-	if matWriteMethod == GfxMatWriteMethod.WriteDifferingAndRevert:
 		fMaterial.revert.commands.append(SPGeometryMode(geo.setFlagList, geo.clearFlagList))
 
 def saveBitGeo(value, defaultValue, flagName, setGeo, clearGeo, matWriteMethod):

--- a/fast64_internal/f3d/f3d_writer.py
+++ b/fast64_internal/f3d/f3d_writer.py
@@ -2074,14 +2074,11 @@ def saveBitGeo(value, defaultValue, flagName, setGeo, clearGeo, matWriteMethod):
 	if value != defaultValue or matWriteMethod == GfxMatWriteMethod.WriteAll:
 		if value:
 			setGeo.flagList.append(flagName)
-		elif matWriteMethod != GfxMatWriteMethod.WriteAll:
+		else:
 			clearGeo.flagList.append(flagName)
 
 def saveGeoModeDefinition(fMaterial, settings, defaults, matWriteMethod):
-	if matWriteMethod == GfxMatWriteMethod.WriteAll:
-		setGeo = SPLoadGeometryMode([])
-	else:
-		setGeo = SPSetGeometryMode([])
+	setGeo = SPSetGeometryMode([])
 	clearGeo = SPClearGeometryMode([])
 
 	saveBitGeo(settings.g_zbuffer, defaults.g_zbuffer, 'G_ZBUFFER',

--- a/fast64_internal/f3d/f3d_writer.py
+++ b/fast64_internal/f3d/f3d_writer.py
@@ -1247,7 +1247,10 @@ def saveOrGetF3DMaterial(material, fModel, obj, drawLayer, convertTextureData):
 		defaultRM = None
 
 	defaults = bpy.context.scene.world.rdp_defaults
-	saveGeoModeDefinition(fMaterial, f3dMat.rdp_settings, defaults, fModel.matWriteMethod)
+	if (fModel.matWriteMethod == GfxMatWriteMethod.WriteAll):
+		saveGeoModeDefinition(fMaterial, f3dMat.rdp_settings, defaults, fModel.matWriteMethod)
+	else:
+		saveGeoModeDefinition(fMaterial, f3dMat.rdp_settings, defaults, fModel.matWriteMethod)
 	saveOtherModeHDefinition(fMaterial, f3dMat.rdp_settings, defaults, fModel.f3d._HW_VERSION_1, fModel.matWriteMethod)
 	saveOtherModeLDefinition(fMaterial, f3dMat.rdp_settings, defaults, defaultRM, fModel.matWriteMethod)
 	saveOtherDefinition(fMaterial, f3dMat, defaults)
@@ -2028,11 +2031,14 @@ def saveBitGeo(value, defaultValue, flagName, setGeo, clearGeo, matWriteMethod):
 	if value != defaultValue or matWriteMethod == GfxMatWriteMethod.WriteAll:
 		if value:
 			setGeo.flagList.append(flagName)
-		else:
+		elif matWriteMethod != GfxMatWriteMethod.WriteAll:
 			clearGeo.flagList.append(flagName)
 
 def saveGeoModeDefinition(fMaterial, settings, defaults, matWriteMethod):
-	setGeo = SPSetGeometryMode([])
+	if matWriteMethod == GfxMatWriteMethod.WriteAll:
+		setGeo = SPLoadGeometryMode([])
+	else:
+		setGeo = SPSetGeometryMode([])
 	clearGeo = SPClearGeometryMode([])
 
 	saveBitGeo(settings.g_zbuffer, defaults.g_zbuffer, 'G_ZBUFFER',

--- a/fast64_internal/f3d/f3d_writer.py
+++ b/fast64_internal/f3d/f3d_writer.py
@@ -1247,8 +1247,8 @@ def saveOrGetF3DMaterial(material, fModel, obj, drawLayer, convertTextureData):
 		defaultRM = None
 
 	defaults = bpy.context.scene.world.rdp_defaults
-	if (fModel.matWriteMethod == GfxMatWriteMethod.WriteAll):
-		saveGeoModeDefinition(fMaterial, f3dMat.rdp_settings, defaults, fModel.matWriteMethod)
+	if bpy.context.scene.f3d_type == 'F3DEX_GBI_2':
+		saveGeoModeDefinitionGBI2(fMaterial, f3dMat.rdp_settings, defaults, fModel.matWriteMethod)
 	else:
 		saveGeoModeDefinition(fMaterial, f3dMat.rdp_settings, defaults, fModel.matWriteMethod)
 	saveOtherModeHDefinition(fMaterial, f3dMat.rdp_settings, defaults, fModel.f3d._HW_VERSION_1, fModel.matWriteMethod)
@@ -2026,6 +2026,49 @@ def getObjDirection(obj):
 def normToSigned8Vector(normal):
 	return [int.from_bytes(int(value * 127).to_bytes(1, 'big',
 		signed = True), 'big') for value in normal]
+
+def saveBitGeoGBI2(value, defaultValue, flagName, geo, matWriteMethod):
+	if value != defaultValue or matWriteMethod == GfxMatWriteMethod.WriteAll:
+		if value:
+			geo.setFlagList.append(flagName)
+		elif matWriteMethod != GfxMatWriteMethod.WriteAll:
+			geo.clearFlagList.append(flagName)
+
+def saveGeoModeDefinitionGBI2(fMaterial, settings, defaults, matWriteMethod):
+	geo = SPGeometryMode([],[])
+
+	saveBitGeoGBI2(settings.g_zbuffer, defaults.g_zbuffer, 'G_ZBUFFER',
+		geo, matWriteMethod)
+	saveBitGeoGBI2(settings.g_shade, defaults.g_shade, 'G_SHADE',
+		geo, matWriteMethod)
+	saveBitGeoGBI2(settings.g_cull_front, defaults.g_cull_front, 'G_CULL_FRONT',
+		geo, matWriteMethod)
+	saveBitGeoGBI2(settings.g_cull_back,  defaults.g_cull_back, 'G_CULL_BACK',
+		geo, matWriteMethod)
+	saveBitGeoGBI2(settings.g_fog, defaults.g_fog, 'G_FOG', geo, matWriteMethod)
+	saveBitGeoGBI2(settings.g_lighting, defaults.g_lighting, 'G_LIGHTING',
+		geo, matWriteMethod)
+
+	# make sure normals are saved correctly.
+	saveBitGeoGBI2(settings.g_tex_gen, defaults.g_tex_gen, 'G_TEXTURE_GEN',
+		geo, matWriteMethod)
+	saveBitGeoGBI2(settings.g_tex_gen_linear, defaults.g_tex_gen_linear,
+		'G_TEXTURE_GEN_LINEAR', geo, matWriteMethod)
+	saveBitGeoGBI2(settings.g_shade_smooth, defaults.g_shade_smooth,
+		'G_SHADING_SMOOTH', geo, matWriteMethod)
+	if bpy.context.scene.f3d_type == 'F3DEX_GBI_2' or \
+		bpy.context.scene.f3d_type == 'F3DEX_GBI':
+		saveBitGeoGBI2(settings.g_clipping, defaults.g_clipping, 'G_CLIPPING',
+			geo, matWriteMethod)
+
+	if len(geo.clearFlagList) == 0 and len(geo.setFlagList) > 0:
+		fMaterial.material.commands.append(SPLoadGeometryMode(geo.setFlagList))
+	elif len(geo.setFlagList) == 0:
+		geo.setFlagList.append('0')
+		fMaterial.material.commands.append(geo)
+
+	if matWriteMethod == GfxMatWriteMethod.WriteDifferingAndRevert:
+		fMaterial.revert.commands.append(SPGeometryMode(geo.clearFlagList, geo.setFlagList))
 
 def saveBitGeo(value, defaultValue, flagName, setGeo, clearGeo, matWriteMethod):
 	if value != defaultValue or matWriteMethod == GfxMatWriteMethod.WriteAll:

--- a/fast64_internal/f3d/f3d_writer.py
+++ b/fast64_internal/f3d/f3d_writer.py
@@ -2070,6 +2070,8 @@ def saveGeoModeDefinitionGBI2(fMaterial, settings, defaults, matWriteMethod):
 	elif len(geo.setFlagList) == 0 and len(geo.clearFlagList) > 0:
 		geo.setFlagList.append('0')
 		fMaterial.material.commands.append(geo)
+	else:
+		fMaterial.material.commands.append(geo)
 
 	if matWriteMethod == GfxMatWriteMethod.WriteDifferingAndRevert:
 		fMaterial.revert.commands.append(SPGeometryMode(geo.clearFlagList, geo.setFlagList))

--- a/fast64_internal/f3d/f3d_writer.py
+++ b/fast64_internal/f3d/f3d_writer.py
@@ -2031,7 +2031,7 @@ def saveBitGeoGBI2(value, defaultValue, flagName, geo, matWriteMethod):
 	if value != defaultValue or matWriteMethod == GfxMatWriteMethod.WriteAll:
 		if value:
 			geo.setFlagList.append(flagName)
-		elif matWriteMethod != GfxMatWriteMethod.WriteAll:
+		else:
 			geo.clearFlagList.append(flagName)
 
 def saveGeoModeDefinitionGBI2(fMaterial, settings, defaults, matWriteMethod):
@@ -2062,8 +2062,12 @@ def saveGeoModeDefinitionGBI2(fMaterial, settings, defaults, matWriteMethod):
 			geo, matWriteMethod)
 
 	if len(geo.clearFlagList) == 0 and len(geo.setFlagList) > 0:
-		fMaterial.material.commands.append(SPLoadGeometryMode(geo.setFlagList))
-	elif len(geo.setFlagList) == 0:
+		if matWriteMethod == GfxMatWriteMethod.WriteAll:
+			fMaterial.material.commands.append(SPLoadGeometryMode(geo.setFlagList))
+		else:
+			geo.clearFlagList.append('0')
+			fMaterial.material.commands.append(geo)
+	elif len(geo.setFlagList) == 0 and len(geo.clearFlagList) > 0:
 		geo.setFlagList.append('0')
 		fMaterial.material.commands.append(geo)
 

--- a/fast64_internal/f3d/f3d_writer.py
+++ b/fast64_internal/f3d/f3d_writer.py
@@ -2061,15 +2061,13 @@ def saveGeoModeDefinitionGBI2(fMaterial, settings, defaults, matWriteMethod):
 		saveBitGeoGBI2(settings.g_clipping, defaults.g_clipping, 'G_CLIPPING',
 			geo, matWriteMethod)
 
-	if len(geo.clearFlagList) == 0 and len(geo.setFlagList) > 0:
-		if matWriteMethod == GfxMatWriteMethod.WriteAll:
-			fMaterial.material.commands.append(SPLoadGeometryMode(geo.setFlagList))
-		else:
-			geo.clearFlagList.append('0')
-			fMaterial.material.commands.append(geo)
-	elif len(geo.setFlagList) == 0 and len(geo.clearFlagList) > 0:
+	if len(geo.clearFlagList) == 0:
+		geo.clearFlagList.append('0')
+	elif len(geo.setFlagList) == 0:
 		geo.setFlagList.append('0')
-		fMaterial.material.commands.append(geo)
+
+	if matWriteMethod == GfxMatWriteMethod.WriteAll:
+		fMaterial.material.commands.append(SPLoadGeometryMode(geo.setFlagList))
 	else:
 		fMaterial.material.commands.append(geo)
 

--- a/fast64_internal/f3d/f3d_writer.py
+++ b/fast64_internal/f3d/f3d_writer.py
@@ -2072,7 +2072,7 @@ def saveGeoModeDefinitionGBI2(fMaterial, settings, defaults, matWriteMethod):
 		fMaterial.material.commands.append(geo)
 
 	if matWriteMethod == GfxMatWriteMethod.WriteDifferingAndRevert:
-		fMaterial.revert.commands.append(SPGeometryMode(geo.clearFlagList, geo.setFlagList))
+		fMaterial.revert.commands.append(SPGeometryMode(geo.setFlagList, geo.clearFlagList))
 
 def saveBitGeo(value, defaultValue, flagName, setGeo, clearGeo, matWriteMethod):
 	if value != defaultValue or matWriteMethod == GfxMatWriteMethod.WriteAll:


### PR DESCRIPTION
This PR aims to simplify material output when the Write All material method is used.
```
gsSPSetGeometryMode(G_SHADE | G_CULL_FRONT | G_SHADING_SMOOTH),
gsSPClearGeometryMode(G_ZBUFFER | G_CULL_BACK | G_FOG | G_LIGHTING | G_TEXTURE_GEN | G_TEXTURE_GEN_LINEAR),
```
now becomes
```
gsSPLoadGeometryMode(G_SHADE | G_CULL_FRONT | G_SHADING_SMOOTH),
```