### PR TITLE
[OoT] Fixed 4 issues

### DIFF
--- a/fast64_internal/oot/cutscene/properties.py
+++ b/fast64_internal/oot/cutscene/properties.py
@@ -236,7 +236,7 @@ class OOTCutsceneProperty(PropertyGroup):
             r.prop(self, "csTermStart")
             r.prop(self, "csTermEnd")
         for i, p in enumerate(self.csLists):
-            p.draw_props(layout, p, i, obj.name, "Cutscene")
+            p.draw_props(layout, i, obj.name, "Cutscene")
 
         drawCSListAddOp(layout, obj.name, "Cutscene")
 

--- a/fast64_internal/oot/oot_collision.py
+++ b/fast64_internal/oot/oot_collision.py
@@ -204,7 +204,7 @@ def ootCameraDataToC(camData):
     camC = CData()
     if len(camData.camPosDict) > 0:
 
-        camDataName = "CamData " + camData.camDataName() + "[" + str(len(camData.camPosDict)) + "]"
+        camDataName = "BgCamInfo " + camData.camDataName() + "[" + str(len(camData.camPosDict)) + "]"
 
         camC.source = camDataName + " = {\n"
         camC.header = "extern " + camDataName + ";\n"

--- a/fast64_internal/oot/scene/exporter/to_c/scene_header.py
+++ b/fast64_internal/oot/scene/exporter/to_c/scene_header.py
@@ -59,7 +59,7 @@ def getLightSettingsEntry(light: OOTLight, lightMode: str, isLightingCustom: boo
 
 def getLightSettings(outScene: OOTScene, headerIndex: int):
     lightSettingsData = CData()
-    lightName = f"LightSettings {outScene.lightListName(headerIndex)}[{len(outScene.lights)}]"
+    lightName = f"EnvLightSettings {outScene.lightListName(headerIndex)}[{len(outScene.lights)}]"
 
     # .h
     lightSettingsData.header = f"extern {lightName};\n"

--- a/fast64_internal/oot/scene/exporter/to_c/spec.py
+++ b/fast64_internal/oot/scene/exporter/to_c/spec.py
@@ -101,7 +101,7 @@ def editSpecFile(scene: OOTScene, exportInfo: ExportInfo, sceneC: OOTSceneC):
 
                 if sceneC.sceneCutscenesIsUsed():
                     for i in range(len(sceneC.sceneCutscenesC)):
-                        sceneSegInclude += indent + f'include "{includeDir}_cs_{i}.o"\n'
+                        sceneSegInclude += indent + f'include "{includeDir}_scene_cs_{i}.o"\n'
 
             sceneSegInclude += indent + "number 2\n"
             specEntries.insert(firstIndex, sceneSegInclude)


### PR DESCRIPTION
Found and fixed 3 issues:
- Fast64 was still using ``LightSettings`` instead of the new type ``EnvLightSettings``, it was fine for normal decomp but on HackerOoT this was an issue as the old type has been removed
- Removed an extra argument inside the ``draw_props()`` function call from ``OOTCutsceneProperty.draw_props``, this was raising an error that didn't show the textbox UI elements for cutscenes
- Added missing ``_scene_`` chars to the filename exported in the spec file for cutscene files