### PR TITLE
Add shared palette handling for CI multitexture

### DIFF
--- a/fast64_internal/f3d/f3d_writer.py
+++ b/fast64_internal/f3d/f3d_writer.py
@@ -1,4 +1,3 @@
-from email.mime import image
 from typing import Union
 import functools
 import bpy, bmesh, mathutils, os, re, copy, math
@@ -23,6 +22,43 @@ from .f3d_gbi import *
 from .f3d_gbi import _DPLoadTextureBlock
 
 from ..utility import *
+
+
+class FImageKey:
+    def __init__(
+        self, image: bpy.types.Image, texFormat: str, palFormat: str, imagesSharingPalette: list[bpy.types.Image] = []
+    ):
+        self.image = image
+        self.texFormat = texFormat
+        self.palFormat = palFormat
+        self.imagesSharingPalette = tuple(imagesSharingPalette)
+
+    def __hash__(self) -> int:
+        return hash((self.image, self.texFormat, self.palFormat, self.imagesSharingPalette))
+
+    def __eq__(self, __o: object) -> bool:
+        if not isinstance(__o, FImageKey):
+            return False
+        return (
+            self.image == __o.image
+            and self.texFormat == __o.texFormat
+            and self.palFormat == __o.palFormat
+            and self.imagesSharingPalette == __o.imagesSharingPalette
+        )
+
+
+class FPaletteKey:
+    def __init__(self, palFormat: str, imagesSharingPalette: list[bpy.types.Image] = []):
+        self.palFormat = palFormat
+        self.imagesSharingPalette = tuple(imagesSharingPalette)
+
+    def __hash__(self) -> int:
+        return hash((self.palFormat, self.imagesSharingPalette))
+
+    def __eq__(self, __o: object) -> bool:
+        if not isinstance(__o, FPaletteKey):
+            return False
+        return self.palFormat == __o.palFormat and self.imagesSharingPalette == __o.imagesSharingPalette
 
 
 def getColorLayer(mesh: bpy.types.Mesh, layer="Col"):
