### PR TITLE
[OoT] Minor room behavior improvements

### DIFF
--- a/fast64_internal/oot/oot_constants.py
+++ b/fast64_internal/oot/oot_constants.py
@@ -516,7 +516,6 @@ ootEnumLinkIdle = [
     ("0x00", "Default", "Default"),
     ("0x01", "Sneezing", "Sneezing"),
     ("0x02", "Wiping Forehead", "Wiping Forehead"),
-    ("0x03", "Too Hot", "Too Hot (Triggers Heat Timer)"),
     ("0x04", "Yawning", "Yawning"),
     ("0x07", "Gasping For Breath", "Gasping For Breath"),
     ("0x09", "Brandish Sword", "Brandish Sword"),
@@ -1418,12 +1417,12 @@ ootEnumCamTransition = [
 # see curRoom.unk_03
 ootEnumRoomBehaviour = [
     ("Custom", "Custom", "Custom"),
-    ("0x00", "None", "None"),
-    ("0x01", "Disable Sun Song Effect", "Disable Sun Song Effect"),
-    ("0x02", "Disable Action Button Jumping", "Disable Action Button Jumping"),
-    ("0x03", "(?) Disable Color Dither", "(?) Disable Color Dither"),
+    ("0x00", "Default", "Default"),
+    ("0x01", "Dungeon Behavior (Z-Target, Sun's Song)", "Dungeon Behavior (Z-Target, Sun's Song)"),
+    ("0x02", "Disable Backflips/Sidehops", "Disable Backflips/Sidehops"),
+    ("0x03", "Disable Color Dither", "Disable Color Dither"),
     ("0x04", "(?) Horse Camera Related", "(?) Horse Camera Related"),
-    ("0x05", "(?) Nayru's Love Light Dim", "(?) Nayru's Love Light Dim"),
+    ("0x05", "Disable Darker Screen Effect (NL/Spins)", "Disable Darker Screen Effect (NL/Spins)"),
 ]
 
 ootEnumExitIndex = [

--- a/fast64_internal/oot/oot_level_writer.py
+++ b/fast64_internal/oot/oot_level_writer.py
@@ -281,7 +281,10 @@ def readRoomData(room, roomHeader, alternateRoomHeaders):
     room.roomBehaviour = getCustomProperty(roomHeader, "roomBehaviour")
     room.disableWarpSongs = roomHeader.disableWarpSongs
     room.showInvisibleActors = roomHeader.showInvisibleActors
-    room.linkIdleMode = getCustomProperty(roomHeader, "linkIdleMode")
+
+    # room heat behavior is active if the idle mode is 0x03
+    room.linkIdleMode = getCustomProperty(roomHeader, "linkIdleMode") if not roomHeader.roomIsHot else "0x03"
+
     room.linkIdleModeCustom = roomHeader.linkIdleModeCustom
     room.setWind = roomHeader.setWind
     room.windVector = normToSigned8Vector(mathutils.Vector(roomHeader.windVector).normalized())

--- a/fast64_internal/oot/oot_scene_room.py
+++ b/fast64_internal/oot/oot_scene_room.py
@@ -476,7 +476,7 @@ class OOTRoomHeaderProperty(bpy.types.PropertyGroup):
     linkIdleMode: bpy.props.EnumProperty(name="Link Idle Mode", items=ootEnumLinkIdle, default="0x00")
     linkIdleModeCustom: bpy.props.StringProperty(name="Link Idle Mode Custom", default="0x00")
     roomIsHot: bpy.props.BoolProperty(
-        name="Use Room Heat Behavior",
+        name="Use Hot Room Behavior",
         description="Use heat timer/screen effect, overrides Link Idle Mode",
         default=False,
     )
@@ -547,6 +547,8 @@ def drawRoomHeaderProperty(layout, roomProp, dropdownLabel, headerIndex, objName
         behaviourBox.prop(roomProp, "roomIsHot")
         if not roomProp.roomIsHot:
             drawEnumWithCustom(behaviourBox, roomProp, "linkIdleMode", "Link Idle Mode", "")
+        else:
+            behaviourBox.label(text="Link Idle Mode: Hot Room")
 
         behaviourBox.prop(roomProp, "disableWarpSongs", text="Disable Warp Songs")
         behaviourBox.prop(roomProp, "showInvisibleActors", text="Show Invisible Actors")

--- a/fast64_internal/oot/oot_scene_room.py
+++ b/fast64_internal/oot/oot_scene_room.py
@@ -18,7 +18,6 @@ def onUpdateOoTLighting(self, context: bpy.types.Context):
     on_update_oot_render_settings(self, context)
 
 
-
 class OOTSceneProperties(bpy.types.PropertyGroup):
     write_dummy_room_list: bpy.props.BoolProperty(
         name="Dummy Room List",
@@ -476,6 +475,11 @@ class OOTRoomHeaderProperty(bpy.types.PropertyGroup):
     showInvisibleActors: bpy.props.BoolProperty(name="Show Invisible Actors")
     linkIdleMode: bpy.props.EnumProperty(name="Link Idle Mode", items=ootEnumLinkIdle, default="0x00")
     linkIdleModeCustom: bpy.props.StringProperty(name="Link Idle Mode Custom", default="0x00")
+    roomIsHot: bpy.props.BoolProperty(
+        name="Use Room Heat Behavior",
+        description="Use heat timer/screen effect, overrides Link Idle Mode",
+        default=False,
+    )
 
     useCustomBehaviourX: bpy.props.BoolProperty(name="Use Custom Behaviour X")
     useCustomBehaviourY: bpy.props.BoolProperty(name="Use Custom Behaviour Y")
@@ -539,7 +543,11 @@ def drawRoomHeaderProperty(layout, roomProp, dropdownLabel, headerIndex, objName
         behaviourBox = layout.column()
         behaviourBox.box().label(text="Behaviour")
         drawEnumWithCustom(behaviourBox, roomProp, "roomBehaviour", "Room Behaviour", "")
-        drawEnumWithCustom(behaviourBox, roomProp, "linkIdleMode", "Link Idle Mode", "")
+
+        behaviourBox.prop(roomProp, "roomIsHot")
+        if not roomProp.roomIsHot:
+            drawEnumWithCustom(behaviourBox, roomProp, "linkIdleMode", "Link Idle Mode", "")
+
         behaviourBox.prop(roomProp, "disableWarpSongs", text="Disable Warp Songs")
         behaviourBox.prop(roomProp, "showInvisibleActors", text="Show Invisible Actors")
 


### PR DESCRIPTION
I was thinking setting the room mode to "too hot" and using the heat timer might be confusing as it's hidden under Link Idle mode, this PR removes the 'too hot' entry from the idle enum and replaces it with a checkbox instead

Also I updated the room behavior enum names to be more accurate after doing some research with decomp