### PR TITLE
[OoT] Add option to write a dummy room list

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -8,6 +8,7 @@ import os
 from pathlib import Path
 from .fast64_internal import *
 from .fast64_internal.panels import SM64_Panel
+from .fast64_internal.oot.oot_level import OOT_ObjectProperties
 
 import cProfile
 import pstats
@@ -271,6 +272,7 @@ class Fast64_ObjectProperties(bpy.types.PropertyGroup):
 	All new object properties should be children of this property group.
 	'''
 	sm64: bpy.props.PointerProperty(type=SM64_ObjectProperties, name="SM64 Object Properties")
+	oot: bpy.props.PointerProperty(type=OOT_ObjectProperties, name="OOT Object Properties")
 
 
 #def updateGameEditor(scene, context):

--- a/fast64_internal/oot/c_writer/oot_level_c.py
+++ b/fast64_internal/oot/c_writer/oot_level_c.py
@@ -374,17 +374,25 @@ def ootRoomListEntryToC(room):
 def ootRoomListHeaderToC(scene):
 	data = CData()
 
-	# Write externs for rom segments
-	for i in range(len(scene.rooms)):
-		data.source += ootRoomExternToC(scene.rooms[i])
-	data.source += "\n"
-
 	data.header += "extern RomFile " + scene.roomListName() + "[];\n"
-	data.source += "RomFile " + scene.roomListName() + "[] = {\n"
-	
-	for i in range(len(scene.rooms)):
-		data.source += '\t' + ootRoomListEntryToC(scene.rooms[i])
-	data.source += '};\n\n'
+
+	if scene.write_dummy_room_list:
+		data.source += "// Dummy room list\n"
+		data.source += "RomFile " + scene.roomListName() + "[] = {\n"
+		data.source += "\t{0, 0},\n" * len(scene.rooms)
+		data.source += "};\n\n"
+	else:
+		# Write externs for rom segments
+		for i in range(len(scene.rooms)):
+			data.source += ootRoomExternToC(scene.rooms[i])
+		data.source += "\n"
+
+		data.source += "RomFile " + scene.roomListName() + "[] = {\n"
+		
+		for i in range(len(scene.rooms)):
+			data.source += '\t' + ootRoomListEntryToC(scene.rooms[i])
+		data.source += '};\n\n'
+
 	return data
 
 def ootEntranceToC(entrance):

--- a/fast64_internal/oot/oot_level.py
+++ b/fast64_internal/oot/oot_level.py
@@ -89,6 +89,7 @@ class OOTObjectPanel(bpy.types.Panel):
 			drawSceneHeaderProperty(box, obj.ootSceneHeader, None, None, objName)
 			if obj.ootSceneHeader.menuTab == 'Alternate':
 				drawAlternateSceneHeaderProperty(box, obj.ootAlternateSceneHeaders, objName)
+			box.prop(obj.fast64.oot.scene, "write_dummy_room_list")
 
 		elif obj.ootEmptyType == 'Room':
 			drawRoomHeaderProperty(box, obj.ootRoomHeader, None, None, objName)
@@ -166,7 +167,16 @@ def onUpdateOOTEmptyType(self, context):
 			setLightPropertyValues(timeOfDayLights.dusk, [120, 90, 0], [250, 135, 50], [30, 30, 60], [120, 70, 50], 0x3E3)
 			setLightPropertyValues(timeOfDayLights.night, [40, 70, 100], [20, 20, 35], [50, 50, 100], [0, 0, 30], 0x3E0)
 
+class OOT_ObjectProperties(bpy.types.PropertyGroup):
+	version: bpy.props.IntProperty(name="OOT_ObjectProperties Version", default=0)
+	cur_version = 0 # version after property migration
+
+	scene: bpy.props.PointerProperty(type=OOTSceneProperties)
+
 oot_obj_classes = (
+	OOTSceneProperties,
+	OOT_ObjectProperties,
+
 	OOT_SearchActorIDEnumOperator,
 	OOT_SearchMusicSeqEnumOperator,
 	OOT_SearchObjectEnumOperator,

--- a/fast64_internal/oot/oot_level_classes.py
+++ b/fast64_internal/oot/oot_level_classes.py
@@ -126,6 +126,7 @@ class OOTSceneTableEntry:
 class OOTScene:
 	def __init__(self, name, model):
 		self.name = toAlnum(name)
+		self.write_dummy_room_list = False
 		self.rooms = {}
 		self.transitionActorList = set()
 		self.entranceList = set()
@@ -174,6 +175,7 @@ class OOTScene:
 
 	def getAlternateHeaderScene(self, name):
 		scene = OOTScene(name, self.model)
+		scene.write_dummy_room_list = self.write_dummy_room_list
 		scene.rooms = self.rooms
 		scene.collision = self.collision
 		scene.exitList = self.exitList

--- a/fast64_internal/oot/oot_level_writer.py
+++ b/fast64_internal/oot/oot_level_writer.py
@@ -133,7 +133,8 @@ def writeOtherSceneProperties(scene, exportInfo, levelC):
 	modifySegmentDefinition(scene, exportInfo, levelC)
 	modifySceneFiles(scene, exportInfo)
 
-def readSceneData(scene, sceneHeader, alternateSceneHeaders):
+def readSceneData(scene, scene_properties, sceneHeader, alternateSceneHeaders):
+	scene.write_dummy_room_list = scene_properties.write_dummy_room_list
 	scene.sceneTableEntry.drawConfig = sceneHeader.sceneTableEntry.drawConfig
 	scene.globalObject = getCustomProperty(sceneHeader, "globalObject")
 	scene.naviCup = getCustomProperty(sceneHeader, "naviCup")
@@ -188,20 +189,20 @@ def readSceneData(scene, sceneHeader, alternateSceneHeaders):
 
 		if not alternateSceneHeaders.childNightHeader.usePreviousHeader:
 			scene.childNightHeader = scene.getAlternateHeaderScene(scene.name)
-			readSceneData(scene.childNightHeader, alternateSceneHeaders.childNightHeader, None)
+			readSceneData(scene.childNightHeader, scene_properties, alternateSceneHeaders.childNightHeader, None)
 
 		if not alternateSceneHeaders.adultDayHeader.usePreviousHeader:
 			scene.adultDayHeader = scene.getAlternateHeaderScene(scene.name)
-			readSceneData(scene.adultDayHeader, alternateSceneHeaders.adultDayHeader, None)
+			readSceneData(scene.adultDayHeader, scene_properties, alternateSceneHeaders.adultDayHeader, None)
 
 		if not alternateSceneHeaders.adultNightHeader.usePreviousHeader:
 			scene.adultNightHeader = scene.getAlternateHeaderScene(scene.name)
-			readSceneData(scene.adultNightHeader, alternateSceneHeaders.adultNightHeader, None)
+			readSceneData(scene.adultNightHeader, scene_properties, alternateSceneHeaders.adultNightHeader, None)
 
 		for i in range(len(alternateSceneHeaders.cutsceneHeaders)):
 			cutsceneHeaderProp = alternateSceneHeaders.cutsceneHeaders[i]
 			cutsceneHeader = scene.getAlternateHeaderScene(scene.name)
-			readSceneData(cutsceneHeader, cutsceneHeaderProp, None)
+			readSceneData(cutsceneHeader, scene_properties, cutsceneHeaderProp, None)
 			scene.cutsceneHeaders.append(cutsceneHeader)
 	else:
 		if len(sceneHeader.extraCutscenes) > 0:
@@ -344,7 +345,7 @@ def ootConvertScene(originalSceneObj, transformMatrix,
 
 	try:
 		scene = OOTScene(sceneName, OOTModel(f3dType, isHWv1, sceneName + '_dl', DLFormat, None))
-		readSceneData(scene, sceneObj.ootSceneHeader, sceneObj.ootAlternateSceneHeaders)
+		readSceneData(scene, sceneObj.fast64.oot.scene, sceneObj.ootSceneHeader, sceneObj.ootAlternateSceneHeaders)
 		processedRooms = set()
 
 		for obj in sceneObj.children:

--- a/fast64_internal/oot/oot_scene_room.py
+++ b/fast64_internal/oot/oot_scene_room.py
@@ -11,6 +11,16 @@ from .oot_actor import *
 #from .oot_collision import *
 from .oot_cutscene import *
 
+class OOTSceneProperties(bpy.types.PropertyGroup):
+	write_dummy_room_list: bpy.props.BoolProperty(
+		name = "Dummy Room List",
+		default = False,
+		description = (
+			"When exporting the scene to C, use NULL for the pointers to room "
+			"start/end offsets, instead of the appropriate symbols"
+		),
+	)
+
 class OOT_SearchMusicSeqEnumOperator(bpy.types.Operator):
 	bl_idname = "object.oot_search_music_seq_enum_operator"
 	bl_label = "Search Music Sequence"


### PR DESCRIPTION
This adds an option to OoT scene objects:
<details>

![image](https://user-images.githubusercontent.com/5306619/151669072-590dd51a-a924-41f1-ab9f-9ee956a9aa61.png)

</details>

Diff between exporting with the option disabled and with the option enabled:
```diff
 	{ ACTOR_PLAYER, 0, -120, 0, 0, 0, 0, 0x0FFF },
 };
 
-extern u8 _spot03_room_0SegmentRomStart[];
-extern u8 _spot03_room_0SegmentRomEnd[];
-
+// Dummy room list
 RomFile spot03_scene_roomList[] = {
-	{ (u32)_spot03_room_0SegmentRomStart, (u32)_spot03_room_0SegmentRomEnd },
+	{0, 0},
 };
 
 EntranceEntry spot03_scene_header00_entranceList[] = {
```

The intent is to allow compiling the files separately (without linking) and then using the compiled files in tools such as zzrtl.

--------

The PR also introduces `Object.fast64.oot` and `Object.fast64.oot.scene`. Hopefully it doesn't break anything, I don't have much testing material