@@ -381,12 +417,13 @@ def saveMeshWithLargeTexturesByFaces(
     # 	bMesh, texDimensions, transformMatrix, isPointSampled, isFlatShaded,
     # 	exportVertexColors, fModel.f3d)
     currentGroupIndex = None
+    imageKey0, imageKey1 = getImageKeys(f3dMat, False)
     for tileLoad, tileFaces in tileLoads:
         revertCommands = GfxList("temp", GfxListTag.Draw, fModel.DLFormat)
         nextTmem = 0
         triGroup.triList.commands.append(DPPipeSync())
         if fMaterial.texturesLoaded[0] and not (otherTextureIndex == 0 and otherTexSingleLoad):
-            texDimensions0, nextTmem = saveTextureIndex(
+            texDimensions0, nextTmem, fImage0 = saveTextureIndex(
                 material.name,
                 fModel,
                 fMaterial,
@@ -400,9 +437,11 @@ def saveMeshWithLargeTexturesByFaces(
                 [tileLoad, None],
                 True,
                 False,
+                None,
+                imageKey0,
             )
         if fMaterial.texturesLoaded[1] and not (otherTextureIndex == 1 and otherTexSingleLoad):
-            texDimensions1, nextTmem = saveTextureIndex(
+            texDimensions1, nextTmem, fImage1 = saveTextureIndex(
                 material.name,
                 fModel,
                 fMaterial,
@@ -416,6 +455,8 @@ def saveMeshWithLargeTexturesByFaces(
                 [None, tileLoad],
                 True,
                 False,
+                None,
+                imageKey1,
             )
 
         triConverter = TriangleConverter(
@@ -1392,6 +1433,23 @@ class FSharedPalette:
         self.palette = []
 
 
+def getImageKeys(f3dMat: F3DMaterialProperty, useSharedCIPalette: bool) -> tuple[FImageKey, FImageKey]:
+    imageKey0 = FImageKey(
+        f3dMat.tex0.tex,
+        f3dMat.tex0.tex_format,
+        f3dMat.tex0.ci_format,
+        [f3dMat.tex0.tex] + ([f3dMat.tex1.tex] if useSharedCIPalette else []),
+    )
+    imageKey1 = FImageKey(
+        f3dMat.tex1.tex,
+        f3dMat.tex1.tex_format,
+        f3dMat.tex1.ci_format,
+        ([f3dMat.tex0.tex] if useSharedCIPalette else []) + [f3dMat.tex1.tex],
+    )
+
+    return imageKey0, imageKey1
+
+
 def saveOrGetF3DMaterial(material, fModel, obj, drawLayer, convertTextureData):
     if material.mat_ver > 3:
         f3dMat = material.f3d_mat
@@ -1519,7 +1577,7 @@ def saveOrGetF3DMaterial(material, fModel, obj, drawLayer, convertTextureData):
     texDimensions0 = None
     texDimensions1 = None
     nextTmem = 0
-    loadTextures = not (material.mat_ver > 3 and f3dMat.use_large_textures)
+    useLargeTextures = material.mat_ver > 3 and f3dMat.use_large_textures
 
     useTex0 = useDict["Texture 0"] and f3dMat.tex0.tex_set
     isTex0CI = f3dMat.tex0.tex_format[:2] == "CI"
@@ -1550,6 +1608,8 @@ def saveOrGetF3DMaterial(material, fModel, obj, drawLayer, convertTextureData):
         loadGfx = fMaterial.material
         revertGfx = fMaterial.revert
 
+    imageKey0, imageKey1 = getImageKeys(f3dMat, useSharedCIPalette)
+
     if useTex0:
         if f3dMat.tex0.tex is None and not f3dMat.tex0.use_tex_reference:
             raise PluginError('In material "' + material.name + '", a texture has not been set.')
@@ -1571,6 +1631,7 @@ def saveOrGetF3DMaterial(material, fModel, obj, drawLayer, convertTextureData):
             True,
             True,
             sharedPalette,
+            imageKey0,
         )
 
     # If the texture in both texels is the same then it can be rewritten to the same location in tmem
@@ -1600,6 +1661,7 @@ def saveOrGetF3DMaterial(material, fModel, obj, drawLayer, convertTextureData):
             True,
             True,
             sharedPalette,
+            imageKey1,
         )
 
     if useSharedCIPalette:
@@ -1609,7 +1671,7 @@ def saveOrGetF3DMaterial(material, fModel, obj, drawLayer, convertTextureData):
         fPalette, paletteKey = saveOrGetPaletteOnlyDefinition(
             fMaterial,
             fModel,
-            f3dMat.tex0.tex,
+            [f3dMat.tex0.tex, f3dMat.tex1.tex],
             sharedPalette.name,
             texFormat,
             palFormat,
@@ -1786,6 +1848,7 @@ def saveTextureIndex(
     loadTextures: bool,
     loadPalettes: bool,
     sharedPalette: FSharedPalette,
+    imageKey: FImageKey,
 ) -> tuple[list[int], int, FImage]:
     tex = texProp.tex
 
@@ -1872,7 +1935,15 @@ def saveTextureIndex(
         else:
             # fPalette should be an fImage here, since sharedPalette is None
             fImage, fPalette, alreadyExists = saveOrGetPaletteAndImageDefinition(
-                fMaterial, fModel, tex, texName, texFormat, palFormat, convertTextureData, sharedPalette
+                fMaterial,
+                fModel,
+                tex,
+                texName,
+                texFormat,
+                palFormat,
+                convertTextureData,
+                sharedPalette,
+                imageKey,
             )
 
         if loadPalettes and sharedPalette is None:
@@ -2143,7 +2214,7 @@ def savePaletteLoading(loadTexGfx, revertTexGfx, fPalette, palFormat, pal, color
 def saveOrGetPaletteOnlyDefinition(
     fMaterial: FMaterial,
     fModel: FModel,
-    image: bpy.types.Image,
+    images: list[bpy.types.Image],
     imageName: str,
     texFmt: str,
     palFmt: str,
@@ -2153,7 +2224,7 @@ def saveOrGetPaletteOnlyDefinition(
 
     palFormat = texFormatOf[palFmt]
     paletteName = checkDuplicateTextureName(fModel, toAlnum(imageName) + "_pal_" + palFmt.lower())
-    paletteKey = (image, (palFmt, "PAL"))
+    paletteKey = FPaletteKey(palFmt, images)
     paletteFilename = getNameFromPath(imageName, True) + "." + fModel.getTextureSuffixFromFormat(texFmt) + ".pal"
 
     fPalette = FImage(
@@ -2179,24 +2250,21 @@ def saveOrGetPaletteOnlyDefinition(
     return fPalette, paletteKey
 
 
-def imageAlreadyExists(fModel: FModel, image: bpy.types.Image, texFmt: str, palFmt: str) -> bool:
-    texFormat = texFormatOf[texFmt]
-    palFormat = texFormatOf[palFmt]
-    bitSize = texBitSizeOf[texFmt]
-    # If image already loaded, return that data.
-    imageKey = (image, (texFmt, palFmt))
-    fImage, fPalette = fModel.getTextureAndHandleShared(imageKey)
-    return fImage is not None
-
-
 def saveOrGetPaletteAndImageDefinition(
-    fMaterial, fModelOrTexRect, image, imageName, texFmt, palFmt, convertTextureData, sharedPalette: FSharedPalette
+    fMaterial,
+    fModelOrTexRect,
+    image,
+    imageName,
+    texFmt,
+    palFmt,
+    convertTextureData,
+    sharedPalette: FSharedPalette,
+    imageKey: FImageKey,
 ) -> tuple[FImage, FImage, bool]:
     texFormat = texFormatOf[texFmt]
     palFormat = texFormatOf[palFmt]
     bitSize = texBitSizeOf[texFmt]
     # If image already loaded, return that data.
-    imageKey = (image, (texFmt, palFmt))
     fImage, fPalette = fModelOrTexRect.getTextureAndHandleShared(imageKey)
     if fImage is not None:
         # print(f"Image already exists")
@@ -2267,7 +2335,7 @@ def saveOrGetPaletteAndImageDefinition(
         else:
             fImage.data = bytearray(texture)
 
-    fModelOrTexRect.addTexture((image, (texFmt, palFmt)), fImage, fMaterial)
+    fModelOrTexRect.addTexture(imageKey, fImage, fMaterial)
 
     # For shared palettes, paletteName should be the same for the same imageName until
     # the next saveOrGetPaletteOnlyDefinition
@@ -2276,7 +2344,7 @@ def saveOrGetPaletteAndImageDefinition(
 
     if sharedPalette is None:
         fPalette, paletteKey = saveOrGetPaletteOnlyDefinition(
-            fMaterial, fModelOrTexRect, image, imageName, texFmt, palFmt, convertTextureData, palette
+            fMaterial, fModelOrTexRect, [image], imageName, texFmt, palFmt, convertTextureData, palette
         )
         fImage.paletteKey = paletteKey
     else:
@@ -2312,7 +2380,8 @@ def saveOrGetTextureDefinition(fMaterial, fModel, image: bpy.types.Image, imageN
     bitSize = texBitSizeOf[texFormat]
 
     # If image already loaded, return that data.
-    imageKey = (image, (texFormat, "NONE"))
+    # We use NONE here for pal format since this function is only to be called for non-ci textures.
+    imageKey = FImageKey(image, texFormat, "NONE")
     fImage, fPalette = fModel.getTextureAndHandleShared(imageKey)
     if fImage is not None:
         return fImage
@@ -2541,7 +2610,7 @@ def saveOrGetTextureDefinition(fMaterial, fModel, image: bpy.types.Image, imageN
             fImage.data = compactNibbleArray(fImage.data, image.size[0], image.size[1])
 
     print("Finished converting.")
-    fModel.addTexture((image, (texFormat, "NONE")), fImage, fMaterial)
+    fModel.addTexture(imageKey, fImage, fMaterial)
 
     return fImage
 

--- a/fast64_internal/f3d/f3d_writer.py
+++ b/fast64_internal/f3d/f3d_writer.py
@@ -1,3 +1,4 @@
+from email.mime import image
 from typing import Union
 import functools
 import bpy, bmesh, mathutils, os, re, copy, math
@@ -16,6 +17,7 @@ from .f3d_material import (
     texBitSizeOf,
     texFormatOf,
     TextureProperty,
+    F3DMaterialProperty,
 )
 from .f3d_gbi import *
 from .f3d_gbi import _DPLoadTextureBlock
@@ -1384,6 +1386,12 @@ def getTexDimensions(material):
     return texDimensions
 
 
+class FSharedPalette:
+    def __init__(self, name):
+        self.name = name
+        self.palette = []
+
+
 def saveOrGetF3DMaterial(material, fModel, obj, drawLayer, convertTextureData):
     if material.mat_ver > 3:
         f3dMat = material.f3d_mat
@@ -1500,8 +1508,10 @@ def saveOrGetF3DMaterial(material, fModel, obj, drawLayer, convertTextureData):
     # Set scale
     s = int(min(round(f3dMat.tex_scale[0] * 0x10000), 0xFFFF))
     t = int(min(round(f3dMat.tex_scale[1] * 0x10000), 0xFFFF))
-    if f3dMat.rdp_settings.g_mdsft_textlod == 'G_TL_LOD':
-        fMaterial.material.commands.append(SPTexture(s, t, f3dMat.rdp_settings.num_textures_mipmapped - 1, fModel.f3d.G_TX_RENDERTILE, 1))
+    if f3dMat.rdp_settings.g_mdsft_textlod == "G_TL_LOD":
+        fMaterial.material.commands.append(
+            SPTexture(s, t, f3dMat.rdp_settings.num_textures_mipmapped - 1, fModel.f3d.G_TX_RENDERTILE, 1)
+        )
     else:
         fMaterial.material.commands.append(SPTexture(s, t, 0, fModel.f3d.G_TX_RENDERTILE, 1))
 
@@ -1509,19 +1519,49 @@ def saveOrGetF3DMaterial(material, fModel, obj, drawLayer, convertTextureData):
     texDimensions0 = None
     texDimensions1 = None
     nextTmem = 0
-    useLargeTextures = material.mat_ver > 3 and f3dMat.use_large_textures
-    if useDict["Texture 0"] and f3dMat.tex0.tex_set:
+    loadTextures = not (material.mat_ver > 3 and f3dMat.use_large_textures)
+
+    useTex0 = useDict["Texture 0"] and f3dMat.tex0.tex_set
+    isTex0CI = f3dMat.tex0.tex_format[:2] == "CI"
+    useTex1 = useDict["Texture 1"] and f3dMat.tex1.tex_set
+    isTex1CI = f3dMat.tex1.tex_format[:2] == "CI"
+
+    useSharedCIPalette = (
+        useTex0
+        and useTex1
+        and isTex0CI
+        and isTex1CI
+        and not f3dMat.tex0.use_tex_reference
+        and not f3dMat.tex1.use_tex_reference
+        and f3dMat.tex0.tex_format == f3dMat.tex1.tex_format
+        and f3dMat.tex0.ci_format == f3dMat.tex1.ci_format
+    )
+
+    # Without shared palette: (load pal0 -> load tex0) or (load pal1 -> load tex1)
+    # with shared palette: load pal -> load tex0 -> load tex1
+    if useSharedCIPalette:
+        sharedPalette = FSharedPalette(getSharedPaletteName(f3dMat))
+
+        # dummy lists to be appended in later
+        loadGfx = GfxList(None, None, fModel.DLFormat)
+        revertGfx = GfxList(None, None, fModel.DLFormat)
+    else:
+        sharedPalette = None
+        loadGfx = fMaterial.material
+        revertGfx = fMaterial.revert
+
+    if useTex0:
         if f3dMat.tex0.tex is None and not f3dMat.tex0.use_tex_reference:
             raise PluginError('In material "' + material.name + '", a texture has not been set.')
 
         fMaterial.useLargeTextures = useLargeTextures
         fMaterial.texturesLoaded[0] = True
-        texDimensions0, nextTmem = saveTextureIndex(
+        texDimensions0, nextTmem, fImage0 = saveTextureIndex(
             material.name,
             fModel,
             fMaterial,
-            fMaterial.material,
-            fMaterial.revert,
+            loadGfx,
+            revertGfx,
             f3dMat.tex0,
             0,
             nextTmem,
@@ -1530,6 +1570,7 @@ def saveOrGetF3DMaterial(material, fModel, obj, drawLayer, convertTextureData):
             None,
             True,
             True,
+            sharedPalette,
         )
 
     # If the texture in both texels is the same then it can be rewritten to the same location in tmem
@@ -1538,18 +1579,18 @@ def saveOrGetF3DMaterial(material, fModel, obj, drawLayer, convertTextureData):
         if nextTmem >= (512 if f3dMat.tex0.tex_format[:2] != "CI" else 256):
             nextTmem = 0
 
-    if useDict["Texture 1"] and f3dMat.tex1.tex_set:
+    if useTex1:
         if f3dMat.tex1.tex is None and not f3dMat.tex1.use_tex_reference:
             raise PluginError('In material "' + material.name + '", a texture has not been set.')
 
         fMaterial.useLargeTextures = useLargeTextures
         fMaterial.texturesLoaded[1] = True
-        texDimensions1, nextTmem = saveTextureIndex(
+        texDimensions1, nextTmem, fImage1 = saveTextureIndex(
             material.name,
             fModel,
             fMaterial,
-            fMaterial.material,
-            fMaterial.revert,
+            loadGfx,
+            revertGfx,
             f3dMat.tex1,
             1,
             nextTmem,
@@ -1558,7 +1599,40 @@ def saveOrGetF3DMaterial(material, fModel, obj, drawLayer, convertTextureData):
             None,
             True,
             True,
+            sharedPalette,
         )
+
+    if useSharedCIPalette:
+        texFormat = f3dMat.tex0.tex_format
+        palFormat = f3dMat.tex0.ci_format
+
+        fPalette, paletteKey = saveOrGetPaletteOnlyDefinition(
+            fMaterial,
+            fModel,
+            f3dMat.tex0.tex,
+            sharedPalette.name,
+            texFormat,
+            palFormat,
+            convertTextureData,
+            sharedPalette.palette,
+        )
+        savePaletteLoading(
+            fMaterial.material,
+            fMaterial.revert,
+            fPalette,
+            palFormat,
+            0,
+            fPalette.height,
+            fModel.f3d,
+            fModel.matWriteMethod,
+        )
+
+        # Append these commands after palette loading commands
+        fMaterial.material.commands.extend(loadGfx.commands)
+        fMaterial.revert.commands.extend(revertGfx.commands)
+
+        fImage0.paletteKey = paletteKey
+        fImage1.paletteKey = paletteKey
 
     # Used so we know how to convert normalized UVs when saving verts.
     if texDimensions0 is not None and texDimensions1 is not None:
@@ -1679,6 +1753,16 @@ def getTextureName(texProp: TextureProperty, fModelName: str, overrideName: str)
     return texName
 
 
+def getSharedPaletteName(f3dMat: F3DMaterialProperty):
+    image0 = f3dMat.tex0.tex
+    image1 = f3dMat.tex1.tex
+    texFormat = f3dMat.tex0.tex_format.lower()
+    tex0Name = getNameFromPath(image0.filepath if image0.filepath != "" else image0.name, True)
+    tex1Name = getNameFromPath(image1.filepath if image1.filepath != "" else image1.name, True)
+
+    return f"{tex0Name}_x_{tex1Name}_{texFormat}_pal"
+
+
 def getTextureNameTexRef(texProp: TextureProperty, fModelName: str) -> str:
     texFormat = texProp.tex_format
     name = texProp.tex_reference
@@ -1688,20 +1772,21 @@ def getTextureNameTexRef(texProp: TextureProperty, fModelName: str) -> str:
 
 
 def saveTextureIndex(
-    propName,
-    fModel,
-    fMaterial,
-    loadTexGfx,
-    revertTexGfx,
-    texProp,
-    index,
-    tmem,
-    overrideName,
-    convertTextureData,
+    propName: str,
+    fModel: FModel,
+    fMaterial: FMaterial,
+    loadTexGfx: GfxList,
+    revertTexGfx: GfxList,
+    texProp: TextureProperty,
+    index: int,
+    tmem: int,
+    overrideName: str,
+    convertTextureData: bool,
     tileSettingsOverride,
-    loadTextures,
-    loadPalettes,
-):
+    loadTextures: bool,
+    loadPalettes: bool,
+    sharedPalette: FSharedPalette,
+) -> tuple[list[int], int, FImage]:
     tex = texProp.tex
 
     if tex is not None and (tex.size[0] == 0 or tex.size[1] == 0):
@@ -1787,10 +1872,10 @@ def saveTextureIndex(
         else:
             # fPalette should be an fImage here, since sharedPalette is None
             fImage, fPalette, alreadyExists = saveOrGetPaletteAndImageDefinition(
-                fMaterial, fModel, tex, texName, texFormat, palFormat, convertTextureData, None
+                fMaterial, fModel, tex, texName, texFormat, palFormat, convertTextureData, sharedPalette
             )
 
-        if loadPalettes:
+        if loadPalettes and sharedPalette is None:
             savePaletteLoading(
                 loadTexGfx, revertTexGfx, fPalette, palFormat, 0, fPalette.height, fModel.f3d, fModel.matWriteMethod
             )
@@ -1829,7 +1914,7 @@ def saveTextureIndex(
     # 	texFormatOf[texFormat], texBitSizeOf[texFormat])
     # fModel.textures[texName] = fImage
 
-    return texDimensions, nextTmem
+    return texDimensions, nextTmem, fImage
 
 
 # texIndex: 0 for texture0, 1 for texture1
@@ -2055,12 +2140,6 @@ def savePaletteLoading(loadTexGfx, revertTexGfx, fPalette, palFormat, pal, color
         )
 
 
-class FSharedPalette:
-    def __init__(self, name):
-        self.name = name
-        self.palette = []
-
-
 def saveOrGetPaletteOnlyDefinition(
     fMaterial: FMaterial,
     fModel: FModel,
@@ -2070,7 +2149,7 @@ def saveOrGetPaletteOnlyDefinition(
     palFmt: str,
     convertTextureData: bool,
     palette: list[int],
-) -> FImage:
+) -> tuple[FImage, tuple[bpy.types.Image, tuple[str, str]]]:
 
     palFormat = texFormatOf[palFmt]
     paletteName = checkDuplicateTextureName(fModel, toAlnum(imageName) + "_pal_" + palFmt.lower())
@@ -2097,7 +2176,7 @@ def saveOrGetPaletteOnlyDefinition(
     # print(f"Palette data: {paletteName} - length {len(fPalette.data)}")
 
     fModel.addTexture(paletteKey, fPalette, fMaterial)
-    return fPalette
+    return fPalette, paletteKey
 
 
 def imageAlreadyExists(fModel: FModel, image: bpy.types.Image, texFmt: str, palFmt: str) -> bool:
@@ -2196,10 +2275,9 @@ def saveOrGetPaletteAndImageDefinition(
     paletteName = checkDuplicateTextureName(fModelOrTexRect, toAlnum(imageName) + "_pal_" + palFmt.lower())
 
     if sharedPalette is None:
-        fPalette = saveOrGetPaletteOnlyDefinition(
+        fPalette, paletteKey = saveOrGetPaletteOnlyDefinition(
             fMaterial, fModelOrTexRect, image, imageName, texFmt, palFmt, convertTextureData, palette
         )
-        paletteKey = (image, (palFmt, "PAL"))
         fImage.paletteKey = paletteKey
     else:
         fPalette = None

--- a/fast64_internal/oot/oot_model_classes.py
+++ b/fast64_internal/oot/oot_model_classes.py
@@ -239,7 +239,7 @@ class OOTModel(FModel):
         if existingFPalette == False:
 
             palFormat = texProp.ci_format
-            fPalette = saveOrGetPaletteOnlyDefinition(
+            fPalette, paletteKey = saveOrGetPaletteOnlyDefinition(
                 fMaterial,
                 self,
                 firstImage,
@@ -253,7 +253,6 @@ class OOTModel(FModel):
             # using the first image for the key, apply paletteKey to all images
             # while this is not ideal, its better to us an image for the key as
             # names are modified when duplicates are found
-            paletteKey = (firstImage, (palFormat, "PAL"))
             for fImage in fImages:
                 fImage.paletteKey = paletteKey
         else:

--- a/fast64_internal/oot/oot_model_classes.py
+++ b/fast64_internal/oot/oot_model_classes.py
@@ -12,6 +12,7 @@ from ..f3d.f3d_writer import (
     DPSetTextureLUT,
     DPSetTile,
     texFormatOf,
+    FImageKey,
 )
 from ..f3d.f3d_parser import F3DContext, F3DTextureReference, getImportData
 from ..f3d.f3d_material import createF3DMat, TextureProperty
@@ -223,6 +224,12 @@ class OOTModel(FModel):
                 texProp.ci_format,
                 True,
                 sharedPalette,
+                FImageKey(
+                    flipbookTexture.image,
+                    texProp.tex_format,
+                    texProp.ci_format,
+                    [flipbookTexture.image for flipbookTexture in flipbookProp.textures],
+                ),
             )
             existingFPalette = self.validateCIFlipbook(existingFPalette, alreadyExists, fPalette, flipbookTexture.image)
             fImages.append(fImage)
@@ -242,7 +249,7 @@ class OOTModel(FModel):
             fPalette, paletteKey = saveOrGetPaletteOnlyDefinition(
                 fMaterial,
                 self,
-                firstImage,
+                [tex.image for tex in flipbookProp.textures],
                 sharedPalette.name,
                 texProp.tex_format,
                 palFormat,

--- a/fast64_internal/sm64/sm64_f3d_writer.py
+++ b/fast64_internal/sm64/sm64_f3d_writer.py
@@ -302,7 +302,7 @@ def exportTexRectCommon(texProp, f3dType, isHWv1, name, convertTextureData):
 
     drawEndCommands = GfxList("temp", GfxListTag.Draw, DLFormat.Dynamic)
 
-    texDimensions, nextTmem = saveTextureIndex(
+    texDimensions, nextTmem, fImage = saveTextureIndex(
         texProp.tex.name,
         fTexRect,
         fMaterial,

--- a/fast64_internal/sm64/sm64_f3d_writer.py
+++ b/fast64_internal/sm64/sm64_f3d_writer.py
@@ -316,6 +316,8 @@ def exportTexRectCommon(texProp, f3dType, isHWv1, name, convertTextureData):
         None,
         True,
         True,
+        None,
+        FImageKey(texProp.tex, texProp.tex_format, texProp.ci_format, [texProp.tex]),
     )
 
     fTexRect.draw.commands.append(


### PR DESCRIPTION
Multitexture materials that use the same CI format for textures 0 and 1 can now use a shared color index palette.