### PR TITLE
Auto set F3D version when game editor mode is set

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -443,9 +443,7 @@ def upgrade_changed_props():
 
 def upgrade_scene_props_node():
     """update f3d materials with SceneProperties node"""
-    has_old_f3d_mats = any(
-        mat.is_f3d and mat.mat_ver < MatUpdateConvert.version for mat in bpy.data.materials
-    )
+    has_old_f3d_mats = any(mat.is_f3d and mat.mat_ver < MatUpdateConvert.version for mat in bpy.data.materials)
     if has_old_f3d_mats:
         bpy.ops.dialog.upgrade_f3d_materials("INVOKE_DEFAULT")
 
@@ -455,6 +453,13 @@ def after_load(_a, _b):
     upgrade_changed_props()
     upgrade_scene_props_node()
     resync_scene_props()
+
+
+def gameEditorUpdate(self, context):
+    if self.gameEditorMode == "SM64":
+        self.f3d_type = "F3D"
+    elif self.gameEditorMode == "OOT":
+        self.f3d_type = "F3DEX2/LX2"
 
 
 # called on add-on enabling
@@ -499,7 +504,9 @@ def register():
         name="Ignore Texture Restrictions (Breaks CI Textures)"
     )
     bpy.types.Scene.fullTraceback = bpy.props.BoolProperty(name="Show Full Error Traceback", default=False)
-    bpy.types.Scene.gameEditorMode = bpy.props.EnumProperty(name="Game", default="SM64", items=gameEditorEnum)
+    bpy.types.Scene.gameEditorMode = bpy.props.EnumProperty(
+        name="Game", default="SM64", items=gameEditorEnum, update=gameEditorUpdate
+    )
     bpy.types.Scene.saveTextures = bpy.props.BoolProperty(name="Save Textures As PNGs (Breaks CI Textures)")
     bpy.types.Scene.generateF3DNodeGraph = bpy.props.BoolProperty(name="Generate F3D Node Graph", default=True)
     bpy.types.Scene.exportHiddenGeometry = bpy.props.BoolProperty(name="Export Hidden Geometry", default=True)


### PR DESCRIPTION
For OOT, its easy to forget to set the F3D version to F3DEX2 when changing game modes, so it would be more convenient to auto set the F3D version when a game mode is selected.