### PR TITLE
[F3D] Flipbook CI textures no longer modify DLs after creation

### DIFF
--- a/fast64_internal/f3d/f3d_gbi.py
+++ b/fast64_internal/f3d/f3d_gbi.py
@@ -2184,6 +2184,15 @@ class FModel:
         self.global_data = FGlobalData()
         self.texturesSavedLastExport = 0  # hacky
 
+    def processTexRefNonCITextures(
+        self, fMaterial: "FMaterial", material: bpy.types.Material, index: int
+    ):
+        return
+
+    def processTexRefCITextures(self, fMaterial: "FMaterial", material: bpy.types.Material, index: int) -> "FImage":
+        texProp = getattr(material.f3dMat, f"tex{index}")
+        return FImage(texProp.pal_reference, None, None, 1, texProp.pal_reference_size, None, False)
+
     # Called before SPEndDisplayList
     def onMaterialCommandsBuilt(self, fMaterial, material, drawLayer):
         return

--- a/fast64_internal/f3d/f3d_gbi.py
+++ b/fast64_internal/f3d/f3d_gbi.py
@@ -2187,9 +2187,14 @@ class FModel:
     def processTexRefNonCITextures(
         self, fMaterial: "FMaterial", material: bpy.types.Material, index: int
     ):
-        return
+        """For non CI textures that use a texture reference, process additional textures that will possibly be loaded here."""
+        pass
 
     def processTexRefCITextures(self, fMaterial: "FMaterial", material: bpy.types.Material, index: int) -> "FImage":
+        """
+        For CI textures that use a texture reference, process additional textures that will possibly be loaded here.
+        This returns a palette FImage that is shared between all processed textures.
+        """
         texProp = getattr(material.f3dMat, f"tex{index}")
         return FImage(texProp.pal_reference, None, None, 1, texProp.pal_reference_size, None, False)
 

--- a/fast64_internal/f3d/f3d_gbi.py
+++ b/fast64_internal/f3d/f3d_gbi.py
@@ -2187,7 +2187,10 @@ class FModel:
     def processTexRefNonCITextures(
         self, fMaterial: "FMaterial", material: bpy.types.Material, index: int
     ):
-        """For non CI textures that use a texture reference, process additional textures that will possibly be loaded here."""
+        """
+        For non CI textures that use a texture reference, process additional textures that will possibly be loaded here.
+        This doesn't return anything.
+        """
         pass
 
     def processTexRefCITextures(self, fMaterial: "FMaterial", material: bpy.types.Material, index: int) -> "FImage":

