### PR TITLE
Fix incorrect CI textures on import for OOT

### DIFF
--- a/fast64_internal/f3d/f3d_parser.py
+++ b/fast64_internal/f3d/f3d_parser.py
@@ -475,8 +475,8 @@ class F3DContext:
 
         self.tlutAppliedTextures = []  # c name
         self.currentTextureName = None
-        self.imagesLoadedFromFile = [] # image
-        self.CIImageFilesStoredAsFullColor = True # determines whether to apply tlut to file or import as is
+        self.imagesDontApplyTlut = set() # image
+        self.ciImageFilesStoredAsFullColor = True # determines whether to apply tlut to file or import as is
 
         # This macro has all the tile setting properties, so we reuse it
         self.tileSettings = [
@@ -715,7 +715,7 @@ class F3DContext:
             and texProp.tex_set
             and texProp.tex_format[:2] == "CI"
             and (texProp.tex not in self.tlutAppliedTextures or texProp.use_tex_reference)
-            and (texProp.tex not in self.imagesLoadedFromFile or not self.CIImageFilesStoredAsFullColor) # oot currently stores CI textures in full color pngs
+            and (texProp.tex not in self.imagesDontApplyTlut or not self.ciImageFilesStoredAsFullColor) # oot currently stores CI textures in full color pngs
         ):
 
             # Only handles TLUT at 256
@@ -1365,8 +1365,8 @@ class F3DContext:
         # TODO: Textures are sometimes loaded in with different dimensions than for rendering.
         # This means width is incorrect?
         image, loadedFromImageFile = parseTextureData(data, textureName, self, tileSettings.fmt, siz, width, self.basePath, isLUT, self.f3d)
-        if loadedFromImageFile and image not in self.imagesLoadedFromFile:
-            self.imagesLoadedFromFile.append(image)
+        if loadedFromImageFile:
+            self.imagesDontApplyTlut.add(image)
 
         self.textureData[textureName] = image
         return self.textureData[textureName]

--- a/fast64_internal/f3d/f3d_parser.py
+++ b/fast64_internal/f3d/f3d_parser.py
@@ -475,8 +475,15 @@ class F3DContext:
 
         self.tlutAppliedTextures = []  # c name
         self.currentTextureName = None
-        self.imagesDontApplyTlut = set() # image
-        self.ciImageFilesStoredAsFullColor = True # determines whether to apply tlut to file or import as is
+        self.imagesDontApplyTlut = set()  # image
+
+        # Determines if images in CI formats loaded from png files,
+        # should have the TLUT set by the dlist applied on top of them (False),
+        # or if the image file should just be loaded as is with no further change (True)
+        # OoT64 and SM64 stores CI images as pngs in actual colors (with the TLUT accounted for),
+        # So for now this can be always True.
+        # In the future this could be an option if for example pngs for CI images were grayscale to represent the palette index.
+        self.ciImageFilesStoredAsFullColor = True  # determines whether to apply tlut to file or import as is
 
         # This macro has all the tile setting properties, so we reuse it
         self.tileSettings = [
@@ -715,7 +722,9 @@ class F3DContext:
             and texProp.tex_set
             and texProp.tex_format[:2] == "CI"
             and (texProp.tex not in self.tlutAppliedTextures or texProp.use_tex_reference)
-            and (texProp.tex not in self.imagesDontApplyTlut or not self.ciImageFilesStoredAsFullColor) # oot currently stores CI textures in full color pngs
+            and (
+                texProp.tex not in self.imagesDontApplyTlut or not self.ciImageFilesStoredAsFullColor
+            )  # oot currently stores CI textures in full color pngs
         ):
 
             # Only handles TLUT at 256
@@ -1364,7 +1373,9 @@ class F3DContext:
 
         # TODO: Textures are sometimes loaded in with different dimensions than for rendering.
         # This means width is incorrect?
-        image, loadedFromImageFile = parseTextureData(data, textureName, self, tileSettings.fmt, siz, width, self.basePath, isLUT, self.f3d)
+        image, loadedFromImageFile = parseTextureData(
+            data, textureName, self, tileSettings.fmt, siz, width, self.basePath, isLUT, self.f3d
+        )
         if loadedFromImageFile:
             self.imagesDontApplyTlut.add(image)
 
@@ -1880,7 +1891,7 @@ def parseTextureData(dlData, textureName, f3dContext, imageFormat, imageSize, wi
                 image.pixels[width * j * 4 : width * (j + 1) * 4] = flippedValues[
                     width * (height - (j + 1)) * 4 : width * (height - j) * 4
                 ]
-        
+
         loadedFromImageFile = True
     else:
         values = [value.strip() for value in data.split(",") if value.strip() != ""]


### PR DESCRIPTION
Fixed bug where CI textures would be corrupted when importing OOT display lists.