### PR TITLE
Fix OoT anim import (reading s16s)

### DIFF
--- a/fast64_internal/oot/oot_anim.py
+++ b/fast64_internal/oot/oot_anim.py
@@ -315,8 +315,12 @@ def getFrameData(filepath, animData, frameDataName):
 	if matchResult is None:
 		raise PluginError("Cannot find animation frame data named " + frameDataName + " in " + filepath)
 	data = matchResult.group(1)
-	frameData = [int.from_bytes([int(value.strip()[2:4], 16), int(value.strip()[4:6], 16)], 
-		'big', signed = True) for value in data.split(",") if value.strip() != ""]
+	def s16(v):
+		v %= 0x10000
+		if v >= 0x8000:
+			v -= 0x10000
+		return v
+	frameData = [s16(int(value.strip(), 0)) for value in data.split(",") if value.strip() != ""]
 
 	return frameData
 


### PR DESCRIPTION
Fixes reading an array of s16, currently fast64 expects all elements to be exactly `0xAABB` (hexadecimal, exactly 4 nibbles, no plus/minus sign)

Highlighted by caverill while figuring out something else

Draft because I feel like there's a `s16()`-like function somewhere already but idk where