### PR TITLE
[f3d] Material tooltips

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -164,7 +164,7 @@ class F3D_GlobalSettingsPanel(bpy.types.Panel):
         col.prop(context.scene, "saveTextures")
         col.prop(context.scene, "f3d_simple", text="Simple Material UI")
         col.prop(context.scene, "generateF3DNodeGraph", text="Generate F3D Node Graph For Materials")
-        col.prop(context.scene, "exportInlineF3D", text="Export Mesh F3D as single DL")
+        col.prop(context.scene, "exportInlineF3D", text="Bleed and Inline Material Exports")
         col.prop(context.scene, "decomp_compatible", invert_checkbox=True, text="Homebrew Compatibility")
         col.prop(context.scene, "ignoreTextureRestrictions")
         if context.scene.ignoreTextureRestrictions:
@@ -469,9 +469,8 @@ def register():
     bpy.types.Scene.saveTextures = bpy.props.BoolProperty(name="Save Textures As PNGs (Breaks CI Textures)")
     bpy.types.Scene.generateF3DNodeGraph = bpy.props.BoolProperty(name="Generate F3D Node Graph", default=True)
     bpy.types.Scene.exportHiddenGeometry = bpy.props.BoolProperty(name="Export Hidden Geometry", default=True)
-    bpy.types.Scene.exportInlineF3D = bpy.props.BoolProperty(name="Export Inline F3D", \
-    description = "F3D for each mesh will be one Gfx list instead of having different Gfx lists for each component of the mesh.\n\
-This will cause repeated F3D cmds. This option does not work on armature exports.", default=False)
+    bpy.types.Scene.exportInlineF3D = bpy.props.BoolProperty(name="Bleed and Inline Material Exports", \
+    description = "Inlines and bleeds materials in a single mesh. GeoLayout + Armature exports bleed over entire model", default=False)
     bpy.types.Scene.blenderF3DScale = bpy.props.FloatProperty(
         name="F3D Blender Scale", default=100, update=on_update_render_settings
     )

