### PR TITLE
[bugfix] add hashing to gbi base classes

### DIFF
--- a/fast64_internal/f3d/f3d_gbi.py
+++ b/fast64_internal/f3d/f3d_gbi.py
@@ -3146,7 +3146,7 @@ def gsSPNoOp(f3d):
 
 
 # base class for gbi macros
-@dataclass
+@dataclass(unsafe_hash = True)
 class GbiMacro:
     _segptrs = False
     _ptr_amp = False
@@ -3179,7 +3179,7 @@ class GbiMacro:
         return GFX_SIZE
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class SPMatrix(GbiMacro):
     matrix: int
     param: int
@@ -3196,7 +3196,7 @@ class SPMatrix(GbiMacro):
 # Divide mesh drawing by materials into separate gfx
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class SPVertex(GbiMacro):
     # v = seg pointer, n = count, v0  = ?
     vertList: VtxList
@@ -3233,7 +3233,7 @@ class SPVertex(GbiMacro):
         return header + ", " + str(self.count) + ", " + str(self.index) + ")"
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class SPViewport(GbiMacro):
     # v = seg pointer, n = count, v0  = ?
     viewport: Vp
@@ -3248,7 +3248,7 @@ class SPViewport(GbiMacro):
             return gsDma1p(f3d.G_MOVEMEM, vpPtr, VP_SIZE, f3d.G_MV_VIEWPORT)
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class SPDisplayList(GbiMacro):
     displayList: GfxList
 
@@ -3269,7 +3269,7 @@ class SPDisplayList(GbiMacro):
             return "glistp = " + self.displayList.name + "(glistp)"
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class SPBranchList(GbiMacro):
     displayList: GfxList
     _ptr_amp = True  # add an ampersand to names
@@ -3374,7 +3374,7 @@ def _gsSP1Quadrangle_w2f(v0, v1, v2, v3, flag):
         return _gsSP1Triangle_w1(v3, v1, v2)
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class SP1Triangle(GbiMacro):
     v0: int
     v1: int
@@ -3390,7 +3390,7 @@ class SP1Triangle(GbiMacro):
         return words[0].to_bytes(4, "big") + words[1].to_bytes(4, "big")
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class SPLine3D(GbiMacro):
     v0: int
     v1: int
@@ -3404,7 +3404,7 @@ class SPLine3D(GbiMacro):
         return words[0].to_bytes(4, "big") + words[1].to_bytes(4, "big")
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class SPLineW3D(GbiMacro):
     v0: int
     v1: int
@@ -3422,7 +3422,7 @@ class SPLineW3D(GbiMacro):
 # SP1Quadrangle
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class SP2Triangles(GbiMacro):
     v00: int
     v01: int
@@ -3444,7 +3444,7 @@ class SP2Triangles(GbiMacro):
         return words[0].to_bytes(4, "big") + words[1].to_bytes(4, "big")
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class SPCullDisplayList(GbiMacro):
     vstart: int
     vend: int
@@ -3457,7 +3457,7 @@ class SPCullDisplayList(GbiMacro):
         return words[0].to_bytes(4, "big") + words[1].to_bytes(4, "big")
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class SPSegment(GbiMacro):
     segment: int
     base: int
@@ -3470,7 +3470,7 @@ class SPSegment(GbiMacro):
         return header + str(self.segment) + ", " + "0x" + format(self.base, "X") + ")"
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class SPClipRatio(GbiMacro):
     ratio: int
 
@@ -3494,7 +3494,7 @@ class SPClipRatio(GbiMacro):
 # SPForceMatrix
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class SPModifyVertex(GbiMacro):
     vtx: int
     where: int
@@ -3515,7 +3515,7 @@ class SPModifyVertex(GbiMacro):
 # SPBranchLessZ
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class SPBranchLessZraw(GbiMacro):
     dl: GfxList
     vtx: int
@@ -3550,7 +3550,7 @@ class SPBranchLessZraw(GbiMacro):
 # SPDmaWrite
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class SPNumLights(GbiMacro):
     # n is macro name (string)
     n: str
@@ -3559,7 +3559,7 @@ class SPNumLights(GbiMacro):
         return gsMoveWd(f3d.G_MW_NUMLIGHT, f3d.G_MWO_NUMLIGHT, f3d.NUML(self.n), f3d)
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class SPLight(GbiMacro):
     # n is macro name (string)
     light: int  # start address of light
