### PR TITLE
Fix create F3D material error in Blender 3.1

### DIFF
--- a/fast64_internal/f3d/f3d_material_nodes.py
+++ b/fast64_internal/f3d/f3d_material_nodes.py
@@ -560,8 +560,8 @@ def createTexCoordNode(node_tree, location, uvSocket, socketDict, isV):
 	socketDict, nextSocketIndex = socketDictToInternalSocket(
 		node_tree, groupNode, input_node, socketDict, 1, True)
 
-	output_node.inputs.new('NodeSocketVector', 'UV')
-	
+	output_node_input_socket = output_node.inputs.new('NodeSocketVector', 'UV')
+
 	x = 0
 	y = 0
 
@@ -714,7 +714,23 @@ def createTexCoordNode(node_tree, location, uvSocket, socketDict, isV):
 	links.new(mix0Mask.inputs[2], mirrorMix.outputs[0])
 
 	# Output
-	links.new(output_node.inputs[0], mix0Mask.outputs[0])
+
+	# In Blender 3.1, for some reason output_node.inputs[0] is some junk socket,
+	# and the socket we want to use is actually output_node.inputs[1].
+	# So just use the socket as returned on creation above, output_node_input_socket.
+	#
+	# But in earlier Blender versions, like Blender 2.93, output_node_input_socket as
+	# returned above is some junk socket that is not the actual input socket. (bug?)
+	#
+	# So we check the Blender version here, lack of a better option.
+	#
+	# Also note inputs[0] needs to be accessed here for some reason, it can't be accessed
+	# above right after new(), at least in Blender 2.93 it doesn't work. (bug?)
+	if bpy.app.version < (3, 1, 0):
+		links.new(mix0Mask.outputs[0], output_node.inputs[0])
+	else:
+		links.new(mix0Mask.outputs[0], output_node_input_socket)
+
 	return groupNode
 
 def splitTextureVectorInputs(node_tree, socketDict, x, y):


### PR DESCRIPTION
Fixing #83

Looks like consequences of Blender fixing one or more bugs in Blender 3.1 maybe, potentially introducing another one I'm not sure

See my debug branch https://github.com/Dragorn421/fast64/commit/06179bf85470353a6beb9030e12be33d3b62fd92 for understanding what's printed below

---------

3.1 output
```
createTexCoordNode
<bpy_collection[2], NodeInputs> 2 ['', 'UV']
[bpy.data.node_groups['Create Tex Coord U F3D v3'].nodes["Group Output"].inputs[0], bpy.data.node_groups['Create Tex Coord U F3D v3'].nodes["Group Output"].inputs[1]]
<bpy_struct, NodeSocketVector("UV") at 0x7fba17462008>
UV <bpy_struct, NodeGroupOutput("Group Output") at 0x7fba17447e08>
node.name Group Output
type VECTOR
bl_idname NodeSocketVector
```

What's weird here is there are two input sockets to the output node, `""` and `"UV"`. this is what causes the issue with fast64 in the first place, the `""` one is used but isn't an actual output so doesn't appear in the node group outputs

so the fix is using the created socket as returned by the new() call

--------

2.93 output
```
createTexCoordNode
<bpy_collection[1], NodeInputs> 1 ['']
[bpy.data.node_groups['Create Tex Coord U F3D v3'].nodes["Group Output"].inputs[0]]
<bpy_struct, NodeSocketVirtual("") at 0x000001D83E429208>
 <bpy_struct, NodeGroupOutput("Group Output") at 0x000001D83E43D608>
node.name Group Output
type CUSTOM
bl_idname NodeSocketVirtual
```

this indeed has a single input socket to the outputs node, but new() returns a socket that doesn't actually get a link made for some reason, which makes the fix for 3.1-fast64 not backwards compatible. this looks like a bug too, which got fixed somewhere after 2.93 I guess

-------------

So I ended up hardcoding a version for the fix...

I tested in 2.93 (and it should work in any < 3.1 since the fast64 behavior should be unaltered for these versions) and 3.1.