### PR TITLE
Add `anim_range_choice` property

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -250,6 +250,35 @@ class Fast64Settings_Properties(bpy.types.PropertyGroup):
 	'''Settings affecting exports for all games found in scene.fast64.settings'''
 	version: bpy.props.IntProperty(name="Fast64Settings_Properties Version", default=0)
 
+	anim_range_choice: bpy.props.EnumProperty(
+		name="Anim Range",
+		description="What to use to determine what frames of the animation to export.",
+		items=[
+			(
+				"action",
+				"Action",
+				"Export all frames from the action",
+				0
+			),
+			(
+				"scene",
+				"Scene",
+				"Export all frames in the scene playback range (export frames being played in Blender)",
+				1,
+			),
+			(
+				"intersect_action_and_scene",
+				"Intersect Action & Scene",
+				(
+					"Export all frames from the action that are also in the scene playback range.\n"
+					"(export frames being played in Blender that also are part of the action frames)"
+				),
+				2,
+			),
+		],
+		default="action",
+	)
+
 class Fast64_Properties(bpy.types.PropertyGroup):
 	'''
 	Properties in scene.fast64.

--- a/__init__.py
+++ b/__init__.py
@@ -228,6 +228,7 @@ class Fast64_GlobalSettingsPanel(bpy.types.Panel):
 		prop_split(col, context.scene, 'gameEditorMode', "Game")
 		col.prop(context.scene, 'exportHiddenGeometry')
 		col.prop(context.scene, 'fullTraceback')
+		prop_split(col, context.scene.fast64.settings, 'anim_range_choice', 'Anim Range')
 
 class Fast64_GlobalToolsPanel(bpy.types.Panel):
 	bl_idname = "FAST64_PT_global_tools"
@@ -252,7 +253,7 @@ class Fast64Settings_Properties(bpy.types.PropertyGroup):
 
 	anim_range_choice: bpy.props.EnumProperty(
 		name="Anim Range",
-		description="What to use to determine what frames of the animation to export.",
+		description="What to use to determine what frames of the animation to export",
 		items=[
 			(
 				"action",
@@ -262,21 +263,25 @@ class Fast64Settings_Properties(bpy.types.PropertyGroup):
 			),
 			(
 				"scene",
-				"Scene",
-				"Export all frames in the scene playback range (export frames being played in Blender)",
+				"Playback",
+				(
+					"Export all frames in the scene's animation preview playback range.\n"
+					"(export frames being played in Blender)"
+				),
 				1,
 			),
 			(
 				"intersect_action_and_scene",
-				"Intersect Action & Scene",
+				"Smart",
 				(
+					"Intersect Action & Scene\n"
 					"Export all frames from the action that are also in the scene playback range.\n"
 					"(export frames being played in Blender that also are part of the action frames)"
 				),
 				2,
 			),
 		],
-		default="action",
+		default="intersect_action_and_scene",
 	)
 
 class Fast64_Properties(bpy.types.PropertyGroup):

--- a/fast64_internal/oot/oot_anim.py
+++ b/fast64_internal/oot/oot_anim.py
@@ -114,7 +114,7 @@ def ootGetAnimBoneRot(bone, poseBone, convertTransformMatrix, isRoot):
 		raise RuntimeError('Animation contains non-root bones with animated translation. OoT SkelAnime only supports animated translation on the root bone.')
 	return finalRotation
 
-def ootConvertAnimationData(anim, armatureObj, frameInterval, convertTransformMatrix):
+def ootConvertAnimationData(anim, armatureObj, convertTransformMatrix, *, frame_start, frame_count):
 	checkForStartBone(armatureObj)
 	bonesToProcess = [getStartBone(armatureObj)]
 	currentBone = armatureObj.data.bones[bonesToProcess[0]]
@@ -145,7 +145,7 @@ def ootConvertAnimationData(anim, armatureObj, frameInterval, convertTransformMa
 		ValueFrameData(i, 2, [])] for i in range(len(animBones))]
 
 	currentFrame = bpy.context.scene.frame_current
-	for frame in range(frameInterval[0], frameInterval[1]):
+	for frame in range(frame_start, frame_start + frame_count):
 		bpy.context.scene.frame_set(frame)
 		rootBone = armatureObj.data.bones[animBones[0]]
 		rootPoseBone = armatureObj.pose.bones[animBones[0]]
@@ -185,9 +185,16 @@ def ootExportAnimationCommon(armatureObj, convertTransformMatrix, skeletonName):
 	
 	skeleton = ootConvertArmatureToSkeletonWithoutMesh(armatureObj, convertTransformMatrix, skeletonName)
 
-	frameInterval = getFrameInterval(anim)
-	ootAnim.frameCount = frameInterval[1] - frameInterval[0]
-	armatureFrameData = ootConvertAnimationData(anim, armatureObj, frameInterval, convertTransformMatrix)
+	frame_start, frame_last = getFrameInterval(anim)
+	ootAnim.frameCount = frame_last - frame_start + 1
+
+	armatureFrameData = ootConvertAnimationData(
+		anim,
+		armatureObj,
+		convertTransformMatrix,
+		frame_start=frame_start,
+		frame_count=(frame_last - frame_start + 1),
+	)
 
 	singleFrameData = []
 	multiFrameData = []
@@ -414,6 +421,7 @@ class OOT_ExportAnimPanel(OOT_Panel):
 		else:
 			prop_split(col, context.scene, 'ootAnimExportFolderName', 'Object')
 		col.prop(context.scene, 'ootAnimIsCustomExport')
+		prop_split(col, context.scene.fast64.settings, 'anim_range_choice', 'Anim Range')
 
 
 		col.operator(OOT_ImportAnim.bl_idname)

--- a/fast64_internal/oot/oot_anim.py
+++ b/fast64_internal/oot/oot_anim.py
@@ -421,7 +421,6 @@ class OOT_ExportAnimPanel(OOT_Panel):
 		else:
 			prop_split(col, context.scene, 'ootAnimExportFolderName', 'Object')
 		col.prop(context.scene, 'ootAnimIsCustomExport')
-		prop_split(col, context.scene.fast64.settings, 'anim_range_choice', 'Anim Range')
 
 
 		col.operator(OOT_ImportAnim.bl_idname)

--- a/fast64_internal/sm64/sm64_anim.py
+++ b/fast64_internal/sm64/sm64_anim.py
@@ -305,7 +305,7 @@ def exportAnimationCommon(armatureObj, loopAnim, name):
 		len(sm64_anim.values.shortData) * 2
 	
 	sm64_anim.header = SM64_AnimationHeader(sm64_anim.name, repetitions,
-		marioYOffset, frameInterval, nodeCount, transformValuesStart, 
+		marioYOffset, [frame_start, frame_last + 1], nodeCount, transformValuesStart, 
 		transformIndicesStart, animSize)
 	
 	return sm64_anim

--- a/fast64_internal/sm64/sm64_anim.py
+++ b/fast64_internal/sm64/sm64_anim.py
@@ -714,7 +714,6 @@ class SM64_ExportAnimPanel(SM64_Panel):
 		propsAnimExport = col.operator(SM64_ExportAnimMario.bl_idname)
 
 		col.prop(context.scene, 'loopAnimation')
-		prop_split(col, context.scene.fast64.settings, 'anim_range_choice', 'Anim Range')
 
 		if context.scene.fast64.sm64.exportType == 'C':
 			col.prop(context.scene, 'animCustomExport')


### PR DESCRIPTION
Add a drop-down list option in the anim export panel, to pick what range of the exported animation to use.

I exported a basic animation with all three options for both OoT and SM64, seems to work on my end.

# Screenshot

![image](https://user-images.githubusercontent.com/5306619/168612542-98c815e1-4088-4125-9165-dea931f46daf.png)