### PR TITLE
[OoT] Fix vertex order in collision polygons

### DIFF
--- a/fast64_internal/oot/oot_collision.py
+++ b/fast64_internal/oot/oot_collision.py
@@ -170,7 +170,7 @@ def exportCollisionCommon(collision, obj, transformMatrix, includeChildren, name
 			# This prevents a bug due to an optimization in OoT's CollisionPoly_GetMinY.
 			# https://github.com/zeldaret/oot/blob/791d9018c09925138b9f830f7ae8142119905c05/src/code/z_bgcheck.c#L161
 			#
-			# 2) The vertices should wrap around the polygon normal **clockwise**.
+			# 2) The vertices should wrap around the polygon normal **counter-clockwise**.
 			# This is needed for OoT's dynapoly, which is collision that can move.
 			# When it moves, the vertex coordinates and normals are recomputed.
 			# The normal is computed based on the vertex coordinates, which makes the order of vertices matter.

--- a/fast64_internal/oot/oot_utility.py
+++ b/fast64_internal/oot/oot_utility.py
@@ -387,14 +387,8 @@ def drawEnumWithCustom(panel, data, attribute, name, customName):
 	if getattr(data, attribute) == "Custom":
 		prop_split(panel, data, attribute + "Custom", customName)
 
-def clampShort(value):
-	return min(max(round(value), -2**15), 2**15 - 1)
-
 def convertNormalizedFloatToShort(value):
-	value *= 2**15
-	value = clampShort(value)
-	
-	return int.from_bytes(int(value).to_bytes(2, 'big', signed = True), 'big')
+	return min(max(round(value * 2**15), -2**15), 2**15 - 1)
 
 def convertNormalizedVectorToShort(value):
 	return (


### PR DESCRIPTION
See added comments in the code for what this fixes.

"1) The vertex with the minimum y coordinate should be first." is a previous fix that I moved

I also had to change `convertNormalizedFloatToShort` to return a signed value instead of unsigned to get a useful normal value to compare to. This "utility" function is only used by the modified collision export function and it seems like a good change in general anyway.