### PR TITLE
Use object name for OOT exporters

### DIFF
--- a/fast64_internal/oot/__init__.py
+++ b/fast64_internal/oot/__init__.py
@@ -4,10 +4,17 @@ from ..panels import OOT_Panel
 from bpy.utils import register_class, unregister_class
 from .oot_level import oot_obj_panel_register, oot_obj_panel_unregister, oot_obj_register, oot_obj_unregister
 from .oot_anim import oot_anim_panel_register, oot_anim_panel_unregister, oot_anim_register, oot_anim_unregister
-from .oot_collision import oot_col_panel_register, oot_col_panel_unregister, oot_col_register, oot_col_unregister
 from .oot_utility import oot_utility_register, oot_utility_unregister
 from ..utility import prop_split
 from ..render_settings import on_update_render_settings
+
+from .oot_collision import (
+    oot_col_panel_register,
+    oot_col_panel_unregister,
+    oot_col_register,
+    oot_col_unregister,
+    OOTCollisionExportSettings,
+)
 
 from .oot_f3d_writer import (
     OOTDLExportSettings,
@@ -81,6 +88,7 @@ class OOT_Properties(bpy.types.PropertyGroup):
     skeletonImportSettings: bpy.props.PointerProperty(type=oot_skeleton.OOTSkeletonImportSettings)
     animExportSettings: bpy.props.PointerProperty(type=oot_anim.OOTAnimExportSettingsProperty)
     animImportSettings: bpy.props.PointerProperty(type=oot_anim.OOTAnimImportSettingsProperty)
+    collisionExportSettings: bpy.props.PointerProperty(type=OOTCollisionExportSettings)
 
 
 oot_classes = (

--- a/fast64_internal/oot/oot_anim.py
+++ b/fast64_internal/oot/oot_anim.py
@@ -38,7 +38,6 @@ class OOTAnimExportSettingsProperty(bpy.types.PropertyGroup):
     customPath: bpy.props.StringProperty(name="Folder", subtype="FILE_PATH")
     folderName: bpy.props.StringProperty(name="Animation Folder", default="object_geldb")
     isLink: bpy.props.BoolProperty(name="Is Link", default=False)
-    skeletonName: bpy.props.StringProperty(name="Skeleton Name", default="gGerudoRedSkel")
 
 
 class OOTAnimImportSettingsProperty(bpy.types.PropertyGroup):
@@ -426,7 +425,8 @@ def exportAnimationC(armatureObj: bpy.types.Object, settings: OOTAnimExportSetti
     exportPath = ootGetObjectPath(settings.isCustom, path, settings.folderName)
 
     checkEmptyName(settings.folderName)
-    checkEmptyName(settings.skeletonName)
+    checkEmptyName(armatureObj.name)
+    name = toAlnum(armatureObj.name)
     convertTransformMatrix = (
         mathutils.Matrix.Scale(getOOTScale(armatureObj.ootActorScale), 4)
         @ mathutils.Matrix.Diagonal(armatureObj.scale).to_4x4()
@@ -465,7 +465,7 @@ def exportAnimationC(armatureObj: bpy.types.Object, settings: OOTAnimExportSetti
             addIncludeFiles("gameplay_keep", headerPath, ootAnim.headerName)
 
     else:
-        ootAnim = ootExportNonLinkAnimation(armatureObj, convertTransformMatrix, settings.skeletonName)
+        ootAnim = ootExportNonLinkAnimation(armatureObj, convertTransformMatrix, name)
 
         ootAnimC = ootAnim.toC()
         path = ootGetPath(exportPath, settings.isCustom, "assets/objects/", settings.folderName, False, False)
@@ -839,7 +839,7 @@ class OOT_ExportAnimPanel(OOT_Panel):
 
         col.operator(OOT_ExportAnim.bl_idname)
         exportSettings = context.scene.fast64.oot.animExportSettings
-        prop_split(col, exportSettings, "skeletonName", "Anim Name Prefix")
+        col.label(text="Exports active animation on selected object.", icon="INFO")
         if exportSettings.isCustom:
             prop_split(col, exportSettings, "customPath", "Folder")
         elif not exportSettings.isLink:

--- a/fast64_internal/oot/oot_anim.py
+++ b/fast64_internal/oot/oot_anim.py
@@ -34,9 +34,9 @@ from ..f3d.f3d_parser import getImportData
 
 
 class OOTAnimExportSettingsProperty(bpy.types.PropertyGroup):
-    isCustomFilename: bpy.props.BoolProperty(name="Use Custom Filename")
+    isCustomFilename: bpy.props.BoolProperty(name="Use Custom Filename", description="Override filename instead of basing it off of the Blender name")
     filename: bpy.props.StringProperty(name="Filename")
-    isCustom: bpy.props.BoolProperty(name="Use Custom Path")
+    isCustom: bpy.props.BoolProperty(name="Use Custom Path", description="Determines whether or not to export to an explicitly specified folder")
     customPath: bpy.props.StringProperty(name="Folder", subtype="FILE_PATH")
     folderName: bpy.props.StringProperty(name="Animation Folder", default="object_geldb")
     isLink: bpy.props.BoolProperty(name="Is Link", default=False)

--- a/fast64_internal/oot/oot_collision.py
+++ b/fast64_internal/oot/oot_collision.py
@@ -45,13 +45,13 @@ from .oot_utility import (
 
 
 class OOTCollisionExportSettings(bpy.types.PropertyGroup):
-    isCustomFilename: bpy.props.BoolProperty(name="Use Custom Filename")
+    isCustomFilename: bpy.props.BoolProperty(name="Use Custom Filename", description="Override filename instead of basing it off of the Blender name")
     filename: bpy.props.StringProperty(name="Filename")
     exportPath: bpy.props.StringProperty(name="Directory", subtype="FILE_PATH")
     exportLevel: bpy.props.EnumProperty(items=ootEnumSceneID, name="Level Used By Collision", default="SCENE_YDAN")
     includeChildren: bpy.props.BoolProperty(name="Include child objects", default=True)
     levelName: bpy.props.StringProperty(name="Name", default="SCENE_YDAN")
-    customExport: bpy.props.BoolProperty(name="Custom Export Path")
+    customExport: bpy.props.BoolProperty(name="Custom Export Path", description="Determines whether or not to export to an explicitly specified folder")
     folder: bpy.props.StringProperty(name="Object Name", default="gameplay_keep")
 
 

--- a/fast64_internal/oot/oot_f3d_writer.py
+++ b/fast64_internal/oot/oot_f3d_writer.py
@@ -54,11 +54,11 @@ from ..f3d.flipbook import flipbook_to_c, flipbook_2d_to_c, flipbook_data_to_c
 
 
 class OOTDLExportSettings(bpy.types.PropertyGroup):
-    isCustomFilename: bpy.props.BoolProperty(name="Use Custom Filename")
+    isCustomFilename: bpy.props.BoolProperty(name="Use Custom Filename", description="Override filename instead of basing it off of the Blender name")
     filename: bpy.props.StringProperty(name="Filename")
     folder: bpy.props.StringProperty(name="DL Folder", default="gameplay_keep")
     customPath: bpy.props.StringProperty(name="Custom DL Path", subtype="FILE_PATH")
-    isCustom: bpy.props.BoolProperty(name="Use Custom Path")
+    isCustom: bpy.props.BoolProperty(name="Use Custom Path", description="Determines whether or not to export to an explicitly specified folder")
     removeVanillaData: bpy.props.BoolProperty(name="Replace Vanilla DLs")
     drawLayer: bpy.props.EnumProperty(name="Draw Layer", items=ootEnumDrawLayers)
     actorOverlayName: bpy.props.StringProperty(name="Overlay", default="")

--- a/fast64_internal/oot/oot_f3d_writer.py
+++ b/fast64_internal/oot/oot_f3d_writer.py
@@ -54,6 +54,8 @@ from ..f3d.flipbook import flipbook_to_c, flipbook_2d_to_c, flipbook_data_to_c
 
 
 class OOTDLExportSettings(bpy.types.PropertyGroup):
+    isCustomFilename: bpy.props.BoolProperty(name="Use Custom Filename")
+    filename: bpy.props.StringProperty(name="Filename")
     folder: bpy.props.StringProperty(name="DL Folder", default="gameplay_keep")
     customPath: bpy.props.StringProperty(name="Custom DL Path", subtype="FILE_PATH")
     isCustom: bpy.props.BoolProperty(name="Use Custom Path")
@@ -299,7 +301,8 @@ def ootConvertMeshToC(
         textureArrayData = writeTextureArraysNew(fModel, flipbookArrayIndex2D)
         data.append(textureArrayData)
 
-    writeCData(data, os.path.join(path, name + ".h"), os.path.join(path, name + ".c"))
+    filename = settings.filename if settings.isCustomFilename else name
+    writeCData(data, os.path.join(path, filename + ".h"), os.path.join(path, filename + ".c"))
 
     if not isCustomExport:
         writeTextureArraysExisting(bpy.context.scene.ootDecompPath, overlayName, False, flipbookArrayIndex2D, fModel)
@@ -614,6 +617,9 @@ class OOT_ExportDLPanel(OOT_Panel):
         exportSettings: OOTDLExportSettings = context.scene.fast64.oot.DLExportSettings
 
         col.label(text="Object name used for export.", icon="INFO")
+        col.prop(exportSettings, "isCustomFilename")
+        if exportSettings.isCustomFilename:
+            prop_split(col, exportSettings, "filename", "Filename")
         prop_split(col, exportSettings, "folder", "Object" if not exportSettings.isCustom else "Folder")
         if exportSettings.isCustom:
             prop_split(col, exportSettings, "customAssetIncludeDir", "Asset Include Path")

--- a/fast64_internal/oot/oot_f3d_writer.py
+++ b/fast64_internal/oot/oot_f3d_writer.py
@@ -54,7 +54,6 @@ from ..f3d.flipbook import flipbook_to_c, flipbook_2d_to_c, flipbook_data_to_c
 
 
 class OOTDLExportSettings(bpy.types.PropertyGroup):
-    name: bpy.props.StringProperty(name="DL Name", default="gBoulderFragmentsDL")
     folder: bpy.props.StringProperty(name="DL Folder", default="gameplay_keep")
     customPath: bpy.props.StringProperty(name="Custom DL Path", subtype="FILE_PATH")
     isCustom: bpy.props.BoolProperty(name="Use Custom Path")
@@ -257,7 +256,7 @@ def ootConvertMeshToC(
     isCustomExport = settings.isCustom
     drawLayer = settings.drawLayer
     removeVanillaData = settings.removeVanillaData
-    name = toAlnum(settings.name)
+    name = toAlnum(originalObj.name)
     overlayName = settings.actorOverlayName
     flipbookUses2DArray = settings.flipbookUses2DArray
     flipbookArrayIndex2D = settings.flipbookArrayIndex2D if flipbookUses2DArray else None
@@ -614,7 +613,7 @@ class OOT_ExportDLPanel(OOT_Panel):
         col.operator(OOT_ExportDL.bl_idname)
         exportSettings: OOTDLExportSettings = context.scene.fast64.oot.DLExportSettings
 
-        prop_split(col, exportSettings, "name", "DL")
+        col.label(text="Object name used for export.", icon="INFO")
         prop_split(col, exportSettings, "folder", "Object" if not exportSettings.isCustom else "Folder")
         if exportSettings.isCustom:
             prop_split(col, exportSettings, "customAssetIncludeDir", "Asset Include Path")

--- a/fast64_internal/oot/oot_skeleton.py
+++ b/fast64_internal/oot/oot_skeleton.py
@@ -57,12 +57,12 @@ from .oot_skeleton_import_data import (
 
 
 class OOTSkeletonExportSettings(bpy.types.PropertyGroup):
-    isCustomFilename: bpy.props.BoolProperty(name="Use Custom Filename")
+    isCustomFilename: bpy.props.BoolProperty(name="Use Custom Filename", description="Override filename instead of basing it off of the Blender name")
     filename: bpy.props.StringProperty(name="Filename")
     mode: bpy.props.EnumProperty(name="Mode", items=ootEnumSkeletonImportMode)
     folder: bpy.props.StringProperty(name="Skeleton Folder", default="object_geldb")
     customPath: bpy.props.StringProperty(name="Custom Skeleton Path", subtype="FILE_PATH")
-    isCustom: bpy.props.BoolProperty(name="Use Custom Path")
+    isCustom: bpy.props.BoolProperty(name="Use Custom Path", description="Determines whether or not to export to an explicitly specified folder")
     removeVanillaData: bpy.props.BoolProperty(name="Replace Vanilla Skeletons On Export", default=True)
     actorOverlayName: bpy.props.StringProperty(name="Overlay", default="ovl_En_GeldB")
     flipbookUses2DArray: bpy.props.BoolProperty(name="Has 2D Flipbook Array", default=False)

--- a/fast64_internal/oot/oot_skeleton.py
+++ b/fast64_internal/oot/oot_skeleton.py
@@ -58,7 +58,6 @@ from .oot_skeleton_import_data import (
 
 class OOTSkeletonExportSettings(bpy.types.PropertyGroup):
     mode: bpy.props.EnumProperty(name="Mode", items=ootEnumSkeletonImportMode)
-    name: bpy.props.StringProperty(name="Skeleton Name", default="gGerudoRedSkel")
     folder: bpy.props.StringProperty(name="Skeleton Folder", default="object_geldb")
     customPath: bpy.props.StringProperty(name="Custom Skeleton Path", subtype="FILE_PATH")
     isCustom: bpy.props.BoolProperty(name="Use Custom Path")
@@ -656,7 +655,7 @@ def ootConvertArmatureToC(
         flipbookArrayIndex2D = importInfo.flipbookArrayIndex2D
         isLink = importInfo.isLink
     else:
-        skeletonName = toAlnum(settings.name)
+        skeletonName = toAlnum(originalArmatureObj.name)
         folderName = settings.folder
         overlayName = settings.actorOverlayName if not settings.isCustom else None
         flipbookUses2DArray = settings.flipbookUses2DArray
@@ -1211,15 +1210,14 @@ class OOT_ExportSkeletonPanel(OOT_Panel):
             b.label(icon="LIBRARY_DATA_BROKEN", text="Do not draw anything in SkelAnime")
             b.label(text="callbacks or cull limbs, will be corrupted.")
         col.prop(exportSettings, "isCustom")
+        col.label(text="Object name used for export.", icon="INFO")
         if exportSettings.isCustom:
-            prop_split(col, exportSettings, "name", "Skeleton")
             prop_split(col, exportSettings, "folder", "Object" if not exportSettings.isCustom else "Folder")
             prop_split(col, exportSettings, "customAssetIncludeDir", "Asset Include Path")
             prop_split(col, exportSettings, "customPath", "Path")
         else:
             prop_split(col, exportSettings, "mode", "Mode")
             if exportSettings.mode == "Generic":
-                prop_split(col, exportSettings, "name", "Skeleton")
                 prop_split(col, exportSettings, "folder", "Object" if not exportSettings.isCustom else "Folder")
                 prop_split(col, exportSettings, "actorOverlayName", "Overlay")
                 col.prop(exportSettings, "flipbookUses2DArray")


### PR DESCRIPTION
Instead of using a specified name in export settings, the name of the object is used instead. This applies to skeleton/DL/collision/animation exporters.