### PR TITLE
Small Fixes 2

### DIFF
--- a/fast64_internal/f3d/f3d_bleed.py
+++ b/fast64_internal/f3d/f3d_bleed.py
@@ -32,6 +32,13 @@ from .f3d_gbi import (
     DPTileSync,
     DPSetTile,
     DPLoadTile,
+    FModel,
+    FMesh,
+    FMaterial,
+    F3D,
+    GfxList,
+    FTriGroup,
+    GbiMacro,
 )
 
 

--- a/fast64_internal/f3d/f3d_gbi.py
+++ b/fast64_internal/f3d/f3d_gbi.py
@@ -6,6 +6,11 @@ from dataclasses import dataclass, fields
 import bpy, os, enum, copy
 from ..utility import *
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from .f3d_material import TextureProperty
+
 
 class ScrollMethod(enum.Enum):
     Vertex = 1
@@ -2209,8 +2214,7 @@ class FImageKey:
         )
 
 
-def getImageKey(texProp, useList) -> FImageKey:
-    # texProp type: TextureProperty
+def getImageKey(texProp: "TextureProperty", useList) -> FImageKey:
     return FImageKey(texProp.tex, texProp.tex_format, texProp.ci_format, useList)
 
 

--- a/fast64_internal/f3d/f3d_gbi.py
+++ b/fast64_internal/f3d/f3d_gbi.py
@@ -2209,7 +2209,8 @@ class FImageKey:
         )
 
 
-def getImageKey(texProp: "TextureProperty", useList) -> FImageKey:
+def getImageKey(texProp, useList) -> FImageKey:
+    # texProp type: TextureProperty
     return FImageKey(texProp.tex, texProp.tex_format, texProp.ci_format, useList)
 
 

--- a/fast64_internal/f3d/f3d_parser.py
+++ b/fast64_internal/f3d/f3d_parser.py
@@ -1305,13 +1305,15 @@ class F3DContext:
 
     def loadTile(self, params):
         tileSettings = self.getTileSettings(params[0])
-        # TODO: Region parsing too hard?
-        # region = [
-        # 	math_eval(params[1], self.f3d) / 4,
-        # 	math_eval(params[2], self.f3d) / 4,
-        # 	math_eval(params[3], self.f3d) / 4,
-        # 	math_eval(params[4], self.f3d) / 4
-        # ]
+        """
+        TODO: Region parsing too hard?
+        region = [
+        	math_eval(params[1], self.f3d) / 4,
+        	math_eval(params[2], self.f3d) / 4,
+        	math_eval(params[3], self.f3d) / 4,
+        	math_eval(params[4], self.f3d) / 4
+        ]
+        """
         region = None
 
         # Defer texture parsing until next set tile.
@@ -1441,7 +1443,7 @@ class F3DContext:
         if textureName in self.textureData:
             return self.textureData[textureName]
 
-        # region ignored?
+        """region ignored?"""
         if isLUT:
             siz = "G_IM_SIZ_16b"
             width = 16

--- a/fast64_internal/f3d/f3d_texture_writer.py
+++ b/fast64_internal/f3d/f3d_texture_writer.py
@@ -16,6 +16,7 @@ from .f3d_material import (
 )
 from .f3d_gbi import *
 from .f3d_gbi import _DPLoadTextureBlock
+from .flipbook import TextureFlipbook
 
 from ..utility import *
 

--- a/fast64_internal/f3d/op_largetexture.py
+++ b/fast64_internal/f3d/op_largetexture.py
@@ -246,8 +246,8 @@ def createLargeTextureMeshInternal(bm, prop):
         # that these meshes won't have holes in them. Prefer correct seamless results
         # over saving a few tri draws (the loads will still be combined).
         distFromWrap = (texelsPerWord, 2)[dim]
-        # Number of texels such that if a wrap load could reach the end of the drawn
-        # region by continuing to load this many texels into the image after wrapping,
+        # Number of texels such that if a wrap load could reach the end of the drawn region
+        # by continuing to load this many texels into the image after wrapping,
         # it's worth it to do so (as opposed to only loading row/col 0, and drawing
         # the rest with a new tri which shares the load at the beginning of the image).
         worthItExtraEnd = max(baseTile[dim] // 8, distFromWrap) if bilinear else 0

--- a/fast64_internal/sm64/sm64_geolayout_classes.py
+++ b/fast64_internal/sm64/sm64_geolayout_classes.py
@@ -20,6 +20,7 @@ from ..utility import (
     geoNodeRotateOrder,
 )
 from ..f3d.f3d_bleed import BleedGraphics
+from ..f3d.f3d_gbi import FModel
 
 from .sm64_geolayout_constants import (
     nodeGroupCmds,

--- a/fast64_internal/sm64/sm64_geolayout_writer.py
+++ b/fast64_internal/sm64/sm64_geolayout_writer.py
@@ -97,6 +97,7 @@ from ..f3d.f3d_gbi import (
     DLFormat,
     SPEndDisplayList,
     SPDisplayList,
+    FMaterial,
 )
 
 from .sm64_geolayout_classes import (
@@ -2502,7 +2503,7 @@ def saveOverrideDraw(
     last_replaced = None
     command_index = 0
 
-    def find_material_from_jump_cmd(material_list: tuple[tuple[bpy.types.Material, str, FAreaData], tuple[FMaterial, Tuple[int, int]]], dl_jump: SPDisplayList):
+    def find_material_from_jump_cmd(material_list: tuple[tuple[bpy.types.Material, str, FAreaData], tuple[FMaterial, tuple[int, int]]], dl_jump: SPDisplayList):
         if dl_jump.displayList.tag == GfxListTag.Geometry:
             return None, None
         for mat in material_list:


### PR DESCRIPTION
I noticed some files had warnings that are easy to fix, so here it is

I'm not able to fix the one from [``sm64_f3d_writer.py``](https://github.com/Fast-64/fast64/blob/d97dcd22ad45f582e0a74f050ca5c17b7053d4da/fast64_internal/sm64/sm64_f3d_writer.py#L320) and the one from [``f3d_parser.py``](https://github.com/Fast-64/fast64/blob/d97dcd22ad45f582e0a74f050ca5c17b7053d4da/fast64_internal/f3d/f3d_parser.py#L2266), though for this one the class seems unused

About the change I did in ``f3d_gbi.py``, importing the class creates a circular import, so I thought it was better to remove the type hint and put a comment to clarify the type instead, not a great a solution but idk if it can work with the import