### PR TITLE
Added import all DLs feature

### DIFF
--- a/fast64_internal/oot/oot_anim.py
+++ b/fast64_internal/oot/oot_anim.py
@@ -401,7 +401,7 @@ class OOT_ImportAnim(bpy.types.Operator):
 
 class OOT_ExportAnimPanel(OOT_Panel):
 	bl_idname = "OOT_PT_export_anim"
-	bl_label = "OOT Animation Exporter"
+	bl_label = "OOT Animation Import/Export"
 
 	# called every frame
 	def draw(self, context):

--- a/fast64_internal/oot/oot_model_classes.py
+++ b/fast64_internal/oot/oot_model_classes.py
@@ -154,11 +154,12 @@ class OOTF3DContext(F3DContext):
 			return name
 		else:
 			segment = pointer >> 24
-			print("POINTER")
 			if segment >= 0x08 and segment <= 0x0D:
-				print("SETTING " + str(segment))
+				print("Calls DL in segment " + hex(segment))
 				setattr(self.materialContext.ootMaterial.opaque, "segment" + format(segment, "1X"), True)
 				setattr(self.materialContext.ootMaterial.transparent, "segment" + format(segment, "1X"), True)
+			else:
+				print("Calls DL " + name)
 			return None
 		return name
 

--- a/fast64_internal/oot/oot_skeleton.py
+++ b/fast64_internal/oot/oot_skeleton.py
@@ -526,7 +526,7 @@ def ootBuildSkeleton(skeletonName, skeletonData, limbList, actorScale, removeDou
 		limbName = f3dContext.getLimbName(dlEntry.limbIndex)
 		boneName = f3dContext.getBoneName(dlEntry.limbIndex)
 		parseF3D(skeletonData, dlEntry.dlName, obj, f3dContext.matrixData[limbName], 
-			limbName, boneName, "oot", drawLayer, f3dContext)
+			limbName, boneName, "oot", drawLayer, f3dContext, False)
 		if f3dContext.isBillboard:
 			armatureObj.data.bones[boneName].ootDynamicTransform.billboard = True
 		f3dContext.clearMaterial() # THIS IS IMPORTANT
@@ -770,7 +770,7 @@ class OOT_ExportSkeleton(bpy.types.Operator):
 
 class OOT_ExportSkeletonPanel(OOT_Panel):
 	bl_idname = "OOT_PT_export_skeleton"
-	bl_label = "OOT Skeleton Exporter"
+	bl_label = "OOT Skeleton Import/Export"
 
 	# called every frame
 	def draw(self, context):


### PR DESCRIPTION
This adds an option to the OoT DL importer which will import all DLs in the input file. This is a hacky alternative to proper scene import support, but that is much larger in scope. However, this is much better than previously, when importing a scene meant grepping for DLs in the scene file and one by one entering their names into Blender. (Importing the DLs from a scene is needed so that you can see the scene when creating new cutscenes in vanilla scenes.)