### PR TITLE
added LOAD_MODEL_FROM_DL to retained level macros

### DIFF
--- a/fast64_internal/sm64/sm64_level_writer.py
+++ b/fast64_internal/sm64/sm64_level_writer.py
@@ -528,7 +528,7 @@ def parseLevelScript(filepath, levelName):
 				levelscript.segmentLoads.append(macroCmd)
 			elif macroCmd[0] == 'JUMP_LINK':
 				levelscript.levelFunctions.append(macroCmd)
-			elif macroCmd[0] == 'LOAD_MODEL_FROM_GEO':
+			elif macroCmd[0] in ['LOAD_MODEL_FROM_GEO', 'LOAD_MODEL_FROM_DL']:
 				levelscript.modelLoads.append(macroCmd)
 			elif macroCmd[0] == 'MARIO':
 				levelscript.mario = macroToString(macroCmd, True)


### PR DESCRIPTION
in summary, `LOAD_MODEL_FROM_DL` was not getting retained between exports so exporting a level would delete those calls. it works nearly the same as `LOAD_MODEL_FROM_GEO` so i was able to join the logic together.

issue was posted here https://canary.discord.com/channels/874816709855440926/874818271378022450/951189088143306752