### PR TITLE
[SM64] allow user to export a level from any of its children

### DIFF
--- a/fast64_internal/sm64/sm64_level_writer.py
+++ b/fast64_internal/sm64/sm64_level_writer.py
@@ -1065,15 +1065,28 @@ class SM64_ExportLevel(ObjectDataExporter):
     bl_options = {"REGISTER", "UNDO", "PRESET"}
 
     def execute(self, context):
-
+        if context.mode != "OBJECT":
+            raise PluginError("Operator can only be used in object mode.")
+        obj: bpy.types.Object = None
         try:
-            if context.mode != "OBJECT":
-                raise PluginError("Operator can only be used in object mode.")
-            if len(context.selected_objects) == 0:
-                raise PluginError("Object not selected.")
-            obj = context.selected_objects[0]
-            if obj.data is not None or obj.sm64_obj_type != "Level Root":
-                raise PluginError("The selected object is not an empty with the Level Root type.")
+            try:
+                if len(context.selected_objects) == 0:
+                    raise PluginError("Object not selected.")
+                obj = context.selected_objects[0]
+                if obj.data is not None or obj.sm64_obj_type != "Level Root":
+                    raise PluginError("The selected object is not an empty with the Level Root type.")
+            except PluginError:
+                # try to find parent level root
+                if obj is not None:
+                    while True:
+                        if not obj.parent:
+                            break
+                        obj = obj.parent
+                        if obj.data is None and obj.sm64_obj_type == "Level Root":
+                            break
+                if obj is None or obj.sm64_obj_type != "Level Root":
+                    raise PluginError("Cannot find level empty.")
+                selectSingleObject(obj)
 
             scaleValue = bpy.context.scene.blenderToSM64Scale
             finalTransform = mathutils.Matrix.Diagonal(mathutils.Vector((scaleValue, scaleValue, scaleValue))).to_4x4()


### PR DESCRIPTION
This just checks up the tree from your currently selected object to see if it can be exported. Its pretty simple in functionality and the biggest convenience of this was actually being able to map a hotkey to the export level operator so that after i make changes i can just hit ctrl enter from my current object and it exports the whole level!