--- a/fast64_internal/f3d/f3d_enums.py
+++ b/fast64_internal/f3d/f3d_enums.py
@@ -165,20 +165,20 @@ enumRGBDither = [
 ]
 
 enumCombKey = [
-    ("G_CK_NONE", "None", "None"),
-    ("G_CK_KEY", "Key", "Key"),
+    ("G_CK_NONE", "None", "Disables chroma key."),
+    ("G_CK_KEY", "Key", "Enables chroma key."),
 ]
 
 enumTextConv = [
-    ("G_TC_CONV", "Convert", "Convert"),
-    ("G_TC_FILTCONV", "Filter And Convert", "Filter And Convert"),
-    ("G_TC_FILT", "Filter", "Filter"),
+    ("G_TC_CONV", "Convert", "Convert, used for YUV to RGB conversion."),
+    ("G_TC_FILTCONV", "Filter And Convert", "Filter And Convert, used for YUV to RGB conversion."),
+    ("G_TC_FILT", "Filter", "Filter, used for default textures."),
 ]
 
 enumTextFilt = [
-    ("G_TF_POINT", "Point", "Point"),
-    ("G_TF_AVERAGE", "Average", "Average"),
-    ("G_TF_BILERP", "Bilinear", "Bilinear"),
+    ("G_TF_POINT", "Point", "Point filtering."),
+    ("G_TF_AVERAGE", "Average", "Average filter, not recommended except for pixel aligned texrects."),
+    ("G_TF_BILERP", "Bilinear", "Bilinear, standard N64 filtering with 3 point sample."),
 ]
 
 enumTextLUT = [
@@ -188,14 +188,14 @@ enumTextLUT = [
 ]
 
 enumTextLOD = [
-    ("G_TL_TILE", "Tile", "Tile"),
-    ("G_TL_LOD", "LOD", "LOD"),
+    ("G_TL_TILE", "Tile", "Shows selected color combiner tiles"),
+    ("G_TL_LOD", "LoD", "Enables LoD calculations"),
 ]
 
 enumTextDetail = [
-    ("G_TD_CLAMP", "Clamp", "Clamp"),
-    ("G_TD_SHARPEN", "Sharpen", "Sharpen"),
-    ("G_TD_DETAIL", "Detail", "Detail"),
+    ("G_TD_CLAMP", "Clamp", "Clamp, shows base tile for texel0 and texel 1 when magnifying (>1 texel/pixel)"),
+    ("G_TD_SHARPEN", "Sharpen", "Sharpen, sharpens pixel colors when magnifying (>1 texel/pixel)"),
+    ("G_TD_DETAIL", "Detail", "Detail, shows base tile when magnifying (>1 texel/pixel), else shows base tile+1"),
 ]
 
 enumTextPersp = [
@@ -206,8 +206,8 @@ enumTextPersp = [
 enumCycleType = [
     ("G_CYC_1CYCLE", "1 Cycle", "1 Cycle"),
     ("G_CYC_2CYCLE", "2 Cycle", "2 Cycle"),
-    ("G_CYC_COPY", "Copy", "Copy"),
-    ("G_CYC_FILL", "Fill", "Fill"),
+    ("G_CYC_COPY", "Copy", "Copies texture values to framebuffer with no perspective correction or blending"),
+    ("G_CYC_FILL", "Fill", "Uses blend color to fill primitve"),
 ]
 
 enumColorDither = [("G_CD_DISABLE", "Disable", "Disable"), ("G_CD_ENABLE", "Enable", "Enable")]
@@ -219,20 +219,20 @@ enumPipelineMode = [
 
 enumAlphaCompare = [
     ("G_AC_NONE", "None", "None"),
-    ("G_AC_THRESHOLD", "Threshold", "Threshold"),
-    ("G_AC_DITHER", "Dither", "Dither"),
+    ("G_AC_THRESHOLD", "Threshold", "Threshold, writes if alpha is greater than blend color alpha"),
+    ("G_AC_DITHER", "Dither", "Dither, writes if alpha is greater than random value"),
 ]
 
 enumDepthSource = [
-    ("G_ZS_PIXEL", "Pixel", "Pixel"),
-    ("G_ZS_PRIM", "Primitive", "Primitive"),
+    ("G_ZS_PIXEL", "Pixel", "Z value is calculated per primitive pixel"),
+    ("G_ZS_PRIM", "Primitive", "Primitive, use prim depth to set Z value"),
 ]
 
 enumCoverage = [
-    ("CVG_DST_CLAMP", "Clamp", "Clamp"),
-    ("CVG_DST_WRAP", "Wrap", "Wrap"),
-    ("CVG_DST_FULL", "Full", "Full"),
-    ("CVG_DST_SAVE", "Save", "Save"),
+    ("CVG_DST_CLAMP", "Clamp", "Clamp if blending, else use new pixel coverage"),
+    ("CVG_DST_WRAP", "Wrap", "Wrap coverage"),
+    ("CVG_DST_FULL", "Full", "Force to full coverage"),
+    ("CVG_DST_SAVE", "Save", "Don't overwrite previous framebuffer coverage value"),
 ]
 
 enumZMode = [

--- a/fast64_internal/f3d/f3d_enums.py
+++ b/fast64_internal/f3d/f3d_enums.py
@@ -176,9 +176,9 @@ enumTextConv = [
 ]
 
 enumTextFilt = [
-    ("G_TF_POINT", "Point", "Point filtering."),
-    ("G_TF_AVERAGE", "Average", "Average filter, not recommended except for pixel aligned texrects."),
-    ("G_TF_BILERP", "Bilinear", "Bilinear, standard N64 filtering with 3 point sample."),
+    ("G_TF_POINT", "Point", "Point filtering"),
+    ("G_TF_AVERAGE", "Average", "Average filter, not recommended except for pixel aligned texrects"),
+    ("G_TF_BILERP", "Bilinear", "Bilinear, standard N64 filtering with 3 point sample"),
 ]
 
 enumTextLUT = [
@@ -189,13 +189,13 @@ enumTextLUT = [
 
 enumTextLOD = [
     ("G_TL_TILE", "Tile", "Shows selected color combiner tiles"),
-    ("G_TL_LOD", "LoD", "Enables LoD calculations"),
+    ("G_TL_LOD", "LoD", "Enables LoD calculations, LoD tile is base tile + log2(texel/pixel) ratio"),
 ]
 
 enumTextDetail = [
-    ("G_TD_CLAMP", "Clamp", "Clamp, shows base tile for texel0 and texel 1 when magnifying (>1 texel/pixel)"),
-    ("G_TD_SHARPEN", "Sharpen", "Sharpen, sharpens pixel colors when magnifying (>1 texel/pixel)"),
-    ("G_TD_DETAIL", "Detail", "Detail, shows base tile when magnifying (>1 texel/pixel), else shows base tile+1"),
+    ("G_TD_CLAMP", "Clamp", "Shows base tile for texel0 and texel 1 when magnifying (>1 texel/pixel), else shows LoD tiles"),
+    ("G_TD_SHARPEN", "Sharpen", "Sharpens pixel colors when magnifying (>1 texel/pixel), always shows LoD tiles"),
+    ("G_TD_DETAIL", "Detail", "Shows base tile when magnifying (>1 texel/pixel), else shows base tile+1 as LoD tiles"),
 ]
 
 enumTextPersp = [

--- a/fast64_internal/f3d/f3d_enums.py
+++ b/fast64_internal/f3d/f3d_enums.py
@@ -170,15 +170,15 @@ enumCombKey = [
 ]
 
 enumTextConv = [
-    ("G_TC_CONV", "Convert", "Convert, used for YUV to RGB conversion."),
-    ("G_TC_FILTCONV", "Filter And Convert", "Filter And Convert, used for YUV to RGB conversion."),
-    ("G_TC_FILT", "Filter", "Filter, used for default textures."),
+    ("G_TC_CONV", "Convert", "Convert YUV to RGB"),
+    ("G_TC_FILTCONV", "Filter And Convert", "Applies chosen filter on cycle 1 and converts YUB to RGB in the second cycle"),
+    ("G_TC_FILT", "Filter", "Applies chosen filter on textures with no color conversion"),
 ]
 
 enumTextFilt = [
     ("G_TF_POINT", "Point", "Point filtering"),
-    ("G_TF_AVERAGE", "Average", "Average filter, not recommended except for pixel aligned texrects"),
-    ("G_TF_BILERP", "Bilinear", "Bilinear, standard N64 filtering with 3 point sample"),
+    ("G_TF_AVERAGE", "Average", "Four sample filter, not recommended except for pixel aligned texrects"),
+    ("G_TF_BILERP", "Bilinear", "Standard N64 filtering with 3 point sample"),
 ]
 
 enumTextLUT = [
@@ -194,8 +194,8 @@ enumTextLOD = [
 
 enumTextDetail = [
     ("G_TD_CLAMP", "Clamp", "Shows base tile for texel0 and texel 1 when magnifying (>1 texel/pixel), else shows LoD tiles"),
-    ("G_TD_SHARPEN", "Sharpen", "Sharpens pixel colors when magnifying (>1 texel/pixel), always shows LoD tiles"),
-    ("G_TD_DETAIL", "Detail", "Shows base tile when magnifying (>1 texel/pixel), else shows LoD tiles + 1"),
+    ("G_TD_SHARPEN", "Sharpen", "Sharpens pixel colors when magnifying (<1 texel/pixel), always shows LoD tiles"),
+    ("G_TD_DETAIL", "Detail", "Shows base tile when magnifying (<1 texel/pixel), else shows LoD tiles + 1"),
 ]
 
 enumTextPersp = [
@@ -207,25 +207,25 @@ enumCycleType = [
     ("G_CYC_1CYCLE", "1 Cycle", "1 Cycle"),
     ("G_CYC_2CYCLE", "2 Cycle", "2 Cycle"),
     ("G_CYC_COPY", "Copy", "Copies texture values to framebuffer with no perspective correction or blending"),
-    ("G_CYC_FILL", "Fill", "Uses blend color to fill primitve"),
+    ("G_CYC_FILL", "Fill", "Uses fill color to fill primitve"),
 ]
 
 enumColorDither = [("G_CD_DISABLE", "Disable", "Disable"), ("G_CD_ENABLE", "Enable", "Enable")]
 
 enumPipelineMode = [
-    ("G_PM_1PRIMITIVE", "1 Primitive", "1 Primitive"),
-    ("G_PM_NPRIMITIVE", "N Primitive", "N Primitive"),
+    ("G_PM_1PRIMITIVE", "1 Primitive", "Adds in pipe sync after every tri draw. Adds significant amounts of lag. Only use in vanilla SM64 hacking projects"),
+    ("G_PM_NPRIMITIVE", "N Primitive", "No additional syncs are added after tri draws. Default option for every game but vanilla SM64"),
 ]
 
 enumAlphaCompare = [
-    ("G_AC_NONE", "None", "None"),
-    ("G_AC_THRESHOLD", "Threshold", "Threshold, writes if alpha is greater than blend color alpha"),
-    ("G_AC_DITHER", "Dither", "Dither, writes if alpha is greater than random value"),
+    ("G_AC_NONE", "None", "No alpha comparison is made, writing is based on coverage"),
+    ("G_AC_THRESHOLD", "Threshold", "Writes if alpha is greater than blend color alpha"),
+    ("G_AC_DITHER", "Dither", "Writes if alpha is greater than random value"),
 ]
 
 enumDepthSource = [
     ("G_ZS_PIXEL", "Pixel", "Z value is calculated per primitive pixel"),
-    ("G_ZS_PRIM", "Primitive", "Primitive, use prim depth to set Z value"),
+    ("G_ZS_PRIM", "Primitive", "Uses prim depth to set Z value, does not work on HLE emulation"),
 ]
 
 enumCoverage = [

--- a/fast64_internal/f3d/f3d_enums.py
+++ b/fast64_internal/f3d/f3d_enums.py
@@ -189,13 +189,13 @@ enumTextLUT = [
 
 enumTextLOD = [
     ("G_TL_TILE", "Tile", "Shows selected color combiner tiles"),
-    ("G_TL_LOD", "LoD", "Enables LoD calculations, LoD tile is base tile + log2(texel/pixel) ratio"),
+    ("G_TL_LOD", "LoD", "Enables LoD calculations, LoD tile is base tile + clamp(log2(texel/pixel)), remainder of log2(texel/pixel) ratio gets stored to LoD Fraction in the color combiner"),
 ]
 
 enumTextDetail = [
     ("G_TD_CLAMP", "Clamp", "Shows base tile for texel0 and texel 1 when magnifying (>1 texel/pixel), else shows LoD tiles"),
     ("G_TD_SHARPEN", "Sharpen", "Sharpens pixel colors when magnifying (>1 texel/pixel), always shows LoD tiles"),
-    ("G_TD_DETAIL", "Detail", "Shows base tile when magnifying (>1 texel/pixel), else shows base tile+1 as LoD tiles"),
+    ("G_TD_DETAIL", "Detail", "Shows base tile when magnifying (>1 texel/pixel), else shows LoD tiles + 1"),
 ]
 
 enumTextPersp = [

--- a/fast64_internal/f3d/f3d_material.py
+++ b/fast64_internal/f3d/f3d_material.py
@@ -2495,7 +2495,7 @@ class RDPSettings(bpy.types.PropertyGroup):
     g_tex_gen: bpy.props.BoolProperty(
         name="Texture UV Generate",
         update=update_node_values_with_preset,
-        description="Generates texture coordinates for reflection mapping based on vertex normals and lookat direction. On a skybox texture, maps the sky to the center of the texture and the ground to a cirlce inscribed in the border. Requires lighting enabled to use"
+        description="Generates texture coordinates for reflection mapping based on vertex normals and lookat direction. On a skybox texture, maps the sky to the center of the texture and the ground to a circle inscribed in the border. Requires lighting enabled to use"
     )
     g_tex_gen_linear: bpy.props.BoolProperty(
         name="Texture UV Generate Linear",

--- a/fast64_internal/f3d/f3d_material.py
+++ b/fast64_internal/f3d/f3d_material.py
@@ -2507,7 +2507,7 @@ class RDPSettings(bpy.types.PropertyGroup):
         name="Smooth Shading",
         default=True,
         update=update_node_values_with_preset,
-        description="Shades primitive smoothly using interpolation between shade values for each vertex(Gouraud shading)"
+        description="Shades primitive smoothly using interpolation between shade values for each vertex (Gouraud shading)"
     )
     # f3dlx2 only
     g_clipping: bpy.props.BoolProperty(

--- a/fast64_internal/f3d/f3d_material.py
+++ b/fast64_internal/f3d/f3d_material.py
@@ -2460,45 +2460,54 @@ class RDPSettings(bpy.types.PropertyGroup):
         name="Z Buffer",
         default=True,
         update=update_node_values_with_preset,
+        description="Turns on/off Z-Buffer.  Z-Buffer set to 0 if disabled."
     )
     g_shade: bpy.props.BoolProperty(
         name="Shading",
         default=True,
         update=update_node_values_with_preset,
+        description="Turns on/off shading. Shade register set to 0 if disabled."
     )
     # v1/2 difference
     g_cull_front: bpy.props.BoolProperty(
         name="Cull Front",
         update=update_node_values_with_preset,
+        description="Turns on/off drawing of front faces"
     )
     # v1/2 difference
     g_cull_back: bpy.props.BoolProperty(
         name="Cull Back",
         default=True,
         update=update_node_values_with_preset,
+        description="Turns on/off drawing of back faces"
     )
     g_fog: bpy.props.BoolProperty(
         name="Fog",
         update=update_node_values_with_preset,
+        description="Turns on/off fog calculation. Fog variable gets stored into shade alpha"
     )
     g_lighting: bpy.props.BoolProperty(
         name="Lighting",
         default=True,
         update=update_node_values_with_preset,
+        description="Enables calculation of shade values from lights and vertex normals. Turn off for vertex colors"
     )
     g_tex_gen: bpy.props.BoolProperty(
         name="Texture UV Generate",
         update=update_node_values_with_preset,
+        description="Generates texture coordinates that maps from norm x/y to [0-1]x/y"
     )
     g_tex_gen_linear: bpy.props.BoolProperty(
         name="Texture UV Generate Linear",
         update=update_node_values_with_preset,
+        description="Generates texture coordinates that linearly maps from cos/sin(norm) to [0-1]x/y"
     )
     # v1/2 difference
     g_shade_smooth: bpy.props.BoolProperty(
         name="Smooth Shading",
         default=True,
         update=update_node_values_with_preset,
+        description="Shades primitive smoothly using interpolation between shade values for each vertex(Gouraud shading)"
     )
     # f3dlx2 only
     g_clipping: bpy.props.BoolProperty(
@@ -2513,6 +2522,7 @@ class RDPSettings(bpy.types.PropertyGroup):
         items=enumAlphaDither,
         default="G_AD_NOISE",
         update=update_node_values_with_preset,
+        description="Applies your choice dithering type to output frambuffer alpha"
     )
     # v2 only
     g_mdsft_rgb_dither: bpy.props.EnumProperty(
@@ -2520,35 +2530,41 @@ class RDPSettings(bpy.types.PropertyGroup):
         items=enumRGBDither,
         default="G_CD_MAGICSQ",
         update=update_node_values_with_preset,
+        description="Applies your choice dithering type to output frambuffer color"
     )
     g_mdsft_combkey: bpy.props.EnumProperty(
         name="Chroma Key",
         items=enumCombKey,
         default="G_CK_NONE",
         update=update_node_values_with_preset,
+        description="Turns on/off the chroma key. Chroma key requires a special setup to work properly"
     )
     g_mdsft_textconv: bpy.props.EnumProperty(
         name="Texture Convert",
         items=enumTextConv,
         default="G_TC_FILT",
         update=update_node_values_with_preset,
+        description="Turns on/off the converter for texture color. Can convert color space from YUV into RGB"
     )
     g_mdsft_text_filt: bpy.props.EnumProperty(
         name="Texture Filter",
         items=enumTextFilt,
         default="G_TF_BILERP",
         update=update_node_values_without_preset,
+        description="Applies your choice of filtering to texels"
     )
     g_mdsft_textlut: bpy.props.EnumProperty(
         name="Texture LUT",
         items=enumTextLUT,
         default="G_TT_NONE",
+        description="Changes texture look up table (LUT) behavior. This property is auto set if you choose a CI texture"
     )
     g_mdsft_textlod: bpy.props.EnumProperty(
         name="Texture LOD",
         items=enumTextLOD,
         default="G_TL_TILE",
         update=update_node_values_with_preset,
+        description="Turns on/off the use of LoD on textures. LoD textures change the used tile based on the texel/pixel ratio"
     )
     num_textures_mipmapped: bpy.props.IntProperty(
         name="Number of Mipmaps",
@@ -2562,18 +2578,21 @@ class RDPSettings(bpy.types.PropertyGroup):
         items=enumTextDetail,
         default="G_TD_CLAMP",
         update=update_node_values_with_preset,
+        description="Changes type of LoD usage. Affects how tiles are selected based on texel magnification. Only works when G_TL_LOD is selected"
     )
     g_mdsft_textpersp: bpy.props.EnumProperty(
         name="Texture Perspective Correction",
         items=enumTextPersp,
         default="G_TP_PERSP",
         update=update_node_values_with_preset,
+        description="Turns on/off texture perspective correction"
     )
     g_mdsft_cycletype: bpy.props.EnumProperty(
         name="Cycle Type",
         items=enumCycleType,
         default="G_CYC_1CYCLE",
         update=update_node_values_with_preset,
+        description="Changes RDP pipeline configuration. For normal textured triangles use one or two cycle mode"
     )
     # v1 only
     g_mdsft_color_dither: bpy.props.EnumProperty(
@@ -2581,12 +2600,14 @@ class RDPSettings(bpy.types.PropertyGroup):
         items=enumColorDither,
         default="G_CD_ENABLE",
         update=update_node_values_with_preset,
+        description="Applies your choice dithering type to output frambuffer"
     )
     g_mdsft_pipeline: bpy.props.EnumProperty(
         name="Pipeline Span Buffer Coherency",
         items=enumPipelineMode,
         default="G_PM_1PRIMITIVE",
         update=update_node_values_with_preset,
+        description="Changes primitive rasterization timing. For games besides SM64, N-prim is optimal"
     )
 
     # lower half mode
@@ -2595,12 +2616,14 @@ class RDPSettings(bpy.types.PropertyGroup):
         items=enumAlphaCompare,
         default="G_AC_NONE",
         update=update_node_values_with_preset,
+        description="Uses alpha comparisons to decide if a pixel should be written. Applies before blending"
     )
     g_mdsft_zsrcsel: bpy.props.EnumProperty(
         name="Z Source Selection",
         items=enumDepthSource,
         default="G_ZS_PIXEL",
         update=update_node_values_with_preset,
+        description="Changes screen-space Z value source used for Z-Buffer calculations"
     )
 
     prim_depth: bpy.props.PointerProperty(
@@ -2639,37 +2662,47 @@ class RDPSettings(bpy.types.PropertyGroup):
     )
     aa_en: bpy.props.BoolProperty(
         update=update_node_values_with_preset,
+        description="Enables anti-aliasing to rasterized primitive edges. Uses coverage to determine edges"
     )
     z_cmp: bpy.props.BoolProperty(
         update=update_node_values_with_preset,
+        description="Checks pixel Z value against Z-Buffer to test writing"
     )
     z_upd: bpy.props.BoolProperty(
         update=update_node_values_with_preset,
+        description="Updates the Z-Buffer with the most recently written pixel Z value"
     )
     im_rd: bpy.props.BoolProperty(
         update=update_node_values_with_preset,
+        description="Enables reading from framebuffer for blending calculations"
     )
     clr_on_cvg: bpy.props.BoolProperty(
         update=update_node_values_with_preset,
+        description="Only draw on coverage (amount primitive covers target pixel) overflow"
     )
     cvg_dst: bpy.props.EnumProperty(
         name="Coverage Destination",
         items=enumCoverage,
         update=update_node_values_with_preset,
+        description="Changes how coverage (amount primitive covers target pixel) gets retrieved/stored"
     )
     zmode: bpy.props.EnumProperty(
         name="Z Mode",
         items=enumZMode,
         update=update_node_values_with_preset,
+        description="Changes Z calculation for different types of primitives"
     )
     cvg_x_alpha: bpy.props.BoolProperty(
         update=update_node_values_with_preset,
+        description="Multiply coverage (amount primitive covers target pixel) with alpha and store result as coverage"
     )
     alpha_cvg_sel: bpy.props.BoolProperty(
         update=update_node_values_with_preset,
+        description="Use coverage (amount primitive covers target pixel) as alpha instead of color combiner alpha"
     )
     force_bl: bpy.props.BoolProperty(
         update=update_node_values_with_preset,
+        description="Always uses blending on. Default blending is conditionally based on depth. Always used when Z Buffering is off"
     )
 
     # cycle dependent - (P * A + M - B) / (A + B)

--- a/fast64_internal/f3d/f3d_material.py
+++ b/fast64_internal/f3d/f3d_material.py
@@ -2460,26 +2460,26 @@ class RDPSettings(bpy.types.PropertyGroup):
         name="Z Buffer",
         default=True,
         update=update_node_values_with_preset,
-        description="Turns on/off Z-Buffer.  Z-Buffer set to 0 if disabled."
+        description="Enables calculation of Z value for primitives. Disable if not reading or writing Z-Buffer in the blender"
     )
     g_shade: bpy.props.BoolProperty(
         name="Shading",
         default=True,
         update=update_node_values_with_preset,
-        description="Turns on/off shading. Shade register set to 0 if disabled."
+        description="Computes shade coordinates for primitives. Disable if not using lighting, vertex colors or fog"
     )
     # v1/2 difference
     g_cull_front: bpy.props.BoolProperty(
         name="Cull Front",
         update=update_node_values_with_preset,
-        description="Turns on/off drawing of front faces"
+        description="Disables drawing of front faces"
     )
     # v1/2 difference
     g_cull_back: bpy.props.BoolProperty(
         name="Cull Back",
         default=True,
         update=update_node_values_with_preset,
-        description="Turns on/off drawing of back faces"
+        description="Disables drawing of back faces"
     )
     g_fog: bpy.props.BoolProperty(
         name="Fog",
@@ -2490,17 +2490,17 @@ class RDPSettings(bpy.types.PropertyGroup):
         name="Lighting",
         default=True,
         update=update_node_values_with_preset,
-        description="Enables calculation of shade values from lights and vertex normals. Turn off for vertex colors"
+        description="Enables calculation shade color using lights. Turn off for vertex colors as shade color"
     )
     g_tex_gen: bpy.props.BoolProperty(
         name="Texture UV Generate",
         update=update_node_values_with_preset,
-        description="Generates texture coordinates that maps from norm x/y to [0-1]x/y"
+        description="Generates texture coordinates for reflection mapping based on vertex normals and lookat direction. On a skybox texture, maps the sky to the center of the texture and the ground to a cirlce inscribed in the border. Requires lighting enabled to use"
     )
     g_tex_gen_linear: bpy.props.BoolProperty(
         name="Texture UV Generate Linear",
         update=update_node_values_with_preset,
-        description="Generates texture coordinates that linearly maps from cos/sin(norm) to [0-1]x/y"
+        description="Modifies the texgen mapping; enable with texgen. Use a normal panorama image for the texture, with the sky at the top and the ground at the bottom. Requires lighting enabled to use"
     )
     # v1/2 difference
     g_shade_smooth: bpy.props.BoolProperty(
@@ -2522,7 +2522,7 @@ class RDPSettings(bpy.types.PropertyGroup):
         items=enumAlphaDither,
         default="G_AD_NOISE",
         update=update_node_values_with_preset,
-        description="Applies your choice dithering type to output frambuffer alpha"
+        description="Applies your choice dithering type to output framebuffer alpha. Dithering is used to convert high precision source colors into lower precision framebuffer values"
     )
     # v2 only
     g_mdsft_rgb_dither: bpy.props.EnumProperty(
@@ -2530,7 +2530,7 @@ class RDPSettings(bpy.types.PropertyGroup):
         items=enumRGBDither,
         default="G_CD_MAGICSQ",
         update=update_node_values_with_preset,
-        description="Applies your choice dithering type to output frambuffer color"
+        description="Applies your choice dithering type to output framebuffer color. Dithering is used to convert high precision source colors into lower precision framebuffer values"
     )
     g_mdsft_combkey: bpy.props.EnumProperty(
         name="Chroma Key",
@@ -2544,7 +2544,7 @@ class RDPSettings(bpy.types.PropertyGroup):
         items=enumTextConv,
         default="G_TC_FILT",
         update=update_node_values_with_preset,
-        description="Turns on/off the converter for texture color. Can convert color space from YUV into RGB"
+        description="Sets the function of the texture convert unit, to do texture filtering, YUV to RGB conversion, or both"
     )
     g_mdsft_text_filt: bpy.props.EnumProperty(
         name="Texture Filter",
@@ -2607,7 +2607,7 @@ class RDPSettings(bpy.types.PropertyGroup):
         items=enumPipelineMode,
         default="G_PM_1PRIMITIVE",
         update=update_node_values_with_preset,
-        description="Changes primitive rasterization timing. For games besides SM64, N-prim is optimal"
+        description="Changes primitive rasterization timing by adding syncs after tri draws. Vanilla SM64 has synchronization issues which could cause a crash if not using 1 prim. For any modern SM64 hacking project or other game N-prim should always be used"
     )
 
     # lower half mode
@@ -2702,7 +2702,7 @@ class RDPSettings(bpy.types.PropertyGroup):
     )
     force_bl: bpy.props.BoolProperty(
         update=update_node_values_with_preset,
-        description="Always uses blending on. Default blending is conditionally based on depth. Always used when Z Buffering is off"
+        description="Always uses blending on. Default blending is conditionally only applied during partial coverage. Forcing blending will disable division step of the blender, so B input must be 1-A or there may be rendering issues. Always use this option when Z Buffering is off"
     )
 
     # cycle dependent - (P * A + M - B) / (A + B)


### PR DESCRIPTION
Adds tooltips to the f3d material GUI for RDP settings. Tooltips are provided by the third argument in an enum item, or by the description key word argument to a property.
Tooltips can be viewed by hovering the mouse over the option in the GUI. The enums tooltips can be viewed by opening the enum and hovering the mouse over the given enum.