### PR TITLE
deprecate combined_params - upgrade all objects in blend

### DIFF
--- a/fast64_internal/f3d/f3d_gbi.py
+++ b/fast64_internal/f3d/f3d_gbi.py
@@ -3785,7 +3785,7 @@ class SPGeometryMode:
 	def to_c(self, static = True):
 		data = 'gsSPGeometryMode(' if static else \
 			'gSPGeometryMode(glistp++, '
-		data += ((' | '.join(self.clearFlaglist)) if len(self.clearFlagList) > 0 else '0') + ', '
+		data += ((' | '.join(self.clearFlagList)) if len(self.clearFlagList) > 0 else '0') + ', '
 		data += ((' | '.join(self.setFlagList)) if len(self.setFlagList) > 0 else '0') + ')'
 		return data
 

--- a/fast64_internal/f3d/f3d_writer.py
+++ b/fast64_internal/f3d/f3d_writer.py
@@ -2059,16 +2059,17 @@ def saveGeoModeDefinitionF3DEX2(fMaterial, settings, defaults, matWriteMethod):
 	saveBitGeoF3DEX2(settings.g_clipping, defaults.g_clipping, 'G_CLIPPING',
 		geo, matWriteMethod)
 
-	if len(geo.clearFlagList) == 0:
-		geo.clearFlagList.append('0')
-	elif len(geo.setFlagList) == 0:
-		geo.setFlagList.append('0')
+	if len(geo.clearFlagList) != 0 or len(geo.setFlagList) != 0:
+		if len(geo.clearFlagList) == 0:
+			geo.clearFlagList.append('0')
+		elif len(geo.setFlagList) == 0:
+			geo.setFlagList.append('0')
 
-	if matWriteMethod == GfxMatWriteMethod.WriteAll:
-		fMaterial.material.commands.append(SPLoadGeometryMode(geo.setFlagList))
-	else:
-		fMaterial.material.commands.append(geo)
-		fMaterial.revert.commands.append(SPGeometryMode(geo.setFlagList, geo.clearFlagList))
+		if matWriteMethod == GfxMatWriteMethod.WriteAll:
+			fMaterial.material.commands.append(SPLoadGeometryMode(geo.setFlagList))
+		else:
+			fMaterial.material.commands.append(geo)
+			fMaterial.revert.commands.append(SPGeometryMode(geo.setFlagList, geo.clearFlagList))
 
 def saveBitGeo(value, defaultValue, flagName, setGeo, clearGeo, matWriteMethod):
 	if value != defaultValue or matWriteMethod == GfxMatWriteMethod.WriteAll:

--- a/fast64_internal/sm64/sm64_objects.py
+++ b/fast64_internal/sm64/sm64_objects.py
@@ -1509,14 +1509,6 @@ class SM64_GameObjectProperties(bpy.types.PropertyGroup):
 		if (game_object.bparams != DEFAULT_BEHAVIOR_PARAMS):
 			game_object.use_individual_params = False
 
-	@staticmethod
-	def remove_unused_props(obj: bpy.types.Object):
-		game_object: SM64_GameObjectProperties = obj.fast64.sm64.game_object
-
-  		# replaced "combined_bparams" with method `get_combined_bparams`
-		if "combined_bparams" in game_object:
-			del game_object["combined_bparams"]
-
 	def get_combined_bparams(self):
 		params = [self.bparam1, self.bparam2, self.bparam3, self.bparam4]
 		fmt_params = []
@@ -1538,7 +1530,7 @@ class SM64_GameObjectProperties(bpy.types.PropertyGroup):
 
 class SM64_ObjectProperties(bpy.types.PropertyGroup):
 	version: bpy.props.IntProperty(name="SM64_ObjectProperties Version", default=0)
-	cur_version = 4 # version after property migration
+	cur_version = 3 # version after property migration
 
 	geo_asm: bpy.props.PointerProperty(type=SM64_GeoASMProperties)
 	level: bpy.props.PointerProperty(type=SM64_LevelProperties)
@@ -1552,8 +1544,6 @@ class SM64_ObjectProperties(bpy.types.PropertyGroup):
 				SM64_GeoASMProperties.upgrade_object(obj)
 			if obj.fast64.sm64.version < 3:
 				SM64_GameObjectProperties.upgrade_object(obj)
-			if obj.fast64.sm64.version < 4:
-				SM64_GameObjectProperties.remove_unused_props(obj)
 			obj.fast64.sm64.version = SM64_ObjectProperties.cur_version
 
 sm64_obj_classes = (


### PR DESCRIPTION
[issue 1: only objects in the first loaded scene were getting updated](https://canary.discord.com/channels/874816709855440926/874816710639767585/931351721232437249)
i was originally under the impression that changing scenes would run the persistent handlers, but its only when first loading a blend. so i changed iterating `bpy.context.scene.objects` to `bpy.data.objects`

[issue 2: combined bparams not matching the individuals](https://canary.discord.com/channels/874816709855440926/874816710639767585/931348767792332830)
My solution is to just _always_ derive combined bparams instead of storing it to another field