### PR TITLE
Fixed issue while upgrading materials if a vert has groups but the mesh does not

### DIFF
--- a/fast64_internal/f3d_material_converter.py
+++ b/fast64_internal/f3d_material_converter.py
@@ -117,6 +117,9 @@ def set_best_draw_layer_for_materials():
             # default to object's draw layer
             mat.f3d_mat.draw_layer.sm64 = obj.draw_layer_static
 
+            if len(obj.vertex_groups) == 0:
+                continue # object doesn't have vertex groups
+
             # get vertex group in the polygon
             group = get_group_from_polygon(obj, p)
             if isinstance(group, bpy.types.VertexGroup):


### PR DESCRIPTION
Blender bug apparently?? I guess this should slightly speed up material conversion anyways, but there's no reason why a vertex should be in a vertex group if the mesh itself doesnt have vertex groups