@@ -3575,7 +3575,7 @@ class SPLight(GbiMacro):
         return data
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class SPLightColor(GbiMacro):
     # n is macro name (string)
     n: str
@@ -3591,7 +3591,7 @@ class SPLightColor(GbiMacro):
         return header + str(self.n) + ", 0x" + format(self.col, "08X") + ")"
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class SPSetLights(GbiMacro):
     lights: Lights
 
@@ -3654,7 +3654,7 @@ def gsSPLookAtY(l, f3d):
         return gsDma1p(f3d.G_MOVEMEM, l, LIGHT_SIZE, f3d.G_MV_LOOKATY)
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class SPLookAt(GbiMacro):
     la: LookAt
     _ptr_amp = True  # add an ampersand to names
@@ -3664,7 +3664,7 @@ class SPLookAt(GbiMacro):
         return gsSPLookAtX(light0Ptr, f3d) + gsSPLookAtY(light0Ptr + 16, f3d)
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class DPSetHilite1Tile(GbiMacro):
     tile: int
     hilite: Hilite
@@ -3682,7 +3682,7 @@ class DPSetHilite1Tile(GbiMacro):
         ).to_binary(f3d, segments)
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class DPSetHilite2Tile(GbiMacro):
     tile: int
     hilite: Hilite
@@ -3700,7 +3700,7 @@ class DPSetHilite2Tile(GbiMacro):
         ).to_binary(f3d, segments)
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class SPFogFactor(GbiMacro):
     fm: int
     fo: int
@@ -3730,7 +3730,7 @@ class SPFogPosition(GbiMacro):
         return header + str(self.minVal) + ", " + str(self.maxVal) + ")"
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class SPTexture(GbiMacro):
     s: int
     t: int
@@ -3762,7 +3762,7 @@ class SPTexture(GbiMacro):
 # SPTextureL
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class SPPerspNormalize(GbiMacro):
     s: int
 
@@ -3774,7 +3774,7 @@ class SPPerspNormalize(GbiMacro):
 # SPPopMatrix
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class SPEndDisplayList(GbiMacro):
     def to_binary(self, f3d, segments):
         words = _SHIFTL(f3d.G_ENDDL, 24, 8), 0
@@ -3826,7 +3826,7 @@ def geoFlagListToWord(flagList, f3d):
     return word
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class SPGeometryMode(GbiMacro):
     clearFlagList: list
     setFlagList: list
@@ -3841,7 +3841,7 @@ class SPGeometryMode(GbiMacro):
             raise PluginError("GeometryMode only available in F3DEX_GBI_2.")
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class SPSetGeometryMode(GbiMacro):
     flagList: list
 
@@ -3854,7 +3854,7 @@ class SPSetGeometryMode(GbiMacro):
             return words[0].to_bytes(4, "big") + words[1].to_bytes(4, "big")
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class SPClearGeometryMode(GbiMacro):
     flagList: list
 
@@ -3867,7 +3867,7 @@ class SPClearGeometryMode(GbiMacro):
             return words[0].to_bytes(4, "big") + words[1].to_bytes(4, "big")
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class SPLoadGeometryMode(GbiMacro):
     flagList: list
 
@@ -3887,7 +3887,7 @@ def gsSPSetOtherMode(cmd, sft, length, data, f3d):
     return words[0].to_bytes(4, "big") + words[1].to_bytes(4, "big")
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class SPSetOtherMode(GbiMacro):
     cmd: str
     sft: int
@@ -3903,7 +3903,7 @@ class SPSetOtherMode(GbiMacro):
         return gsSPSetOtherMode(cmd, sft, self.length, data, f3d)
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class DPPipelineMode(GbiMacro):
     # mode is a string
     mode: str
@@ -3916,7 +3916,7 @@ class DPPipelineMode(GbiMacro):
         return gsSPSetOtherMode(f3d.G_SETOTHERMODE_H, f3d.G_MDSFT_PIPELINE, 1, modeVal, f3d)
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class DPSetCycleType(GbiMacro):
     # mode is a string
     mode: str
