### PR TITLE
[OoT] Imports cleanup

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -2,25 +2,22 @@ import bpy
 from bpy.utils import register_class, unregister_class
 from . import addon_updater_ops
 from .fast64_internal.operators import AddWaterBox
+from .fast64_internal.panels import SM64_Panel
 from .fast64_internal.utility import PluginError, raisePluginError, attemptModifierApply, prop_split
+
+from .fast64_internal.sm64 import SM64_Properties, sm64_register, sm64_unregister
+from .fast64_internal.sm64.sm64_geolayout_bone import SM64_BoneProperties
+from .fast64_internal.sm64.sm64_objects import SM64_ObjectProperties
 from .fast64_internal.sm64.sm64_geolayout_utility import createBoneGroups
 from .fast64_internal.sm64.sm64_geolayout_parser import generateMetarig
-from .fast64_internal.sm64.sm64_geolayout_bone import SM64_BoneProperties
-from .fast64_internal.sm64 import SM64_Properties, sm64_register, sm64_unregister
-from .fast64_internal.sm64.sm64_objects import SM64_ObjectProperties
+
 from .fast64_internal.oot import OOT_Properties, oot_register, oot_unregister
+from .fast64_internal.oot.oot_level import OOT_ObjectProperties
+
 from .fast64_internal.f3d.f3d_material import mat_register, mat_unregister
 from .fast64_internal.f3d.f3d_render_engine import render_engine_register, render_engine_unregister
 from .fast64_internal.f3d.f3d_writer import f3d_writer_register, f3d_writer_unregister
 from .fast64_internal.f3d.f3d_parser import f3d_parser_register, f3d_parser_unregister
