### PR TITLE
Created new room system for exporting with additional objects

### DIFF
--- a/fast64_internal/sm64/sm64_objects.py
+++ b/fast64_internal/sm64/sm64_objects.py
@@ -6,9 +6,11 @@ from .sm64_constants import *
 from .sm64_function_map import func_map
 from .sm64_spline import *
 from .sm64_geolayout_classes import *
+from .sm64_utility import check_obj_is_room
 
 from ..utility import *
 from ..f3d.f3d_material import sm64EnumDrawLayers
+from ..util.collection_list_base import get_collection_classes
 
 enumTerrain = [
     ("Custom", "Custom", "Custom"),
@@ -1346,7 +1348,10 @@ class SM64ObjectPanel(bpy.types.Panel):
             self.draw_inline_obj(box, obj)
 
         elif obj.sm64_obj_type == "None":
-            box.box().label(text="This can be used as an empty transform node in a geolayout hierarchy.")
+            if not obj.fast64.sm64.room.draw(box.box(), context):
+                b2 = box.box()
+                b2.label(text="This can be used as an empty transform node in a geolayout hierarchy.")
+                b2.prop(obj, "ignore_render", text="Ignore heirarchy in geolayout.")
 
     def draw_acts(self, obj, layout):
         layout.label(text="Acts")
@@ -1794,6 +1799,126 @@ class SM64_GameObjectProperties(bpy.types.PropertyGroup):
         return self.bparams
 
 
+def check_parents_has_cond(obj: bpy.types.Object, cond_cb: Callable[[bpy.types.Object], bool]):
+    if not cond_cb(obj):
+        if obj.parent:
+            return check_parents_has_cond(obj.parent, cond_cb)
+        return False
+    return True
+
+
+def check_children_for_cond(obj: bpy.types.Object, cond_cb: Callable[[bpy.types.Object], bool]):
+    if cond_cb(obj):
+        return True
+    if len(obj.children):
+        for c in obj.children:
+            if check_children_for_cond(c, cond_cb):
+                return True
+    return False
+
+
+def poll_room_child(self: "SM64_RoomChildObject", obj: bpy.types.Object):
+    def check_object_is_area(inner_obj: bpy.types.Object):
+        # Should not be an area root
+        return inner_obj.sm64_obj_type == "Area Root"
+
+    def check_object_is_this_empty(inner_obj: bpy.types.Object):
+        # Should not have this room empty as a parent
+        return inner_obj is self.id_data
+
+    def check_object_has_mesh(inner_obj: bpy.types.Object):
+        # Should not be an area root OR should not be the room empty
+        return isinstance(inner_obj.data, bpy.types.Mesh)
+
+    if check_object_is_area(obj) or check_object_is_this_empty(obj) or not obj.parent or obj.sm64_obj_type != "None":
+        return False
+    return (
+        check_parents_has_cond(obj, check_object_is_area)
+        and not check_parents_has_cond(obj, check_object_is_this_empty)
+        and check_children_for_cond(obj, check_object_has_mesh)
+    )
+
+
+class SM64_RoomChildObject(bpy.types.PropertyGroup):
+    obj: bpy.props.PointerProperty(type=bpy.types.Object, name="Export object", poll=poll_room_child)
+
+    def draw(self, layout: bpy.types.UILayout, _data: "SM64_RoomObjectProperties", index: int):
+        row = layout.row(align=True).split(factor=0.15)
+        row.label(text=f" {index}:")
+        row.prop(self, "obj", text="")
+
+
+(
+    BeforeRoom_AddObj,
+    BeforeRoom_RemoveObj,
+    BeforeRoom_MoveObj,
+    BeforeRoom_DrawUIList,
+    draw_before_room_prop_list,
+) = get_collection_classes(
+    "beforeroomlist", ("object.fast64.sm64.room",), ("objects_render_before",), ("objects_render_before_active_index",)
+)
+
+(
+    AfterRoom_AddObj,
+    AfterRoom_RemoveObj,
+    AfterRoom_MoveObj,
+    AfterRoom_DrawUIList,
+    draw_after_room_prop_list,
+) = get_collection_classes(
+    "afterroomlist", ("object.fast64.sm64.room",), ("objects_render_after",), ("objects_render_after_active_index",)
+)
+
+
+class SM64_RoomObjectProperties(bpy.types.PropertyGroup):
+    # Objects that render before the room empties hirearchy
+    objects_render_before: bpy.props.CollectionProperty(type=SM64_RoomChildObject, name="Render Objects Before")
+    objects_render_before_active_index: bpy.props.IntProperty(default=0, name="Render Before Active Index")
+    # Objects that render after the room empties hirearchy
+    objects_render_after: bpy.props.CollectionProperty(type=SM64_RoomChildObject, name="Render Objects After")
+    objects_render_after_active_index: bpy.props.IntProperty(default=0, name="Render After Active Index")
+
+    def draw(self, layout: bpy.types.UILayout, context: bpy.types.Context):
+        this_object: bpy.types.Object = self.id_data
+        if this_object.sm64_obj_type != "None":
+            return False
+        parent: bpy.types.Object = this_object.parent
+        if not check_obj_is_room(this_object):
+            return False
+
+        layout.label(text="This is a room empty.")
+        room_index = 0
+        for i, c_obj in enumerate(parent.children):
+            if c_obj is this_object:
+                room_index = i
+                break
+        if room_index == 0:
+            layout.label(text="The children of this room will be visible in ALL rooms.")
+        else:
+            layout.label(text=f"Room #{room_index}")
+            layout.label(text="Select additional objects to render with this room.")
+        layout.separator(factor=1)
+        layout.label(text="Before hirearchy")
+        draw_before_room_prop_list(layout, context)
+        layout.separator(factor=1)
+        layout.label(text="After hirearchy")
+        draw_after_room_prop_list(layout, context)
+        return True
+
+
+SM64RoomClasses = (
+    SM64_RoomChildObject,
+    BeforeRoom_AddObj,
+    BeforeRoom_RemoveObj,
+    BeforeRoom_MoveObj,
+    BeforeRoom_DrawUIList,
+    AfterRoom_AddObj,
+    AfterRoom_RemoveObj,
+    AfterRoom_MoveObj,
+    AfterRoom_DrawUIList,
+    SM64_RoomObjectProperties,
+)
+
+
 class SM64_ObjectProperties(bpy.types.PropertyGroup):
     version: bpy.props.IntProperty(name="SM64_ObjectProperties Version", default=0)
     cur_version = 3  # version after property migration
@@ -1802,6 +1927,7 @@ class SM64_ObjectProperties(bpy.types.PropertyGroup):
     level: bpy.props.PointerProperty(type=SM64_LevelProperties)
     area: bpy.props.PointerProperty(type=SM64_AreaProperties)
     game_object: bpy.props.PointerProperty(type=SM64_GameObjectProperties)
+    room: bpy.props.PointerProperty(type=SM64_RoomObjectProperties)
 
     @staticmethod
     def upgrade_changed_props():
@@ -1814,6 +1940,7 @@ class SM64_ObjectProperties(bpy.types.PropertyGroup):
 
 
 sm64_obj_classes = (
+    *SM64RoomClasses,
     WarpNodeProperty,
     AddWarpNode,
     RemoveWarpNode,

--- a/fast64_internal/sm64/sm64_utility.py
+++ b/fast64_internal/sm64/sm64_utility.py
@@ -1,17 +1,25 @@
 import bpy, os
 
+
 def starSelectWarning(operator, fileStatus):
-	if fileStatus is not None and not fileStatus.starSelectC:
-		operator.report({'WARNING'}, "star_select.c not found, skipping star select scrolling.")
+    if fileStatus is not None and not fileStatus.starSelectC:
+        operator.report({"WARNING"}, "star_select.c not found, skipping star select scrolling.")
+
 
 def cameraWarning(operator, fileStatus):
-	if fileStatus is not None and not fileStatus.cameraC:
-		operator.report({'WARNING'}, "camera.c not found, skipping camera volume and zoom mask exporting.")
+    if fileStatus is not None and not fileStatus.cameraC:
+        operator.report({"WARNING"}, "camera.c not found, skipping camera volume and zoom mask exporting.")
 
-ULTRA_SM64_MEMORY_C = 'src/boot/memory.c'
-SM64_MEMORY_C = 'src/game/memory.c'
+
+ULTRA_SM64_MEMORY_C = "src/boot/memory.c"
+SM64_MEMORY_C = "src/game/memory.c"
+
 
 def getMemoryCFilePath(decompDir):
-	isUltra = os.path.exists(os.path.join(decompDir, ULTRA_SM64_MEMORY_C))
-	relPath = ULTRA_SM64_MEMORY_C if isUltra else SM64_MEMORY_C
-	return os.path.join(decompDir, relPath)
+    isUltra = os.path.exists(os.path.join(decompDir, ULTRA_SM64_MEMORY_C))
+    relPath = ULTRA_SM64_MEMORY_C if isUltra else SM64_MEMORY_C
+    return os.path.join(decompDir, relPath)
+
+
+def check_obj_is_room(obj: bpy.types.Object):
+    return bool(obj.parent and obj.parent.sm64_obj_type == "Area Root" and obj.parent.enableRoomSwitch)

--- a/fast64_internal/util/collection_list_base.py
+++ b/fast64_internal/util/collection_list_base.py
@@ -1,0 +1,247 @@
+import bpy
+
+
+class UnimplementedError(Exception):
+    pass
+
+
+def get_attr_from_dot_path(obj: object, path: str):
+    for attribute in path.split("."):
+        obj = getattr(obj, attribute)
+    return obj
+
+
+def get_collection_props_from_context(
+    context: bpy.types.Context | object,
+    base_path: tuple[str],  # path from context to the root of your prop, e.g. context.[scene.base_prop]
+    collection_name: tuple[str],  # from base path, collection prop
+    index_name: tuple[str],  # prop that tracks index
+) -> tuple[object, bpy.types.Collection, int]:
+    collection_base = context
+
+    for i in range(0, len(collection_name)):
+        if i > 0:
+            collection_base = col_prop[index]
+
+        collection_base = get_attr_from_dot_path(collection_base, base_path[i])
+        col_prop = get_attr_from_dot_path(collection_base, collection_name[i])
+        index = get_attr_from_dot_path(collection_base, index_name[i])
+
+    return collection_base, col_prop, index
+
+
+class CollectionOperator(bpy.types.Operator):
+    bl_options = {"REGISTER", "UNDO", "PRESET"}
+
+    base_path: str = None  # path from context to the root of your prop, e.g. context.[scene.base_prop]
+    collection_name: tuple[str] = None  # from base path, collection prop
+    index_name: tuple[str] = None  # prop that tracks index
+
+    def get_collection(self) -> tuple[object, bpy.types.Collection, int]:
+        if self.base_path is None:
+            raise UnimplementedError("self.base_path not defined")
+        if self.collection_name is None:
+            raise UnimplementedError("self.collection_name not defined")
+        if self.index_name is None:
+            raise UnimplementedError("self.index_name not defined")
+
+        return get_collection_props_from_context(bpy.context, self.base_path, self.collection_name, self.index_name)
+
+
+class AddNewToCollection(CollectionOperator):
+    bl_label = "Add an item to the list"
+
+    @staticmethod
+    def get_idname(base_list_name):
+        return f"{base_list_name}.add_item"
+
+    def execute(self, context):
+        _, collection, _ = self.get_collection()
+        collection.add()
+
+        return {"FINISHED"}
+
+
+class RemoveFromCollection(CollectionOperator):
+    bl_label = "Remove an item in the list"
+
+    @staticmethod
+    def get_idname(base_list_name):
+        return f"{base_list_name}.remove_item"
+
+    @classmethod
+    def poll(cls, context):
+        # TODO: Remove if __init__ is successful
+        raise Exception("classmethod `poll` not implemented: should poll the collection")
+
+    def execute(self, context):
+        collection_base, collection, index = self.get_collection()
+        collection.remove(index)
+        setattr(collection_base, self.index_name[-1], min(max(0, index - 1), len(collection)))
+
+        return {"FINISHED"}
+
+
+class MoveItemInCollection(CollectionOperator):
+    """Move an item in the list."""
+
+    bl_label = "Move an item in the list"
+
+    direction: bpy.props.EnumProperty(
+        items=(
+            ("UP", "Up", ""),
+            ("DOWN", "Down", ""),
+        )
+    )
+
+    @staticmethod
+    def get_idname(base_list_name):
+        return f"{base_list_name}.move_item"
+
+    def move_index(self):
+        """Move index of an item render queue while clamping it."""
+        collection_base, collection, index = self.get_collection()
+
+        list_length = len(collection) - 1  # (index starts at 0)
+        new_index = index + (-1 if self.direction == "UP" else 1)
+        setattr(collection_base, self.index_name[-1], max(0, min(new_index, list_length)))
+
+    def execute(self, context):
+        _, collection, index = self.get_collection()
+
+        neighbor = index + (-1 if self.direction == "UP" else 1)
+        collection.move(neighbor, index)
+        self.move_index()
+
+        return {"FINISHED"}
+
+
+class DrawList(bpy.types.UIList):
+    """Demo UIList."""
+
+    name = "List Name"  # User should override
+    custom_icon = "OBJECT_DATAMODE"
+    layout_type = "DEFAULT"
+
+    def draw_item(self, context, layout, data, item, icon, active_data, active_propname, index):
+
+        # Make sure your code supports all 3 layout types
+        if self.layout_type in {"DEFAULT", "COMPACT"}:
+            if getattr(item, "draw", None):
+                item.draw(layout, data, index)
+            else:
+                layout.label(text=item.name, icon=self.custom_icon)
+
+        elif self.layout_type in {"GRID"}:
+            layout.alignment = "CENTER"
+            layout.label(text="", icon=self.custom_icon)
+
+
+def get_collection_classes(
+    # unique identifier for list root (can really be anything)
+    base_list_name: str,
+    # The following props are a list of tuples so you can have nested lists
+    # path from context to the root of your prop, e.g. context.["scene.base_prop"]
+    # You can supply dots in these paths to navigate through nested properties
+    base_path: tuple[str],
+    # from base_path, collection prop
+    collection_name: tuple[str],
+    # prop that tracks index
+    index_name: tuple[str],
+):
+    """
+    This function returns new classes that aid in creation of UI lists.
+    Here is an example of how it would be called:
+
+        (
+            # first four are classes
+            AddItemToNestedList,
+            RemoveItemFromNestedList,
+            MoveItemInNestedList,
+            DrawNestedUIList,
+            # last return value is the function you can call to draw your interactive list
+            draw_custom_object_prop_list
+        ) = get_collection_classes(
+            "anyuniqueidentifier",
+            ("object.fast64.sm64", "path.to_second_list"),
+            ("first_list_prop", "second_list_prop"),
+            ("first_list_prop_active_index", "second_list_prop_active_index")
+        )
+
+        What else you need to do:
+            - Register the first four classes returned from this function.
+
+            - Create a CollectionProperty, and an active index int property FOR that collection, e.g.:
+                class My_Custom_Properties(bpy.types.PropertyGroup):
+                    custom_props: bpy.props.CollectionProperty(type=CustomObjectExportProp, name="Custom Properties")
+                    custom_props_active_index: bpy.props.IntProperty(default=0, name="Custom Props Active Index")
+
+            - The CollectionProperty should point to a PropertyGroup for more customization. By default, the list
+              UI will only display the .name of the property, but you can add a custom draw method to that class, e.g.:
+
+                class CustomObjectExportProp(bpy.types.PropertyGroup):
+                    name: bpy.props.StringProperty(name="Name")
+                    value: bpy.props.StringProperty(name="Value")
+
+                    def draw(self, layout: bpy.types.UILayout, _data: "CollectionPropsParentData", index: int):
+                        row = layout.row(align=True).split(factor=0.15)
+                        row.label(text=f"{index}:")
+                        row.prop(self, 'value', text="")
+
+            - Call the draw function from somewhere in your UI:
+                draw_custom_object_prop_list(UILayout, context)
+
+    """
+
+    def get_this_collection(cls, context):
+        _, collection, _ = get_collection_props_from_context(context, base_path, collection_name, index_name)
+        return collection
+
+    class col_add(AddNewToCollection):
+        pass
+
+    class col_remove(RemoveFromCollection):
+        pass
+
+    setattr(col_remove, "poll", classmethod(get_this_collection))
+
+    class col_move(MoveItemInCollection):
+        pass
+
+    setattr(col_move, "poll", classmethod(get_this_collection))
+
+    for cls in [col_add, col_remove, col_move]:
+        setattr(cls, "bl_idname", cls.get_idname(base_list_name))
+        setattr(cls, "base_path", base_path)
+        setattr(cls, "collection_name", collection_name)
+        setattr(cls, "index_name", index_name)
+
+    class draw_item(DrawList):
+        name = base_list_name
+        bl_idname = f"draw{base_list_name}"
+
+    def draw_list(
+        layout: bpy.types.UILayout,
+        context: bpy.types.Context,
+    ):
+        collection_base, _collection, _index = get_collection_props_from_context(
+            context, base_path, collection_name, index_name
+        )
+
+        row = layout.row()
+        row.template_list(
+            draw_item.bl_idname, draw_item.name, collection_base, collection_name[-1], collection_base, index_name[-1]
+        )
+
+        column = row.column()
+        addrm_box = column.box()
+        addrm_box.emboss = "NORMAL"
+        addrm_box.operator(col_add.bl_idname, text="", icon="ADD")
+        addrm_box.operator(col_remove.bl_idname, text="", icon="REMOVE")
+
+        mv_box = column.box()
+        mv_box.emboss = "NORMAL"
+        mv_box.operator(col_move.bl_idname, text="", icon="TRIA_UP").direction = "UP"
+        mv_box.operator(col_move.bl_idname, text="", icon="TRIA_DOWN").direction = "DOWN"
+
+    return col_add, col_remove, col_move, draw_item, draw_list

--- a/fast64_internal/utility.py
+++ b/fast64_internal/utility.py
@@ -781,7 +781,7 @@ def store_original_meshes(add_warning: Callable[[str], None]):
     instanced_meshes = set()
     active_obj = bpy.context.view_layer.objects.active
     for obj in yield_children(active_obj):
-        if obj.data is not None:
+        if obj.data is not None and type(obj.data) == bpy.types.Mesh:
             has_modifiers = len(obj.modifiers) != 0
             has_uneven_scale = not obj_scale_is_unified(obj)
             shares_mesh = obj.data.users > 1


### PR DESCRIPTION
This system allows you to select certain objects to render with an sm64 room. It shows up as a UI list on room empties! I've created an example/demo blend file on how its used and I'll show some screenshots of the UI.

Test level:
<img width="509" alt="image" src="https://user-images.githubusercontent.com/79979276/195603383-b899f879-3405-4b03-82c1-1a09d8e2afd7.png">

Here I have room 2 inside of room 1:
![image](https://user-images.githubusercontent.com/79979276/195603566-983526a9-5776-429d-88cd-09992e151276.png)
The Room1 empty is the first item, which renders all of the children of room1, then the room3 exterior is rendered as well.

Room1 renders the outer box of room 2 and room 3:
![image](https://user-images.githubusercontent.com/79979276/195603913-956a69d3-7db8-4f5b-8602-b874dc4b242d.png)

Since room 3 is transitional, it renders the entirety of room 1 and room 4
![image](https://user-images.githubusercontent.com/79979276/195604034-77be4fb1-e7a9-4fb0-bc9b-ab79b98caf52.png)

Room 4 just renders the outer box of room 3
![image](https://user-images.githubusercontent.com/79979276/195604149-d38c1075-65ed-4dc1-9907-97531f84a5ef.png)

Its pretty simple to set this up, and requires you to use zero duplicates, and also lets you decide on how things should be ordered.

A more complex example of this would be the level I was working on that has 11 different rooms, and runs well on console. I was developing this feature alongside of this level so it is pretty well-tested as is.
![image](https://user-images.githubusercontent.com/79979276/195604737-6d4d5bf0-8371-4357-b09e-d863cca7365e.png)

Also:
![image](https://user-images.githubusercontent.com/79979276/195605030-a8e647f3-8e51-4212-bc88-80900726023f.png)