@@ -3933,7 +3933,7 @@ class DPSetCycleType(GbiMacro):
         return gsSPSetOtherMode(f3d.G_SETOTHERMODE_H, f3d.G_MDSFT_CYCLETYPE, 2, modeVal, f3d)
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class DPSetTexturePersp(GbiMacro):
     # mode is a string
     mode: str
@@ -3946,7 +3946,7 @@ class DPSetTexturePersp(GbiMacro):
         return gsSPSetOtherMode(f3d.G_SETOTHERMODE_H, f3d.G_MDSFT_TEXTPERSP, 1, modeVal, f3d)
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class DPSetTextureDetail(GbiMacro):
     # mode is a string
     mode: str
@@ -3961,7 +3961,7 @@ class DPSetTextureDetail(GbiMacro):
         return gsSPSetOtherMode(f3d.G_SETOTHERMODE_H, f3d.G_MDSFT_TEXTDETAIL, 2, modeVal, f3d)
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class DPSetTextureLOD(GbiMacro):
     # mode is a string
     mode: str
@@ -3974,7 +3974,7 @@ class DPSetTextureLOD(GbiMacro):
         return gsSPSetOtherMode(f3d.G_SETOTHERMODE_H, f3d.G_MDSFT_TEXTLOD, 1, modeVal, f3d)
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class DPSetTextureLUT(GbiMacro):
     # mode is a string
     mode: str
@@ -3991,7 +3991,7 @@ class DPSetTextureLUT(GbiMacro):
         return gsSPSetOtherMode(f3d.G_SETOTHERMODE_H, f3d.G_MDSFT_TEXTLUT, 2, modeVal, f3d)
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class DPSetTextureFilter(GbiMacro):
     # mode is a string
     mode: str
@@ -4006,7 +4006,7 @@ class DPSetTextureFilter(GbiMacro):
         return gsSPSetOtherMode(f3d.G_SETOTHERMODE_H, f3d.G_MDSFT_TEXTFILT, 2, modeVal, f3d)
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class DPSetTextureConvert(GbiMacro):
     # mode is a string
     mode: str
@@ -4021,7 +4021,7 @@ class DPSetTextureConvert(GbiMacro):
         return gsSPSetOtherMode(f3d.G_SETOTHERMODE_H, f3d.G_MDSFT_TEXTCONV, 3, modeVal, f3d)
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class DPSetCombineKey(GbiMacro):
     # mode is a string
     mode: str
@@ -4034,7 +4034,7 @@ class DPSetCombineKey(GbiMacro):
         return gsSPSetOtherMode(f3d.G_SETOTHERMODE_H, f3d.G_MDSFT_COMBKEY, 1, modeVal, f3d)
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class DPSetColorDither(GbiMacro):
     # mode is a string
     mode: str
@@ -4060,7 +4060,7 @@ class DPSetColorDither(GbiMacro):
             return gsSPSetOtherMode(f3d.G_SETOTHERMODE_H, f3d.G_MDSFT_COLORDITHER, 1, modeVal, f3d)
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class DPSetAlphaDither(GbiMacro):
     # mode is a string
     mode: str
@@ -4080,7 +4080,7 @@ class DPSetAlphaDither(GbiMacro):
             raise PluginError("SetAlphaDither not available in HW v1.")
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class DPSetAlphaCompare(GbiMacro):
     # mask is a string
     mode: str
@@ -4095,7 +4095,7 @@ class DPSetAlphaCompare(GbiMacro):
         return gsSPSetOtherMode(f3d.G_SETOTHERMODE_L, f3d.G_MDSFT_ALPHACOMPARE, 2, maskVal, f3d)
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class DPSetDepthSource(GbiMacro):
     # src is a string
     src: str
@@ -4124,7 +4124,7 @@ def GBL_c2(m1a, m1b, m2a, m2b):
     return (m1a) << 28 | (m1b) << 24 | (m2a) << 20 | (m2b) << 16
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class DPSetRenderMode(GbiMacro):
     # bl0-3 are string for each blender enum
     def __init__(self, flagList, blendList):
@@ -4203,7 +4203,7 @@ def gsSetImage(cmd, fmt, siz, width, i):
 # DPSetDepthImage
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class DPSetTextureImage(GbiMacro):
     fmt: str
     siz: str
