### PR TITLE
Rewrite `applyRotation`, `doRotation` to not use the rotate operator

### DIFF
--- a/fast64_internal/sm64/sm64_geolayout_parser.py
+++ b/fast64_internal/sm64/sm64_geolayout_parser.py
@@ -1562,8 +1562,7 @@ class SM64_ImportGeolayout(bpy.types.Operator):
             bpy.ops.object.select_all(action="DESELECT")
             if armatureObj is not None:
                 for armatureMeshGroup in armatureMeshGroups:
-                    armatureMeshGroup[0].select_set(True)
-                doRotation(math.radians(-90), "X")
+                    doRotation(armatureMeshGroup[0], math.radians(-90), "X")
 
                 for armatureMeshGroup in armatureMeshGroups:
                     bpy.ops.object.select_all(action="DESELECT")
@@ -1571,8 +1570,6 @@ class SM64_ImportGeolayout(bpy.types.Operator):
                     bpy.context.view_layer.objects.active = armatureMeshGroup[0]
                     bpy.ops.object.make_single_user(obdata=True)
                     bpy.ops.object.transform_apply(location=False, rotation=True, scale=False, properties=False)
-            else:
-                doRotation(math.radians(-90), "X")
             bpy.ops.object.select_all(action="DESELECT")
             # objs[-1].select_set(True)
 


### PR DESCRIPTION
`bpy.ops.transform.rotate` is the first obstacle I encountered when using fast64 from scripting

These changes seem to work with OoT

**I would like someone to test the behavior on sm64 things**, see if anything broke somehow

The functions are primarily used for blender<->game coordinates conversion, with +-90° rotations around the x axis

----------

Something weird with `bpy.ops.transform.rotate` / this stuff, apparently in fast64/main rotating "-90° around X" does the game->blender coordinates conversion (see `importMeshC` for example)
"-90° around X" which I understand as "-90° around +X" would be:
game=(x, y, z) -> blender=(x, z, -y)
But the proper game->blender coordinates conversion is:
game=(x, y, z) -> blender=(x, -z, y)

The implementation in this PR doesn't have this weird thing (doesn't use `bpy.ops.transform.rotate`), so I put
`angle = -angle` somewhere to "correct" the angle, but probably what should be done instead is flip the sign on every `applyRotation`/`doRotation` usage?