### PR TITLE
Add warning about RDP bug with alpha compare threshold

### DIFF
--- a/fast64_internal/f3d/f3d_material.py
+++ b/fast64_internal/f3d/f3d_material.py
@@ -396,7 +396,7 @@ def ui_lower_mode(settings, dataHolder, layout: bpy.types.UILayout, useDropdown)
 	if not useDropdown or dataHolder.menu_lower:
 		prop_split(inputGroup, settings, 'g_mdsft_alpha_compare', 'Alpha Compare')
 		if settings.g_mdsft_alpha_compare == 'G_AC_THRESHOLD' and settings.g_mdsft_cycletype == 'G_CYC_2CYCLE':
-			inputGroup.label(text = 'Compares blend alpha to *cycle 1* combined (CC) alpha.')
+			inputGroup.label(text = 'Compares blend alpha to *first cycle* combined (CC) alpha.')
 		prop_split(inputGroup, settings, 'g_mdsft_zsrcsel', 'Z Source Selection')
 	if settings.g_mdsft_zsrcsel == 'G_ZS_PRIM':
 		prim_box = inputGroup.box()
@@ -937,7 +937,7 @@ class F3DPanel(bpy.types.Panel):
 			rowAlpha.prop(f3dMat.combiner1, 'D_alpha')
 			if (f3dMat.rdp_settings.g_mdsft_alpha_compare == 'G_AC_THRESHOLD' 
 				and f3dMat.rdp_settings.g_mdsft_cycletype == 'G_CYC_2CYCLE'):
-				combinerBox.label(text = 'Cycle 1 alpha out used for compare threshold.')
+				combinerBox.label(text = 'First cycle alpha out used for compare threshold.')
 
 			if f3dMat.rdp_settings.g_mdsft_cycletype == 'G_CYC_2CYCLE':
 				combinerBox2 = layout.box()
@@ -957,7 +957,7 @@ class F3DPanel(bpy.types.Panel):
 				rowAlpha2.prop(f3dMat.combiner2, 'D_alpha')
 
 				combinerBox2.label(
-					text = 'Note: In cycle 2, texture 0 and texture 1 are flipped.')
+					text = 'Note: In second cycle, texture 0 and texture 1 are flipped.')
 
 			#layout.box().label(
 			#	text = 'Note: Alpha preview is not 100% accurate.')

--- a/fast64_internal/f3d/f3d_material.py
+++ b/fast64_internal/f3d/f3d_material.py
@@ -395,6 +395,8 @@ def ui_lower_mode(settings, dataHolder, layout: bpy.types.UILayout, useDropdown)
 			icon = 'TRIA_DOWN' if dataHolder.menu_lower else 'TRIA_RIGHT')
 	if not useDropdown or dataHolder.menu_lower:
 		prop_split(inputGroup, settings, 'g_mdsft_alpha_compare', 'Alpha Compare')
+		if settings.g_mdsft_alpha_compare == 'G_AC_THRESHOLD' and settings.g_mdsft_cycletype == 'G_CYC_2CYCLE':
+			inputGroup.label(text = 'Compares blend alpha to *cycle 1* combined (CC) alpha.')
 		prop_split(inputGroup, settings, 'g_mdsft_zsrcsel', 'Z Source Selection')
 	if settings.g_mdsft_zsrcsel == 'G_ZS_PRIM':
 		prim_box = inputGroup.box()
@@ -933,6 +935,9 @@ class F3DPanel(bpy.types.Panel):
 			rowAlpha.prop(f3dMat.combiner1, 'B_alpha')
 			rowAlpha.prop(f3dMat.combiner1, 'C_alpha')
 			rowAlpha.prop(f3dMat.combiner1, 'D_alpha')
+			if (f3dMat.rdp_settings.g_mdsft_alpha_compare == 'G_AC_THRESHOLD' 
+				and f3dMat.rdp_settings.g_mdsft_cycletype == 'G_CYC_2CYCLE'):
+				combinerBox.label(text = 'Cycle 1 alpha out used for compare threshold.')
 
 			if f3dMat.rdp_settings.g_mdsft_cycletype == 'G_CYC_2CYCLE':
 				combinerBox2 = layout.box()
@@ -951,7 +956,7 @@ class F3DPanel(bpy.types.Panel):
 				rowAlpha2.prop(f3dMat.combiner2, 'C_alpha')
 				rowAlpha2.prop(f3dMat.combiner2, 'D_alpha')
 
-				layout.box().label(
+				combinerBox2.label(
 					text = 'Note: In cycle 2, texture 0 and texture 1 are flipped.')
 
 			#layout.box().label(


### PR DESCRIPTION
If using alpha compare threshold in two cycle mode, the alpha input it compares to is the combined alpha from the first cycle, not from the second cycle. The combined alpha value sent to the blender is still the correct combined alpha from the second cycle.

This is not described in the official SGI docs or anywhere else I have seen. In fact it is not mentioned that there is any way to get CC results from the first cycle while in two cycle mode.

Added labels warning users about this if they are using alpha compare threshold in two cycle mode.