@@ -4246,7 +4246,7 @@ def GCCc1w1(sbRGB1, saA1, mA1, aRGB1, sbA1, aA1):
     )
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class DPSetCombineMode(GbiMacro):
     # all strings
     a0: str
@@ -4299,7 +4299,7 @@ def sDPRGBColor(cmd, r, g, b, a):
     return gsDPSetColor(cmd, (_SHIFTL(r, 24, 8) | _SHIFTL(g, 16, 8) | _SHIFTL(b, 8, 8) | _SHIFTL(a, 0, 8)))
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class DPSetEnvColor(GbiMacro):
     r: int
     g: int
@@ -4310,7 +4310,7 @@ class DPSetEnvColor(GbiMacro):
         return sDPRGBColor(f3d.G_SETENVCOLOR, self.r, self.g, self.b, self.a)
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class DPSetBlendColor(GbiMacro):
     r: int
     g: int
@@ -4321,7 +4321,7 @@ class DPSetBlendColor(GbiMacro):
         return sDPRGBColor(f3d.G_SETBLENDCOLOR, self.r, self.g, self.b, self.a)
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class DPSetFogColor(GbiMacro):
     r: int
     g: int
@@ -4332,7 +4332,7 @@ class DPSetFogColor(GbiMacro):
         return sDPRGBColor(f3d.G_SETFOGCOLOR, self.r, self.g, self.b, self.a)
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class DPSetFillColor(GbiMacro):
     d: int
 
@@ -4340,7 +4340,7 @@ class DPSetFillColor(GbiMacro):
         return gsDPSetColor(f3d.G_SETFILLCOLOR, self.d)
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class DPSetPrimDepth(GbiMacro):
     z: int = 0
     dz: int = 0
@@ -4349,7 +4349,7 @@ class DPSetPrimDepth(GbiMacro):
         return gsDPSetColor(f3d.G_SETPRIMDEPTH, _SHIFTL(self.z, 16, 16) | _SHIFTL(self.dz, 0, 16))
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class DPSetPrimColor(GbiMacro):
     m: int
     l: int
@@ -4365,7 +4365,7 @@ class DPSetPrimColor(GbiMacro):
         return words[0].to_bytes(4, "big") + words[1].to_bytes(4, "big")
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class DPSetOtherMode(GbiMacro):
     mode0: list
     mode1: list
@@ -4382,7 +4382,7 @@ def gsDPLoadTileGeneric(c, tile, uls, ult, lrs, lrt):
     return words[0].to_bytes(4, "big") + words[1].to_bytes(4, "big")
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class DPSetTileSize(GbiMacro):
     t: int
     uls: int
@@ -4397,7 +4397,7 @@ class DPSetTileSize(GbiMacro):
         return self.t == f3d.G_TX_LOADTILE
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class DPLoadTile(GbiMacro):
     t: int
     uls: int
@@ -4409,7 +4409,7 @@ class DPLoadTile(GbiMacro):
         return gsDPLoadTileGeneric(f3d.G_LOADTILE, self.t, self.uls, self.ult, self.lrs, self.lrt)
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class DPSetTile(GbiMacro):
     fmt: str
     siz: str
@@ -4450,7 +4450,7 @@ class DPSetTile(GbiMacro):
         return self.tile == f3d.G_TX_LOADTILE
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class DPLoadBlock(GbiMacro):
     tile: int
     uls: int
@@ -4467,7 +4467,7 @@ class DPLoadBlock(GbiMacro):
         return words[0].to_bytes(4, "big") + words[1].to_bytes(4, "big")
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class DPLoadTLUTCmd(GbiMacro):
     tile: int
     count: int
@@ -4477,7 +4477,7 @@ class DPLoadTLUTCmd(GbiMacro):
         return words[0].to_bytes(4, "big") + words[1].to_bytes(4, "big")
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class DPLoadTextureBlock(GbiMacro):
     timg: FImage
     fmt: str
@@ -4550,7 +4550,7 @@ class DPLoadTextureBlock(GbiMacro):
         return GFX_SIZE * 7
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class DPLoadTextureBlockYuv(GbiMacro):
     timg: FImage
     fmt: str
@@ -4628,7 +4628,7 @@ class DPLoadTextureBlockYuv(GbiMacro):
 # gsDPLoadTextureBlockYuvS
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class _DPLoadTextureBlock(GbiMacro):
     timg: FImage
     tmem: int