-from .fast64_internal.panels import SM64_Panel
-from .fast64_internal.oot.oot_level import OOT_ObjectProperties
-
-from .fast64_internal.render_settings import (
-    Fast64RenderSettings_Properties,
-    resync_scene_props,
-    on_update_render_settings,
-)
 
 from .fast64_internal.f3d_material_converter import (
     MatUpdateConvert,
@@ -29,6 +26,12 @@ from .fast64_internal.f3d_material_converter import (
     bsdf_conv_unregister,
     bsdf_conv_panel_regsiter,
     bsdf_conv_panel_unregsiter,
+)
+
+from .fast64_internal.render_settings import (
+    Fast64RenderSettings_Properties,
+    resync_scene_props,
+    on_update_render_settings,
 )
 
 # info about add on

--- a/__init__.py
+++ b/__init__.py
@@ -1,25 +1,35 @@
-import sys
-import tempfile
-import copy
-import shutil
 import bpy
-import traceback
-import os
-from pathlib import Path
-
-from .fast64_internal import *
+from bpy.utils import register_class, unregister_class
+from . import addon_updater_ops
+from .fast64_internal.operators import AddWaterBox
+from .fast64_internal.utility import PluginError, raisePluginError, attemptModifierApply, prop_split
+from .fast64_internal.sm64.sm64_geolayout_utility import createBoneGroups
+from .fast64_internal.sm64.sm64_geolayout_parser import generateMetarig
+from .fast64_internal.sm64.sm64_geolayout_bone import SM64_BoneProperties
+from .fast64_internal.sm64 import SM64_Properties, sm64_register, sm64_unregister
+from .fast64_internal.sm64.sm64_objects import SM64_ObjectProperties
+from .fast64_internal.oot import OOT_Properties, oot_register, oot_unregister
+from .fast64_internal.f3d.f3d_material import mat_register, mat_unregister
+from .fast64_internal.f3d.f3d_render_engine import render_engine_register, render_engine_unregister
+from .fast64_internal.f3d.f3d_writer import f3d_writer_register, f3d_writer_unregister
+from .fast64_internal.f3d.f3d_parser import f3d_parser_register, f3d_parser_unregister
 from .fast64_internal.panels import SM64_Panel
 from .fast64_internal.oot.oot_level import OOT_ObjectProperties
+
 from .fast64_internal.render_settings import (
     Fast64RenderSettings_Properties,
     resync_scene_props,
     on_update_render_settings,
 )
 
-import cProfile
-import pstats
-
-from . import addon_updater_ops
+from .fast64_internal.f3d_material_converter import (
+    MatUpdateConvert,
+    upgradeF3DVersionAll,
+    bsdf_conv_register,
+    bsdf_conv_unregister,
+    bsdf_conv_panel_regsiter,
+    bsdf_conv_panel_unregsiter,
+)
 
 # info about add on
 bl_info = {

--- a/fast64_internal/__init__.py
+++ b/fast64_internal/__init__.py
@@ -1,5 +1,5 @@
 from .f3d_material_converter import *
 from .f3d import *
 from .sm64 import *
-from .oot import *
+from .oot import *  # is this really needed?
 from .panels import *

--- a/fast64_internal/__init__.py
+++ b/fast64_internal/__init__.py
@@ -3,17 +3,3 @@ from .f3d import *
 from .sm64 import *
 from .oot import *
 from .panels import *
-
-# temporary star imports until more imports are cleaned up
-from .oot.oot_f3d_writer import *
-from .oot.oot_constants import *
-from .oot.oot_collision import *
-from .oot.oot_level import *
-from .oot.oot_level_writer import *
-from .oot.c_writer import *
-from .oot.oot_spline import *
-from .oot.oot_anim import *
-from .oot.oot_skeleton import *
-from .oot.oot_cutscene import *
-from .oot.oot_operators import *
-from .utility import *

--- a/fast64_internal/oot/__init__.py
+++ b/fast64_internal/oot/__init__.py
@@ -1,20 +1,57 @@
 import bpy
-from bpy.utils import register_class, unregister_class
-
-from .oot_anim import oot_anim_panel_register, oot_anim_panel_unregister, oot_anim_register, oot_anim_unregister
-from .oot_collision import oot_col_panel_register, oot_col_panel_unregister, oot_col_register, oot_col_unregister
-from .oot_f3d_writer import OOTDLExportSettings, OOTDLImportSettings, oot_dl_writer_panel_register, oot_dl_writer_panel_unregister, oot_dl_writer_register, oot_dl_writer_unregister
-from .oot_level import oot_obj_panel_register, oot_obj_panel_unregister, oot_obj_register, oot_obj_unregister
-from .oot_level_writer import oot_level_panel_register, oot_level_panel_unregister, oot_level_register, oot_level_unregister
-from .oot_operators import oot_operator_panel_register, oot_operator_panel_unregister, oot_operator_register, oot_operator_unregister
-from .oot_skeleton import oot_skeleton_panel_register, oot_skeleton_panel_unregister, oot_skeleton_register, oot_skeleton_unregister
-from .oot_spline import oot_spline_panel_register, oot_spline_panel_unregister, oot_spline_register, oot_spline_unregister
-from .oot_utility import oot_utility_register, oot_utility_unregister
-from .oot_cutscene import oot_cutscene_panel_register, oot_cutscene_panel_unregister, oot_cutscene_register, oot_cutscene_unregister
 from .c_writer import OOTBootupSceneOptions
 from ..panels import OOT_Panel
+from bpy.utils import register_class, unregister_class
+from .oot_level import oot_obj_panel_register, oot_obj_panel_unregister, oot_obj_register, oot_obj_unregister
+from .oot_anim import oot_anim_panel_register, oot_anim_panel_unregister, oot_anim_register, oot_anim_unregister
+from .oot_collision import oot_col_panel_register, oot_col_panel_unregister, oot_col_register, oot_col_unregister
+from .oot_utility import oot_utility_register, oot_utility_unregister
 from ..utility import prop_split
 from ..render_settings import on_update_render_settings
+
+from .oot_f3d_writer import (
+    OOTDLExportSettings,
+    OOTDLImportSettings,
+    oot_dl_writer_panel_register,
+    oot_dl_writer_panel_unregister,
+    oot_dl_writer_register,
+    oot_dl_writer_unregister,
+)
+
+from .oot_level_writer import (
+    oot_level_panel_register,
+    oot_level_panel_unregister,
+    oot_level_register,
+    oot_level_unregister,
+)
+
+from .oot_operators import (
+    oot_operator_panel_register,
+    oot_operator_panel_unregister,
+    oot_operator_register,
+    oot_operator_unregister,
+)
+
+from .oot_skeleton import (
+    oot_skeleton_panel_register,
+    oot_skeleton_panel_unregister,
+    oot_skeleton_register,
+    oot_skeleton_unregister,
+)
+
+from .oot_spline import (
+    oot_spline_panel_register,
+    oot_spline_panel_unregister,
+    oot_spline_register,
+    oot_spline_unregister,
+)
+
+from .oot_cutscene import (
+    oot_cutscene_panel_register,
+    oot_cutscene_panel_unregister,
+    oot_cutscene_register,
+    oot_cutscene_unregister,
+)
 
 
 class OOT_FileSettingsPanel(OOT_Panel):

--- a/fast64_internal/oot/__init__.py
+++ b/fast64_internal/oot/__init__.py
@@ -1,21 +1,20 @@
-from . import oot_anim
-from . import oot_collision
-from . import oot_cutscene
-from . import oot_f3d_writer
-from . import oot_level
-from . import oot_level_writer
-from . import oot_operators
-from . import oot_skeleton
-from . import oot_spline
-from . import oot_utility
-from .c_writer import OOTBootupSceneOptions
+import bpy
+from bpy.utils import register_class, unregister_class
 
+from .oot_anim import oot_anim_panel_register, oot_anim_panel_unregister, oot_anim_register, oot_anim_unregister
+from .oot_collision import oot_col_panel_register, oot_col_panel_unregister, oot_col_register, oot_col_unregister
+from .oot_f3d_writer import OOTDLExportSettings, OOTDLImportSettings, oot_dl_writer_panel_register, oot_dl_writer_panel_unregister, oot_dl_writer_register, oot_dl_writer_unregister
+from .oot_level import oot_obj_panel_register, oot_obj_panel_unregister, oot_obj_register, oot_obj_unregister
+from .oot_level_writer import oot_level_panel_register, oot_level_panel_unregister, oot_level_register, oot_level_unregister
+from .oot_operators import oot_operator_panel_register, oot_operator_panel_unregister, oot_operator_register, oot_operator_unregister
+from .oot_skeleton import oot_skeleton_panel_register, oot_skeleton_panel_unregister, oot_skeleton_register, oot_skeleton_unregister
+from .oot_spline import oot_spline_panel_register, oot_spline_panel_unregister, oot_spline_register, oot_spline_unregister
+from .oot_utility import oot_utility_register, oot_utility_unregister
+from .oot_cutscene import oot_cutscene_panel_register, oot_cutscene_panel_unregister, oot_cutscene_register, oot_cutscene_unregister
+from .c_writer import OOTBootupSceneOptions
 from ..panels import OOT_Panel
 from ..utility import prop_split
 from ..render_settings import on_update_render_settings
-
-import bpy
-from bpy.utils import register_class, unregister_class
 
 
 class OOT_FileSettingsPanel(OOT_Panel):
@@ -40,8 +39,8 @@ class OOT_Properties(bpy.types.PropertyGroup):
     version: bpy.props.IntProperty(name="OOT_Properties Version", default=0)
     hackerFeaturesEnabled: bpy.props.BoolProperty(name="Enable HackerOOT Features")
     bootupSceneOptions: bpy.props.PointerProperty(type=OOTBootupSceneOptions)
-    DLExportSettings: bpy.props.PointerProperty(type=oot_f3d_writer.OOTDLExportSettings)
-    DLImportSettings: bpy.props.PointerProperty(type=oot_f3d_writer.OOTDLImportSettings)
+    DLExportSettings: bpy.props.PointerProperty(type=OOTDLExportSettings)
+    DLImportSettings: bpy.props.PointerProperty(type=OOTDLImportSettings)
     skeletonExportSettings: bpy.props.PointerProperty(type=oot_skeleton.OOTSkeletonExportSettings)
     skeletonImportSettings: bpy.props.PointerProperty(type=oot_skeleton.OOTSkeletonImportSettings)
 
@@ -53,40 +52,40 @@ oot_classes = (
 
 
 def oot_panel_register():
-    oot_operators.oot_operator_panel_register()
-    oot_f3d_writer.oot_dl_writer_panel_register()
-    oot_collision.oot_col_panel_register()
-    oot_level.oot_obj_panel_register()
-    oot_level_writer.oot_level_panel_register()
-    oot_spline.oot_spline_panel_register()
-    oot_anim.oot_anim_panel_register()
-    oot_skeleton.oot_skeleton_panel_register()
-    oot_cutscene.oot_cutscene_panel_register()
+    oot_operator_panel_register()
+    oot_dl_writer_panel_register()
+    oot_col_panel_register()
+    oot_obj_panel_register()
+    oot_level_panel_register()
+    oot_spline_panel_register()
+    oot_anim_panel_register()
+    oot_skeleton_panel_register()
+    oot_cutscene_panel_register()
 
 
 def oot_panel_unregister():
-    oot_operators.oot_operator_panel_unregister()
-    oot_collision.oot_col_panel_unregister()
-    oot_level.oot_obj_panel_unregister()
-    oot_level_writer.oot_level_panel_unregister()
-    oot_spline.oot_spline_panel_unregister()
-    oot_f3d_writer.oot_dl_writer_panel_unregister()
-    oot_anim.oot_anim_panel_unregister()
-    oot_skeleton.oot_skeleton_panel_unregister()
-    oot_cutscene.oot_cutscene_panel_unregister()
+    oot_operator_panel_unregister()
+    oot_col_panel_unregister()
+    oot_obj_panel_unregister()
+    oot_level_panel_unregister()
+    oot_spline_panel_unregister()
+    oot_dl_writer_panel_unregister()
+    oot_anim_panel_unregister()
+    oot_skeleton_panel_unregister()
+    oot_cutscene_panel_unregister()
 
 
 def oot_register(registerPanels):
-    oot_operators.oot_operator_register()
-    oot_utility.oot_utility_register()
-    oot_collision.oot_col_register()  # register first, so panel goes above mat panel
-    oot_level.oot_obj_register()
-    oot_level_writer.oot_level_register()
-    oot_spline.oot_spline_register()
-    oot_f3d_writer.oot_dl_writer_register()
-    oot_anim.oot_anim_register()
-    oot_skeleton.oot_skeleton_register()
-    oot_cutscene.oot_cutscene_register()
+    oot_operator_register()
+    oot_utility_register()
+    oot_col_register()  # register first, so panel goes above mat panel
+    oot_obj_register()
+    oot_level_register()
+    oot_spline_register()
+    oot_dl_writer_register()
+    oot_anim_register()
+    oot_skeleton_register()
+    oot_cutscene_register()
 
     for cls in oot_classes:
         register_class(cls)
@@ -105,16 +104,16 @@ def oot_unregister(unregisterPanels):
     for cls in reversed(oot_classes):
         unregister_class(cls)
 
-    oot_operators.oot_operator_unregister()
-    oot_utility.oot_utility_unregister()
-    oot_collision.oot_col_unregister()  # register first, so panel goes above mat panel
-    oot_level.oot_obj_unregister()
-    oot_level_writer.oot_level_unregister()
-    oot_spline.oot_spline_unregister()
-    oot_f3d_writer.oot_dl_writer_unregister()
-    oot_anim.oot_anim_unregister()
-    oot_skeleton.oot_skeleton_unregister()
-    oot_cutscene.oot_cutscene_unregister()
+    oot_operator_unregister()
+    oot_utility_unregister()
+    oot_col_unregister()  # register first, so panel goes above mat panel
+    oot_obj_unregister()
+    oot_level_unregister()
+    oot_spline_unregister()
+    oot_dl_writer_unregister()
+    oot_anim_unregister()
+    oot_skeleton_unregister()
+    oot_cutscene_unregister()
 
     if unregisterPanels:
         oot_panel_unregister()

--- a/fast64_internal/oot/c_writer/oot_level_c.py
+++ b/fast64_internal/oot/c_writer/oot_level_c.py
@@ -1,8 +1,10 @@
-import math
-from ..oot_f3d_writer import *
-from ..oot_level_writer import *
-from ..oot_collision import *
-from ..oot_cutscene import *
+from ...utility import CData, PluginError
+from ...f3d.f3d_gbi import ScrollMethod
+from ..oot_f3d_writer import OOTGfxFormatter
+from ..oot_collision import ootCollisionToC
+from ..oot_cutscene import ootCutsceneDataToC
+from ..oot_utility import indent
+from ..oot_constants import ootRoomShapeStructs, ootRoomShapeEntryStructs
 
 
 def cmdName(name, header, index):

--- a/fast64_internal/oot/c_writer/oot_scene_bootup.py
+++ b/fast64_internal/oot/c_writer/oot_scene_bootup.py
@@ -1,9 +1,8 @@
 import os, re, bpy
-import string
 from bpy.utils import register_class, unregister_class
 from ...utility import PluginError, writeFile, readFile
 from ..oot_constants import ootEnumHeaderMenuComplete
-from typing import Callable, Iterable, Any, List
+from typing import Any
 
 
 def setBootupScene(configPath: str, entranceIndex: str, options: "OOTBootupSceneOptions"):

--- a/fast64_internal/oot/c_writer/oot_scene_folder.py
+++ b/fast64_internal/oot/c_writer/oot_scene_folder.py
@@ -1,6 +1,5 @@
 import os, re, shutil
-from ...utility import *
-from ..oot_utility import *
+from ..oot_utility import getSceneDirFromLevelName
 
 def modifySceneFiles(scene, exportInfo):
 	exportPath = exportInfo.exportPath
@@ -8,13 +7,13 @@ def modifySceneFiles(scene, exportInfo):
 		sceneDir = exportInfo.customSubPath + exportInfo.name
 	else:
 		sceneDir = getSceneDirFromLevelName(scene.name)
-	scenePath = os.path.join(exportPath, sceneDir) 
+	scenePath = os.path.join(exportPath, sceneDir)
 	for filename in os.listdir(scenePath):
 		filepath = os.path.join(scenePath, filename)
 		if os.path.isfile(filepath):
 			match = re.match(scene.name + "\_room\_(\d+)\.[ch]", filename)
 			if match is not None and int(match.group(1)) >= len(scene.rooms):
-				os.remove(filepath) 
+				os.remove(filepath)
 
 def deleteSceneFiles(exportInfo):
 	exportPath = exportInfo.exportPath

--- a/fast64_internal/oot/c_writer/oot_scene_table_c.py
+++ b/fast64_internal/oot/c_writer/oot_scene_table_c.py
@@ -46,7 +46,7 @@ def getSceneIndex(sceneNameList, sceneName):
 def getOriginalIndex(sceneName):
     """
     Returns the index of a specific scene defined by which one the user chose
-	or by the ``sceneName`` parameter if it's not set to ``None``
+        or by the ``sceneName`` parameter if it's not set to ``None``
     """
     i = 0
 

--- a/fast64_internal/oot/c_writer/oot_spec.py
+++ b/fast64_internal/oot/c_writer/oot_spec.py
@@ -1,6 +1,6 @@
-import os, re
-from ...utility import *
-from ..oot_utility import *
+import os, re, bpy
+from ...utility import readFile, writeFile
+from ..oot_utility import getSceneDirFromLevelName, indent
 
 def getSegmentDefinitionEntryBySceneName(segmentDefinition, sceneName):
 	entries = []
@@ -74,7 +74,7 @@ def modifySegmentDefinition(scene, exportInfo, levelC):
 
 			for i in range(len(scene.rooms)):
 				roomSuffix = "_room_" + str(i)
-				segmentDefinitions.insert(firstIndex, 
+				segmentDefinitions.insert(firstIndex,
 					'\n' + indent + 'name "' + scene.name + roomSuffix + '"\n' +\
 					compressFlag +\
 					indent + "romalign 0x1000\n" +\
@@ -87,15 +87,15 @@ def modifySegmentDefinition(scene, exportInfo, levelC):
 				indent + "romalign 0x1000\n" +\
 				indent + 'include "' + includeDir + '_scene_main.o"\n' +\
 				indent + 'include "' + includeDir + '_scene_col.o"\n'
-			
+
 			if levelC is not None:
 				if (levelC.sceneTexturesIsUsed()):
 					sceneSegInclude += indent + 'include "' + includeDir + '_scene_tex.o"\n'
-				
+
 				if (levelC.sceneCutscenesIsUsed()):
 					for i in range(len(levelC.sceneCutscenesC)):
 						sceneSegInclude += indent + 'include "' + includeDir + '_cs_' + str(i) + '.o"\n'
-				
+
 			sceneSegInclude += indent + "number 2\n"
 
 			segmentDefinitions.insert(firstIndex, sceneSegInclude)
@@ -104,7 +104,7 @@ def modifySegmentDefinition(scene, exportInfo, levelC):
 
 			for i in range(len(scene.rooms)):
 				roomSuffix = "_room_" + str(i)
-				segmentDefinitions.insert(firstIndex, 
+				segmentDefinitions.insert(firstIndex,
 					'\n' + indent + 'name "' + scene.name + roomSuffix + '"\n' +\
 					compressFlag +\
 					indent + "romalign 0x1000\n" +\

--- a/fast64_internal/oot/oot_actor.py
+++ b/fast64_internal/oot/oot_actor.py
@@ -1,19 +1,14 @@
+import bpy
+from .oot_constants import ootEnumActorID, ootEnumSceneSetupPreset, ootEnumCamTransition
+from ..utility import PluginError, prop_split, label_split
+from .oot_utility import getRoomObj, getEnumName, drawAddButton, drawCollectionOps, drawEnumWithCustom
 
-import math, os, bpy, bmesh, mathutils
-from bpy.utils import register_class, unregister_class
-from io import BytesIO
-
-from ..f3d.f3d_gbi import *
-from .oot_constants import *
-from .oot_utility import *
-
-from ..utility import *
 
 class OOT_SearchActorIDEnumOperator(bpy.types.Operator):
 	bl_idname = "object.oot_search_actor_id_enum_operator"
 	bl_label = "Select Actor ID"
 	bl_property = "actorID"
-	bl_options = {'REGISTER', 'UNDO'} 
+	bl_options = {'REGISTER', 'UNDO'}
 
 	actorID : bpy.props.EnumProperty(items = ootEnumActorID, default = "ACTOR_PLAYER")
 	actorUser : bpy.props.StringProperty(default = "Actor")
@@ -62,7 +57,7 @@ def drawActorHeaderProperty(layout, headerProp, propUser, altProp, objName):
 		if altProp is None or altProp.childNightHeader.usePreviousHeader:
 			# Draw previous header checkbox (so get previous state), but labeled
 			# as current one and grayed out
-			childNightRow.prop(headerProp, prevHeaderName, text = "Child Night") 
+			childNightRow.prop(headerProp, prevHeaderName, text = "Child Night")
 			childNightRow.enabled = False
 		else:
 			childNightRow.prop(headerProp, 'childNightHeader', text = "Child Night")
@@ -91,13 +86,13 @@ def drawActorHeaderItemProperty(layout, propUser, headerItemProp, index, altProp
 	box.prop(headerItemProp, 'expandTab', text = 'Header ' + \
 		str(headerItemProp.headerIndex), icon = 'TRIA_DOWN' if headerItemProp.expandTab else \
 		'TRIA_RIGHT')
-	
+
 	if headerItemProp.expandTab:
 		drawCollectionOps(box, index, propUser, None, objName)
 		prop_split(box, headerItemProp, 'headerIndex', 'Header Index')
 		if altProp is not None and headerItemProp.headerIndex >= len(altProp.cutsceneHeaders) + 4:
 			box.label(text = "Header does not exist.", icon = 'QUESTION')
-		
+
 class OOTActorProperty(bpy.types.PropertyGroup):
 	actorID : bpy.props.EnumProperty(name = 'Actor', items = ootEnumActorID, default = 'ACTOR_PLAYER')
 	actorIDCustom : bpy.props.StringProperty(name = 'Actor ID', default = 'ACTOR_PLAYER')
@@ -126,7 +121,7 @@ def drawActorProperty(layout, actorProp, altRoomProp, objName):
 
 	#layout.box().label(text = 'Actor IDs defined in include/z64actors.h.')
 	prop_split(actorIDBox, actorProp, "actorParam", 'Actor Parameter')
-	
+
 	actorIDBox.prop(actorProp, 'rotOverride', text = 'Override Rotation (ignore Blender rot)')
 	if actorProp.rotOverride:
 		prop_split(actorIDBox, actorProp, 'rotOverrideX', 'Rot X')
@@ -141,7 +136,7 @@ class OOTTransitionActorProperty(bpy.types.PropertyGroup):
 	cameraTransitionFrontCustom : bpy.props.StringProperty(default = '0x00')
 	cameraTransitionBack : bpy.props.EnumProperty(items = ootEnumCamTransition, default = '0x00')
 	cameraTransitionBackCustom : bpy.props.StringProperty(default = '0x00')
-	
+
 	actor : bpy.props.PointerProperty(type = OOTActorProperty)
 
 def drawTransitionActorProperty(layout, transActorProp, altSceneProp, roomObj, objName):
@@ -173,7 +168,7 @@ def drawTransitionActorProperty(layout, transActorProp, altSceneProp, roomObj, o
 	drawEnumWithCustom(actorIDBox, transActorProp, "cameraTransitionBack", "Camera Transition Back", "")
 
 	drawActorHeaderProperty(actorIDBox, transActorProp.actor.headerSettings, "Transition Actor", altSceneProp, objName)
-	
+
 class OOTEntranceProperty(bpy.types.PropertyGroup):
 	# This is also used in entrance list, and roomIndex is obtained from the room this empty is parented to.
 	spawnIndex : bpy.props.IntProperty(min = 0)
@@ -197,5 +192,5 @@ def drawEntranceProperty(layout, obj, altSceneProp, objName):
 	box.prop(entranceProp, "customActor")
 	if entranceProp.customActor:
 		prop_split(box, entranceProp.actor, "actorIDCustom", "Actor ID Custom")
-	
+
 	drawActorHeaderProperty(box, entranceProp.actor.headerSettings, "Entrance", altSceneProp, objName)

--- a/fast64_internal/oot/oot_anim.py
+++ b/fast64_internal/oot/oot_anim.py
@@ -1,11 +1,26 @@
-import shutil, copy, math, mathutils, bpy, os, re
-
-from bpy.utils import register_class, unregister_class
-from .oot_constants import *
-from .oot_utility import *
-from .oot_skeleton import *
-from ..utility import *
+import math, mathutils, bpy, os, re
 from ..panels import OOT_Panel
+from bpy.utils import register_class, unregister_class
+from .oot_skeleton import ootConvertArmatureToSkeletonWithoutMesh
+from ..utility import CData, PluginError, toAlnum, writeCData, readFile, hexOrDecInt, raisePluginError, prop_split
+
+from .oot_utility import (
+    checkForStartBone,
+    getStartBone,
+    getSortedChildren,
+    ootGetPath,
+    addIncludeFiles,
+    checkEmptyName,
+    ootGetObjectPath,
+)
+
+from ..utility_anim import (
+    ValueFrameData,
+    saveTranslationFrame,
+    saveQuaternionFrame,
+    squashFramesIfAllSame,
+    getFrameInterval,
+)
 
 
 class OOTAnimation:

--- a/fast64_internal/oot/oot_collision.py
+++ b/fast64_internal/oot/oot_collision.py
@@ -1,14 +1,45 @@
-import bpy, bmesh, os, math, re, shutil, mathutils
+import bpy, os, math, mathutils
 from bpy.utils import register_class, unregister_class
-from io import BytesIO
-
-from ..utility import *
-from .oot_utility import *
-from .oot_constants import *
 from ..panels import OOT_Panel
+from .oot_constants import ootEnumSceneID
 
-from .oot_collision_classes import *
-from .oot_scene_room import *
+from ..utility import (
+    PluginError,
+    CData,
+    prop_split,
+    unhideAllAndGetHiddenList,
+    hideObjsInList,
+    writeCData,
+    raisePluginError,
+)
+
+from .oot_collision_classes import (
+    OOTCollisionVertex,
+    OOTCollisionPolygon,
+    OOTCollision,
+    OOTCameraData,
+    getPolygonType,
+    ootEnumFloorSetting,
+    ootEnumWallSetting,
+    ootEnumFloorProperty,
+    ootEnumConveyer,
+    ootEnumConveyorSpeed,
+    ootEnumCollisionTerrain,
+    ootEnumCollisionSound,
+    ootEnumCameraSType,
+)
+
+from .oot_utility import (
+    OOTObjectCategorizer,
+    ootGetObjectPath,
+    convertIntTo2sComplement,
+    addIncludeFiles,
+    drawCollectionOps,
+    drawEnumWithCustom,
+    ootDuplicateHierarchy,
+    ootCleanupScene,
+    ootGetPath,
+)
 
 
 class OOTCameraPositionProperty(bpy.types.PropertyGroup):

--- a/fast64_internal/oot/oot_collision_classes.py
+++ b/fast64_internal/oot/oot_collision_classes.py
@@ -1,10 +1,6 @@
-import bpy, bmesh, os, math, re, shutil, mathutils
-from bpy.utils import register_class, unregister_class
-from io import BytesIO
-
-from ..utility import *
-from .oot_utility import *
-from .oot_constants import *
+import math
+from ..utility import PluginError
+from .oot_utility import BoxEmpty, convertIntTo2sComplement, getCustomProperty
 
 ootEnumConveyer = [
     ("None", "None", "None"),

--- a/fast64_internal/oot/oot_cutscene.py
+++ b/fast64_internal/oot/oot_cutscene.py
@@ -1,8 +1,31 @@
-import math, os, bpy, bmesh, mathutils
-from .oot_constants import *
-from .oot_utility import *
-from .oot_level_classes import *
+import os, bpy
+from bpy.utils import register_class, unregister_class
 from ..panels import OOT_Panel
+from ..utility import PluginError, CData, prop_split, writeCData, raisePluginError
+from .oot_utility import OOTCollectionAdd, drawCollectionOps, getCollection, getCutsceneName, getCustomProperty
+
+from .oot_constants import (
+	ootEnumCSTextboxType,
+	ootEnumCSListType,
+	ootEnumCSTransitionType,
+	ootEnumCSTextboxTypeIcons,
+	ootEnumCSListTypeIcons,
+	ootEnumCSListTypeListC,
+	ootEnumCSTextboxTypeEntryC,
+	ootEnumCSListTypeEntryC,
+)
+
+from .oot_level_classes import (
+	OOTCSList,
+	OOTCSTextbox,
+	OOTCSLighting,
+	OOTCSTime,
+	OOTCSBGM,
+	OOTCSMisc,
+	OOTCS0x09,
+	OOTCSUnk,
+	OOTCutscene,
+)
 
 ################################################################################
 # Properties
@@ -18,16 +41,16 @@ class OOTCSProperty():
 	expandTab : bpy.props.BoolProperty(default = True)
 	startFrame : bpy.props.IntProperty(name = '', default = 0, min = 0)
 	endFrame : bpy.props.IntProperty(name = '', default = 1, min = 0)
-		
+
 	def getName(self):
 		return self.propName
-		
+
 	def filterProp(self, name, listProp):
 		return True
-	
+
 	def filterName(self, name, listProp):
 		return name
-	
+
 	def draw(self, layout, listProp, listIndex, cmdIndex, objName, collectionType):
 		layout.prop(self, 'expandTab', text = self.getName() + " " + str(cmdIndex),
 			icon = 'TRIA_DOWN' if self.expandTab else 'TRIA_RIGHT')
@@ -51,10 +74,10 @@ class OOTCSTextboxProperty(OOTCSProperty, bpy.types.PropertyGroup):
 	topOptionBranch : bpy.props.StringProperty(name = '', default = '0x0000')
 	bottomOptionBranch : bpy.props.StringProperty(name = '', default = '0x0000')
 	ocarinaMessageId : bpy.props.StringProperty(name = '', default = '0x0000')
-	
+
 	def getName(self):
 		return self.textboxType
-	
+
 	def filterProp(self, name, listProp):
 		if self.textboxType == "Text":
 			return name not in ["ocarinaSongAction", "ocarinaMessageId"]
@@ -68,7 +91,7 @@ class OOTCSTextboxProperty(OOTCSProperty, bpy.types.PropertyGroup):
 class OOTCSTextboxAdd(bpy.types.Operator):
 	bl_idname = 'object.oot_cstextbox_add'
 	bl_label = 'Add CS Textbox'
-	bl_options = {'REGISTER', 'UNDO'} 
+	bl_options = {'REGISTER', 'UNDO'}
 
 	collectionType : bpy.props.StringProperty()
 	textboxType : bpy.props.EnumProperty(items = ootEnumCSTextboxType)
@@ -79,30 +102,30 @@ class OOTCSTextboxAdd(bpy.types.Operator):
 		collection = getCollection(self.objName, self.collectionType, self.listIndex)
 		newTextboxElement = collection.add()
 		newTextboxElement.textboxType = self.textboxType
-		return {'FINISHED'} 
+		return {'FINISHED'}
 
 class OOTCSLightingProperty(OOTCSProperty, bpy.types.PropertyGroup):
 	propName = "Lighting"
 	attrName = "lighting"
 	subprops = ["index", "startFrame"]
 	index : bpy.props.IntProperty(name = '', default = 1, min = 1)
-	
+
 class OOTCSTimeProperty(OOTCSProperty, bpy.types.PropertyGroup):
 	propName = "Time"
 	attrName = "time"
 	subprops = ["startFrame", "hour", "minute"]
 	hour : bpy.props.IntProperty(name = '', default = 23, min = 0, max = 23)
 	minute : bpy.props.IntProperty(name = '', default = 59, min = 0, max = 59)
-	
+
 class OOTCSBGMProperty(OOTCSProperty, bpy.types.PropertyGroup):
 	propName = "BGM"
 	attrName = "bgm"
 	subprops = ["value", "startFrame", "endFrame"]
 	value : bpy.props.StringProperty(name = '', default = '0x0000')
-	
+
 	def filterProp(self, name, listProp):
 		return name != "endFrame" or listProp.listType == "FadeBGM"
-	
+
 	def filterName(self, name, listProp):
 		if name == 'value':
 			return "Fade Type" if listProp.listType == "FadeBGM" else "Sequence"
@@ -140,10 +163,10 @@ class OOTCSUnkProperty(OOTCSProperty, bpy.types.PropertyGroup):
 	unk11 : bpy.props.StringProperty(name = '', default = '0x00000000')
 	unk12 : bpy.props.StringProperty(name = '', default = '0x00000000')
 
-	
+
 class OOTCSListProperty(bpy.types.PropertyGroup):
 	expandTab : bpy.props.BoolProperty(default = True)
-	
+
 	listType : bpy.props.EnumProperty(items = ootEnumCSListType)
 	textbox : bpy.props.CollectionProperty(type = OOTCSTextboxProperty)
 	lighting: bpy.props.CollectionProperty(type = OOTCSLightingProperty)
@@ -152,20 +175,20 @@ class OOTCSListProperty(bpy.types.PropertyGroup):
 	misc : bpy.props.CollectionProperty(type = OOTCSMiscProperty)
 	nine : bpy.props.CollectionProperty(type = OOTCS0x09Property)
 	unk : bpy.props.CollectionProperty(type = OOTCSUnkProperty)
-	
+
 	unkType : bpy.props.StringProperty(name = '', default = '0x0001')
 	fxType : bpy.props.EnumProperty(items = ootEnumCSTransitionType)
 	fxStartFrame : bpy.props.IntProperty(name = '', default = 0, min = 0)
 	fxEndFrame : bpy.props.IntProperty(name = '', default = 1, min = 0)
 
 def drawCSListProperty(layout, listProp, listIndex, objName, collectionType):
-	layout.prop(listProp, 'expandTab', 
+	layout.prop(listProp, 'expandTab',
 		text = listProp.listType + ' List' if listProp.listType != 'FX' else 'Scene Trans FX',
 		icon = 'TRIA_DOWN' if listProp.expandTab else 'TRIA_RIGHT')
 	if not listProp.expandTab: return
 	box = layout.box().column()
 	drawCollectionOps(box, listIndex, collectionType, None, objName, False)
-	
+
 	if listProp.listType == "Textbox":
 		attrName = "textbox"
 	elif listProp.listType == "FX":
@@ -188,7 +211,7 @@ def drawCSListProperty(layout, listProp, listIndex, objName, collectionType):
 		attrName = "unk"
 	else:
 		raise PluginError("Internal error: invalid listType " + listProp.listType)
-		
+
 	dat = getattr(listProp, attrName)
 	for i, p in enumerate(dat):
 		p.draw(box, listProp, listIndex, i, objName, collectionType)
@@ -213,7 +236,7 @@ def drawCSListProperty(layout, listProp, listIndex, objName, collectionType):
 class OOTCSListAdd(bpy.types.Operator):
 	bl_idname = 'object.oot_cslist_add'
 	bl_label = 'Add CS List'
-	bl_options = {'REGISTER', 'UNDO'} 
+	bl_options = {'REGISTER', 'UNDO'}
 
 	collectionType : bpy.props.StringProperty()
 	listType : bpy.props.EnumProperty(items = ootEnumCSListType)
@@ -223,7 +246,7 @@ class OOTCSListAdd(bpy.types.Operator):
 		collection = getCollection(self.objName, self.collectionType, None)
 		newList = collection.add()
 		newList.listType = self.listType
-		return {'FINISHED'} 
+		return {'FINISHED'}
 
 def drawCSAddButtons(layout, objName, collectionType):
 	def addButton(row):
@@ -455,7 +478,7 @@ class OOT_ExportCutscene(bpy.types.Operator):
 	bl_idname = 'object.oot_export_cutscene'
 	bl_label = "Export Cutscene"
 	bl_options = {'REGISTER', 'UNDO', 'PRESET'}
-	
+
 	def execute(self, context):
 		try:
 			if context.mode != 'OBJECT':
@@ -480,7 +503,7 @@ class OOT_ExportAllCutscenes(bpy.types.Operator):
 	bl_idname = 'object.oot_export_all_cutscenes'
 	bl_label = "Export All Cutscenes"
 	bl_options = {'REGISTER', 'UNDO', 'PRESET'}
-	
+
 	def execute(self, context):
 		try:
 			if context.mode != 'OBJECT':
@@ -517,7 +540,7 @@ class OOT_ExportCutscenePanel(OOT_Panel):
 		col.operator(OOT_ExportCutscene.bl_idname)
 		col.operator(OOT_ExportAllCutscenes.bl_idname)
 		prop_split(col, context.scene, 'ootCutsceneExportPath', 'File')
-		
+
 
 oot_cutscene_classes = (
 	OOT_ExportCutscene,
@@ -531,7 +554,7 @@ oot_cutscene_panel_classes = (
 def oot_cutscene_panel_register():
 	for cls in oot_cutscene_panel_classes:
 		register_class(cls)
-		
+
 def oot_cutscene_panel_unregister():
 	for cls in oot_cutscene_panel_classes:
 		unregister_class(cls)
@@ -539,12 +562,12 @@ def oot_cutscene_panel_unregister():
 def oot_cutscene_register():
 	for cls in oot_cutscene_classes:
 		register_class(cls)
-		
+
 	bpy.types.Scene.ootCutsceneExportPath = bpy.props.StringProperty(
 		name = 'File', subtype='FILE_PATH')
-		
+
 def oot_cutscene_unregister():
 	for cls in reversed(oot_cutscene_classes):
 		unregister_class(cls)
-		
+
 	del bpy.types.Scene.ootCutsceneExportPath

--- a/fast64_internal/oot/oot_f3d_writer.py
+++ b/fast64_internal/oot/oot_f3d_writer.py
@@ -1,15 +1,37 @@
-import shutil, copy, bpy, os
+import bpy, os, mathutils
 from bpy.utils import register_class, unregister_class
-
-from .oot_utility import *
-from .oot_constants import *
-from ..f3d.f3d_writer import *
-from ..f3d.f3d_material import *
-from ..f3d.f3d_parser import *
 from ..panels import OOT_Panel
+from ..utility import PluginError, CData, prop_split, writeCData, raisePluginError, getGroupIndexFromname, toAlnum
+from ..f3d.f3d_parser import importMeshC, ootEnumDrawLayers
+from ..f3d.f3d_gbi import DLFormat, TextureExportSettings, ScrollMethod, F3D
 
-from .oot_model_classes import *
-from .oot_scene_room import *
+from ..f3d.f3d_writer import (
+    TriangleConverterInfo,
+    removeDL,
+    saveStaticModel,
+    getInfoDict,
+    checkForF3dMaterialInFaces,
+    saveOrGetF3DMaterial,
+    saveMeshWithLargeTexturesByFaces,
+    saveMeshByFaces,
+)
+
+from .oot_utility import (
+    OOTObjectCategorizer,
+    ootGetObjectPath,
+    ootDuplicateHierarchy,
+    ootCleanupScene,
+    ootGetPath,
+    addIncludeFiles,
+)
+
+from .oot_model_classes import (
+    OOTF3DContext,
+    OOTTriangleConverterInfo,
+    OOTModel,
+    OOTGfxFormatter,
+    OOTDynamicTransformProperty,
+)
 
 
 class OOTDLExportSettings(bpy.types.PropertyGroup):

--- a/fast64_internal/oot/oot_level.py
+++ b/fast64_internal/oot/oot_level.py
@@ -1,15 +1,57 @@
-import math, os, bpy, bmesh, mathutils
+import bpy
 from bpy.utils import register_class, unregister_class
-from io import BytesIO
+from ..utility import prop_split, gammaInverse
+from .oot_collision import OOTWaterBoxProperty, drawWaterBoxProperty
+from .oot_constants import ootEnumEmptyType
+from .oot_utility import getSceneObj, getRoomObj
 
-from ..f3d.f3d_gbi import *
-from .oot_constants import *
-from .oot_utility import *
-from .oot_scene_room import *
-from .oot_actor import *
-from .oot_collision import *
-from .oot_spline import *
-from ..utility import *
+from .oot_actor import (
+    OOTActorProperty,
+    OOTTransitionActorProperty,
+    OOTEntranceProperty,
+    OOT_SearchActorIDEnumOperator,
+    OOTActorHeaderItemProperty,
+    OOTActorHeaderProperty,
+    drawActorProperty,
+    drawTransitionActorProperty,
+    drawEntranceProperty,
+)
+
+from .oot_scene_room import (
+    OOTRoomHeaderProperty,
+    OOTSceneHeaderProperty,
+    OOTAlternateSceneHeaderProperty,
+    OOTAlternateRoomHeaderProperty,
+    OOTSceneProperties,
+    OOT_SearchMusicSeqEnumOperator,
+    OOT_SearchObjectEnumOperator,
+    OOT_SearchSceneEnumOperator,
+    OOTLightProperty,
+    OOTLightGroupProperty,
+    OOTObjectProperty,
+    OOTExitProperty,
+    OOTSceneTableEntryProperty,
+    OOTExtraCutsceneProperty,
+    drawSceneHeaderProperty,
+    drawAlternateSceneHeaderProperty,
+    drawRoomHeaderProperty,
+    drawAlternateRoomHeaderProperty,
+)
+
+from .oot_cutscene import (
+    OOTCutsceneProperty,
+    OOTCSTextboxProperty,
+    OOTCSTextboxAdd,
+    OOTCSLightingProperty,
+    OOTCSTimeProperty,
+    OOTCSBGMProperty,
+    OOTCSMiscProperty,
+    OOTCS0x09Property,
+    OOTCSUnkProperty,
+    OOTCSListProperty,
+    OOTCSListAdd,
+    drawCutsceneProperty,
+)
 
 
 def headerSettingsToIndices(headerSettings):

--- a/fast64_internal/oot/oot_level_classes.py
+++ b/fast64_internal/oot/oot_level_classes.py
@@ -1,13 +1,12 @@
-import math, os, bpy, bmesh, mathutils
-from bpy.utils import register_class, unregister_class
-from io import BytesIO
-
-from ..utility import *
-from .oot_utility import *
-from .oot_constants import *
-from ..f3d.f3d_gbi import *
-from .oot_collision_classes import *
-from .oot_model_classes import *
+from ..utility import PluginError, toAlnum
+from .oot_collision_classes import OOTCollision
+from .oot_model_classes import OOTModel
+from ..f3d.f3d_gbi import (
+    SPDisplayList,
+    SPEndDisplayList,
+    GfxListTag,
+    GfxList,
+)
 
 
 class OOTActor:

--- a/fast64_internal/oot/oot_model_classes.py
+++ b/fast64_internal/oot/oot_model_classes.py
@@ -1,11 +1,20 @@
-import shutil, copy, bpy, os
-from bpy.utils import register_class, unregister_class
+import bpy
+from ..f3d.f3d_writer import VertexGroupInfo, TriangleConverterInfo
+from ..f3d.f3d_parser import F3DContext
+from ..f3d.f3d_material import createF3DMat
+from ..utility import CData, hexOrDecInt
 
-from .oot_utility import *
-from .oot_constants import *
-from ..f3d.f3d_writer import *
-from ..f3d.f3d_material import *
-from ..f3d.f3d_parser import *
+from ..f3d.f3d_gbi import (
+    FModel,
+    GfxMatWriteMethod,
+    SPDisplayList,
+    GfxList,
+    GfxListTag,
+    DLFormat,
+    SPMatrix,
+    GfxFormatter,
+    MTX_SIZE,
+)
 
 
 class OOTModel(FModel):

--- a/fast64_internal/oot/oot_operators.py
+++ b/fast64_internal/oot/oot_operators.py
@@ -1,9 +1,8 @@
-import bpy, mathutils, math
+import bpy, mathutils
 from bpy.utils import register_class, unregister_class
-from ..utility import *
-from ..f3d.f3d_material import *
-from ..operators import *
 from ..panels import OOT_Panel
+from ..operators import AddWaterBox, addMaterialByName
+from ..utility import parentObject, setOrigin
 
 
 class OOT_AddWaterBox(AddWaterBox):

--- a/fast64_internal/oot/oot_scene_room.py
+++ b/fast64_internal/oot/oot_scene_room.py
@@ -1,22 +1,39 @@
-import math, os, bpy, bmesh, mathutils
-from bpy.utils import register_class, unregister_class
-from io import BytesIO
-
-from ..utility import *
-from .oot_utility import *
-from .oot_constants import *
-from ..f3d.f3d_gbi import *
-
-from .oot_actor import *
-
-# from .oot_collision import *
-from .oot_cutscene import *
+import bpy
 from ..render_settings import on_update_oot_render_settings
+from ..utility import ootGetSceneOrRoomHeader, prop_split
+from .oot_utility import drawAddButton, drawCollectionOps, drawEnumWithCustom, getEnumName, getSceneObj, getRoomObj
+from .oot_cutscene import OOTCSListProperty, drawCSListProperty, drawCSAddButtons
+
+from .oot_constants import (
+    ootEnumObjectID,
+    ootEnumMusicSeq,
+    ootEnumSceneID,
+    ootEnumExitIndex,
+    ootEnumTransitionAnims,
+    ootEnumLightGroupMenu,
+    ootEnumGlobalObject,
+    ootEnumNaviHints,
+    ootEnumSkybox,
+    ootEnumCloudiness,
+    ootEnumSkyboxLighting,
+    ootEnumMapLocation,
+    ootEnumCameraMode,
+    ootEnumNightSeq,
+    ootEnumAudioSessionPreset,
+    ootEnumCSWriteType,
+    ootEnumSceneMenu,
+    ootEnumSceneMenuAlternate,
+    ootEnumRoomMenu,
+    ootEnumRoomMenuAlternate,
+    ootEnumRoomBehaviour,
+    ootEnumLinkIdle,
+    ootEnumRoomShapeType,
+    ootEnumHeaderMenu,
+)
 
 
 def onUpdateOoTLighting(self, context: bpy.types.Context):
     on_update_oot_render_settings(self, context)
-
 
 
 class OOTSceneProperties(bpy.types.PropertyGroup):

--- a/fast64_internal/oot/oot_skeleton.py
+++ b/fast64_internal/oot/oot_skeleton.py
@@ -1,16 +1,41 @@
-import shutil, copy, mathutils, bpy, math, os, re
-from bpy.utils import register_class, unregister_class
-
-from ..utility import *
-from .oot_utility import *
-from .oot_constants import *
-from .oot_model_classes import *
+import mathutils, bpy, math, os, re
 from ..panels import OOT_Panel
+from ..f3d.f3d_gbi import DLFormat, FMesh, TextureExportSettings, ScrollMethod, F3D
+from .oot_model_classes import OOTVertexGroupInfo, OOTModel, OOTGfxFormatter, OOTF3DContext, OOTDynamicTransformProperty
+from bpy.utils import register_class, unregister_class
+from ..f3d.f3d_writer import getInfoDict
+from ..f3d.f3d_parser import getImportData, parseF3D
+from .oot_f3d_writer import ootProcessVertexGroup
+from ..f3d.f3d_material import ootEnumDrawLayers
 
-from ..f3d.f3d_parser import *
-from ..f3d.f3d_writer import *
-from ..f3d.f3d_material import TextureProperty, tmemUsageUI
-from .oot_f3d_writer import *
+from ..utility import (
+    PluginError,
+    CData,
+    getDeclaration,
+    hexOrDecInt,
+    applyRotation,
+    prop_split,
+    getGroupIndexFromname,
+    writeFile,
+    readFile,
+    raisePluginError,
+    writeCData,
+    toAlnum,
+    setOrigin,
+    getGroupNameFromIndex,
+    attemptModifierApply,
+    cleanupDuplicatedObjects,
+)
+
+from .oot_utility import (
+    ootGetObjectPath,
+    checkEmptyName,
+    checkForStartBone,
+    getStartBone,
+    getSortedChildren,
+    ootGetPath,
+    addIncludeFiles,
+)
 
 
 class OOTSkeletonExportSettings(bpy.types.PropertyGroup):

--- a/fast64_internal/oot/oot_spline.py
+++ b/fast64_internal/oot/oot_spline.py
@@ -1,16 +1,13 @@
-import math, os, bpy, bmesh, mathutils
+import bpy
 from bpy.utils import register_class, unregister_class
-
-from .oot_constants import *
-from .oot_utility import *
-from .oot_scene_room import *
+from ..utility import PluginError, toAlnum, prop_split
 
 class OOTPath:
 	def __init__(self, ownerName, splineIndex):
 		self.ownerName = toAlnum(ownerName)
 		self.splineIndex = splineIndex
 		self.points = []
-	
+
 	def pathName(self):
 		return self.ownerName + "_pathwayList_" + str(self.splineIndex)
 
@@ -22,7 +19,7 @@ def ootConvertPath(name, index, obj, transformMatrix):
 		position = transformMatrix @ point.co
 		path.points.append(position)
 		#path.speeds.append(int(round(point.radius)))
-	
+
 	return path
 
 def onSplineTypeSet(self, context):
@@ -34,7 +31,7 @@ class OOTSplinePanel(bpy.types.Panel):
 	bl_space_type = 'PROPERTIES'
 	bl_region_type = 'WINDOW'
 	bl_context = "object"
-	bl_options = {'HIDE_HEADER'} 
+	bl_options = {'HIDE_HEADER'}
 
 	@classmethod
 	def poll(cls, context):
@@ -49,7 +46,7 @@ class OOTSplinePanel(bpy.types.Panel):
 			box.label(text = 'Only NURBS curves are compatible.')
 		else:
 			prop_split(box, context.object.ootSplineProperty, "index", "Index")
-		
+
 		#drawParentSceneRoom(box, context.object)
 
 class OOTSplineProperty(bpy.types.PropertyGroup):
@@ -86,7 +83,7 @@ def oot_spline_panel_unregister():
 def oot_spline_register():
 	for cls in oot_spline_classes:
 		register_class(cls)
-	
+
 	bpy.types.Object.ootSplineProperty = bpy.props.PointerProperty(type = OOTSplineProperty)
 
 def oot_spline_unregister():

--- a/fast64_internal/oot/oot_utility.py
+++ b/fast64_internal/oot/oot_utility.py
@@ -1,6 +1,16 @@
-from ..utility import *
-import bpy, math, mathutils, os, re
+import bpy, math, os
 from bpy.utils import register_class, unregister_class
+from ..utility import (
+    PluginError,
+    prop_split,
+    getDataFromFile,
+    saveDataToFile,
+    attemptModifierApply,
+    setOrigin,
+    applyRotation,
+    cleanupDuplicatedObjects,
+    ootGetSceneOrRoomHeader,
+)
 
 # default indentation to use when writing to decomp files
 indent = " " * 4

--- a/fast64_internal/sm64/sm64_geolayout_constants.py
+++ b/fast64_internal/sm64/sm64_geolayout_constants.py
@@ -1,3 +1,6 @@
+from ..utility import PluginError
+
+
 drawLayers = {
 	'Unused' 		: [0, 3],
 	'Solid'			: 1,
@@ -37,7 +40,7 @@ GEO_SCALE				= 0x1D
 GEO_START_W_RENDERAREA	= 0x20
 
 startCommands = [
-	GEO_START, 
+	GEO_START,
 	GEO_START_W_SHADOW,
 	GEO_START_W_RENDERAREA
 ]

--- a/fast64_internal/sm64/sm64_level_parser.py
+++ b/fast64_internal/sm64/sm64_level_parser.py
@@ -33,11 +33,11 @@ def parseCommonSegmentLoad(romfile):
 	for segment, pointer in loadSegmentAddresses.items():
 		romfile.seek(pointer)
 		command = romfile.read(12)
-		
+
 		segment = command[3]
 		segmentStart = int.from_bytes(command[4:8], 'big')
 		segmentEnd = int.from_bytes(command[8:12], 'big')
-	
+
 		segmentData[segment] = (segmentStart, segmentEnd)
 
 	return segmentData
@@ -48,7 +48,7 @@ def parseLevel(romfile, startAddress, segmentData):
 
 	romfile.seek(currentAddress)
 	currentCmd = romfile.read(2)
-	romfile.seek(currentAddress) # second seek is because reading moves read pointer forward	
+	romfile.seek(currentAddress) # second seek is because reading moves read pointer forward
 	currentCmd = romfile.read(currentCmd[1])
 	#currentAddress += currentCmd[1]
 
@@ -149,7 +149,7 @@ def parseLevel(romfile, startAddress, segmentData):
 			jetStream = SM64_Jet_Stream(currentCmd, currentAddress)
 			currentArea.jetStreams.append(jetStream)
 
-		else:	
+		else:
 			print("Unhandled command: " + hex(currentCmd[0]))
 
 		if currentCmd[0] != L_PUSH and currentCmd[0] != L_JUMP and currentCmd[0] != L_POP:
@@ -201,7 +201,7 @@ class SM64_Music_Screen:
 		command[0] = L_SET_MUSIC_SCREEN
 		command[1] = 8
 		command[2:5] = self.params
-		command[5] = seqNum
+		command[5] = self.seqNum
 
 		return command
 
@@ -217,7 +217,7 @@ class SM64_Music_Level:
 		command = bytearray(8)
 		command[0] = L_SET_MUSIC_LEVEL
 		command[1] = 4
-		command[3] = seqNum
+		command[3] = self.seqNum
 
 		return command
 

--- a/fast64_internal/sm64/sm64_rom_tweaks.py
+++ b/fast64_internal/sm64/sm64_rom_tweaks.py
@@ -1,4 +1,6 @@
 from .sm64_constants import loadSegmentAddresses
+from ..utility import PluginError
+
 
 def ExtendBank0x04(romfile, segmentData, segment4):
 


### PR DESCRIPTION
Changes:
- Removed every ``from XXX import *`` from ``fast64_internal/oot`` (except the two useless files that gets deleted in #95) and other places where things broke
- Only import classes/functions/variables that are actually required
- Fixed missing imports where it was needed

Note that I'd love to do that with SM64 files but I don't know a thing about this game so I might break things on accident, though I still fixed some things here and there, same applies for F3D files

Also idk if the oot import is really required inside ``fast64_internal/__init__.py``