--- a/fast64_internal/f3d/f3d_writer.py
+++ b/fast64_internal/f3d/f3d_writer.py
@@ -424,6 +424,7 @@ def saveMeshWithLargeTexturesByFaces(
         triGroup.triList.commands.append(DPPipeSync())
         if fMaterial.texturesLoaded[0] and not (otherTextureIndex == 0 and otherTexSingleLoad):
             texDimensions0, nextTmem, fImage0 = saveTextureIndex(
+                material,
                 material.name,
                 fModel,
                 fMaterial,
@@ -442,6 +443,7 @@ def saveMeshWithLargeTexturesByFaces(
             )
         if fMaterial.texturesLoaded[1] and not (otherTextureIndex == 1 and otherTexSingleLoad):
             texDimensions1, nextTmem, fImage1 = saveTextureIndex(
+                material,
                 material.name,
                 fModel,
                 fMaterial,
@@ -1618,6 +1620,7 @@ def saveOrGetF3DMaterial(material, fModel, obj, drawLayer, convertTextureData):
         fMaterial.useLargeTextures = useLargeTextures
         fMaterial.texturesLoaded[0] = True
         texDimensions0, nextTmem, fImage0 = saveTextureIndex(
+            material,
             material.name,
             fModel,
             fMaterial,
@@ -1648,6 +1651,7 @@ def saveOrGetF3DMaterial(material, fModel, obj, drawLayer, convertTextureData):
         fMaterial.useLargeTextures = useLargeTextures
         fMaterial.texturesLoaded[1] = True
         texDimensions1, nextTmem, fImage1 = saveTextureIndex(
+            material,
             material.name,
             fModel,
             fMaterial,
@@ -1835,6 +1839,7 @@ def getTextureNameTexRef(texProp: TextureProperty, fModelName: str) -> str:
 
 
 def saveTextureIndex(
+    material: bpy.types.Material,
     propName: str,
     fModel: FModel,
     fMaterial: FMaterial,
@@ -1932,7 +1937,7 @@ def saveTextureIndex(
     if isCITexture:
         if texProp.use_tex_reference:
             fImage = FImage(texProp.tex_reference, None, None, width, height, None, False)
-            fPalette = FImage(texProp.pal_reference, None, None, 1, texProp.pal_reference_size, None, False)
+            fPalette = fModel.processTexRefCITextures(fMaterial, material, index)
         else:
             # fPalette should be an fImage here, since sharedPalette is None
             fImage, fPalette, alreadyExists = saveOrGetPaletteAndImageDefinition(
@@ -1954,6 +1959,7 @@ def saveTextureIndex(
     else:
         if texProp.use_tex_reference:
             fImage = FImage(texProp.tex_reference, None, None, width, height, None, False)
+            fModel.processTexRefNonCITextures(fMaterial, material, index)
         else:
             fImage = saveOrGetTextureDefinition(fMaterial, fModel, tex, texName, texFormat, convertTextureData)
 

--- a/fast64_internal/oot/oot_model_classes.py
+++ b/fast64_internal/oot/oot_model_classes.py
@@ -134,29 +134,6 @@ class OOTModel(FModel):
         else:
             return texFmt.lower()
 
-    def modifyDLForCIFlipbook(self, fMaterial: FMaterial, fPalette: FMaterial, texProp: TextureProperty):
-        # Modfiy DL to use new palette texture
-        tlutCmdIndex = 0
-        gfxList = fMaterial.material
-        while tlutCmdIndex < len(gfxList.commands):
-            if isinstance(gfxList.commands[tlutCmdIndex], DPLoadTLUTCmd):
-                loadTlutCmd = gfxList.commands[tlutCmdIndex]
-                loadTlutCmd.count = int(round(len(fPalette.data) / 2)) - 1
-
-                setTLUTCmd = gfxList.commands[tlutCmdIndex - 5]
-                setTImageCmd = gfxList.commands[tlutCmdIndex - 4]
-                if tlutCmdIndex < 5 or not isinstance(setTLUTCmd, DPSetTextureLUT):
-                    raise PluginError("Error when processing flipbook CI textures: unexpected display list format.")
-                setTImageCmd.fmt = texFormatOf[texProp.ci_format]
-                setTImageCmd.image = fPalette
-                setTLUTCmd.mode = "G_TT_RGBA16" if setTImageCmd.fmt == "G_IM_FMT_RGBA" else "G_TT_IA16"
-                break
-
-            else:
-                tlutCmdIndex += 1
-        if tlutCmdIndex == len(gfxList.commands):
-            raise PluginError(f"Can not find TLUT command in material {fMaterial.name}")
-
     def addFlipbookWithRepeatCheck(self, flipbook: TextureFlipbook):
         model = self.getFlipbookOwner()
         for existingFlipbook in model.flipbooks:
@@ -207,9 +184,16 @@ class OOTModel(FModel):
                 )
             return existingFPalette
 
-    def processFlipbookCI(self, fMaterial: FMaterial, flipbookProp: FlipbookProperty, texProp: TextureProperty):
+    def processTexRefCITextures(self, fMaterial: FMaterial, material: bpy.types.Material, index: int) -> FImage:
         # print("Processing flipbook...")
         model = self.getFlipbookOwner()
+        flipbookProp = getattr(material.flipbookGroup, f"flipbook{index}")
+        texProp = getattr(material.f3d_mat, f"tex{index}")
+        if not usesFlipbook(material, flipbookProp, index, True, ootFlipbookReferenceIsValid):
+            return FModel.processTexRefCITextures(fMaterial, material, index)
+
+        if len(flipbookProp.textures) == 0:
+            raise PluginError(f"{str(material)} cannot have a flipbook material with no flipbook textures.")
         flipbook = TextureFlipbook(flipbookProp.name, flipbookProp.exportMode, [])
         sharedPalette = FSharedPalette(model.name + "_" + flipbookProp.textures[0].image.name + "_pal")
         existingFPalette = None
@@ -278,10 +262,17 @@ class OOTModel(FModel):
         else:
             fPalette = existingFPalette
 
-        model.modifyDLForCIFlipbook(fMaterial, fPalette, texProp)
+        return fPalette
 
-    def processFlipbookNonCI(self, fMaterial: FMaterial, flipbookProp: FlipbookProperty, texProp: TextureProperty):
+    def processTexRefNonCITextures(self, fMaterial: FMaterial, material: bpy.types.Material, index: int):
         model = self.getFlipbookOwner()
+        flipbookProp = getattr(material.flipbookGroup, f"flipbook{index}")
+        texProp = getattr(material.f3d_mat, f"tex{index}")
+        if not usesFlipbook(material, flipbookProp, index, True, ootFlipbookReferenceIsValid):
+            return FModel.processTexRefNonCITextures(fMaterial, material, index)
+        if len(flipbookProp.textures) == 0:
+            raise PluginError(f"{str(material)} cannot have a flipbook material with no flipbook textures.")
+
         flipbook = TextureFlipbook(flipbookProp.name, flipbookProp.exportMode, [])
         for flipbookTexture in flipbookProp.textures:
             if flipbookTexture.image is None:
@@ -320,27 +311,6 @@ class OOTModel(FModel):
                 gfxList.commands.append(
                     SPDisplayList(GfxList(getattr(matDrawLayer, p + "_seg"), GfxListTag.Material, DLFormat.Static))
                 )
-
-        # save flipbook textures
-        for i in range(2):
-            flipbookProp = getattr(material.flipbookGroup, "flipbook" + str(i))
-            texProp = getattr(material.f3d_mat, "tex" + str(i))
-            if usesFlipbook(material, flipbookProp, i, True, ootFlipbookReferenceIsValid):
-                if len(flipbookProp.textures) == 0:
-                    raise PluginError(f"{str(material)} cannot have a flipbook material with no flipbook textures.")
-
-                if texProp.tex_format[:2] == "CI":
-                    self.processFlipbookCI(
-                        fMaterial,
-                        flipbookProp,
-                        texProp,
-                    )
-                else:
-                    self.processFlipbookNonCI(
-                        fMaterial,
-                        flipbookProp,
-                        texProp,
-                    )
 
     def onAddMesh(self, fMesh, contextObj):
         if contextObj is not None and hasattr(contextObj, "ootDynamicTransform"):

--- a/fast64_internal/sm64/sm64_f3d_writer.py
+++ b/fast64_internal/sm64/sm64_f3d_writer.py
@@ -358,6 +358,7 @@ def exportTexRectCommon(texProp, f3dType, isHWv1, name, convertTextureData):
     drawEndCommands = GfxList("temp", GfxListTag.Draw, DLFormat.Dynamic)
 
     texDimensions, nextTmem, fImage = saveTextureIndex(
+        None,
         texProp.tex.name,
         fTexRect,
         fMaterial,


### PR DESCRIPTION
Flipbook texture handling now occurs right after a use_texture_reference texture is processed. This allows the TLUT loading commands to use the correct palette without having to be modified later on.