@@ -4707,7 +4707,7 @@ class _DPLoadTextureBlock(GbiMacro):
 # gsDPLoadMultiBlockS
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class DPLoadTextureBlock_4b(GbiMacro):
     timg: FImage
     fmt: str
@@ -4778,7 +4778,7 @@ class DPLoadTextureBlock_4b(GbiMacro):
 # _gsDPLoadTextureBlock_4b
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class DPLoadTextureTile(GbiMacro):
     timg: FImage
     fmt: str
@@ -4854,7 +4854,7 @@ class DPLoadTextureTile(GbiMacro):
 # gsDPLoadMultiTile
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class DPLoadTextureTile_4b(GbiMacro):
     timg: FImage
     fmt: str
@@ -4930,7 +4930,7 @@ class DPLoadTextureTile_4b(GbiMacro):
 # gsDPLoadMultiTile_4b
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class DPLoadTLUT_pal16(GbiMacro):
     pal: int
     dram: FImage  # pallete object
@@ -4972,7 +4972,7 @@ class DPLoadTLUT_pal16(GbiMacro):
             return GFX_SIZE * 7
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class DPLoadTLUT_pal256(GbiMacro):
     dram: FImage  # pallete object
     _ptr_amp = True  # adds & to name of image
@@ -5011,7 +5011,7 @@ class DPLoadTLUT_pal256(GbiMacro):
             return GFX_SIZE * 7
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class DPLoadTLUT(GbiMacro):
     count: int
     tmemaddr: int
@@ -5058,7 +5058,7 @@ class DPLoadTLUT(GbiMacro):
 # gsDPFillRectangle
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class DPSetConvert(GbiMacro):
     k0: int
     k1: int
@@ -5074,7 +5074,7 @@ class DPSetConvert(GbiMacro):
         return words[0].to_bytes(4, "big") + words[1].to_bytes(4, "big")
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class DPSetKeyR(GbiMacro):
     cR: int
     sR: int
@@ -5087,7 +5087,7 @@ class DPSetKeyR(GbiMacro):
         return words[0].to_bytes(4, "big") + words[1].to_bytes(4, "big")
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class DPSetKeyGB(GbiMacro):
     cG: int
     sG: int
@@ -5117,7 +5117,7 @@ def gsDPParam(cmd, param):
 # gsDPTextureRectangleFlip
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class SPTextureRectangle(GbiMacro):
     xl: int
     yl: int
@@ -5148,7 +5148,7 @@ class SPTextureRectangle(GbiMacro):
         return GFX_SIZE * 2
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class SPScisTextureRectangle(GbiMacro):
     xl: int
     yl: int
@@ -5171,25 +5171,25 @@ class SPScisTextureRectangle(GbiMacro):
 # gsDPWord
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class DPFullSync(GbiMacro):
     def to_binary(self, f3d, segments):
         return gsDPNoParam(f3d.G_RDPFULLSYNC)
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class DPTileSync(GbiMacro):
     def to_binary(self, f3d, segments):
         return gsDPNoParam(f3d.G_RDPTILESYNC)
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class DPPipeSync(GbiMacro):
     def to_binary(self, f3d, segments):
         return gsDPNoParam(f3d.G_RDPPIPESYNC)
 
 
-@dataclass
+@dataclass(unsafe_hash = True)
 class DPLoadSync(GbiMacro):
     def to_binary(self, f3d, segments):
         return gsDPNoParam(f3d.G_RDPLOADSYNC)


### PR DESCRIPTION
Title says it all. This fixes a bug with the last change to gbi base classes which made them unhashable, and therefore unable to be added to sets/dicts: a function that is used in material overrides for armature exports.

The danger of this is that mutating the objects after they are stored inside a hashtable object is they will become unsearchable in these objects. An example is given here (from stack exchange)
```python
cat = Category('foo', 'bar') # a dataclass with unsafe_hash = True
categories = {cat}
cat.id = 'baz'

print(cat in categories)  # False
```
Alternate means of fixing this bug would be to create a base class implementation of `__hash__` that inherited from the `object` type. This has the benefit of maintaining state within hashtables if mutated, but not generating equal hashes if the classes are equal.