### PR TITLE
Fix OoT skeleton import failing from `LIMB_DONE`

### DIFF
--- a/fast64_internal/oot/oot_skeleton.py
+++ b/fast64_internal/oot/oot_skeleton.py
@@ -604,8 +604,12 @@ def ootAddLimbRecursively(limbIndex, skeletonData, obj, armatureObj, parentTrans
 		translation = [0,0,0]
 	else:
 		translation = [hexOrDecInt(matchResult.group(1)), hexOrDecInt(matchResult.group(2)), hexOrDecInt(matchResult.group(3))]
-	nextChildIndex = hexOrDecInt(matchResult.group(4))
-	nextSiblingIndex = hexOrDecInt(matchResult.group(5))
+
+	LIMB_DONE = 255
+	nextChildIndexStr = matchResult.group(4)
+	nextChildIndex = LIMB_DONE if nextChildIndexStr == "LIMB_DONE" else hexOrDecInt(nextChildIndexStr)
+	nextSiblingIndexStr = matchResult.group(5)
+	nextSiblingIndex = LIMB_DONE if nextSiblingIndexStr == "LIMB_DONE" else hexOrDecInt(nextSiblingIndexStr)
 
 	#str(limbIndex) + " " + str(translation) + " " + str(nextChildIndex) + " " + \
 	#	str(nextSiblingIndex) + " " + str(dlName))
@@ -622,10 +626,10 @@ def ootAddLimbRecursively(limbIndex, skeletonData, obj, armatureObj, parentTrans
 		f3dContext.dlList.append(OOTDLEntry(dlName, limbIndex))
 		#parseF3D(skeletonData, dlName, obj, transformMatrix, boneName, f3dContext)
 
-	if nextChildIndex != 255:
+	if nextChildIndex != LIMB_DONE:
 		isLOD |= ootAddLimbRecursively(nextChildIndex, skeletonData, obj, armatureObj, currentTransform, boneName, f3dContext, useFarLOD)
 	
-	if nextSiblingIndex != 255:
+	if nextSiblingIndex != LIMB_DONE:
 		isLOD |= ootAddLimbRecursively(nextSiblingIndex, skeletonData, obj, armatureObj, parentTransform, parentBoneName, f3dContext, useFarLOD)
 	
 	return isLOD

--- a/fast64_internal/oot/oot_skeleton.py
+++ b/fast64_internal/oot/oot_skeleton.py
@@ -605,7 +605,7 @@ def ootAddLimbRecursively(limbIndex, skeletonData, obj, armatureObj, parentTrans
 	else:
 		translation = [hexOrDecInt(matchResult.group(1)), hexOrDecInt(matchResult.group(2)), hexOrDecInt(matchResult.group(3))]
 
-	LIMB_DONE = 255
+	LIMB_DONE = 0xFF
 	nextChildIndexStr = matchResult.group(4)
 	nextChildIndex = LIMB_DONE if nextChildIndexStr == "LIMB_DONE" else hexOrDecInt(nextChildIndexStr)
 	nextSiblingIndexStr = matchResult.group(5)


### PR DESCRIPTION
at some point (not recently) the `0xFF` value for "no limb next" was changed to use `LIMB_DONE`, somehow this hasn't been noticed earlier and as a result fast64 currently can't import oot skeletons