### PR TITLE
[F3D] Chroma Key F3D source display fix

### DIFF
--- a/fast64_internal/f3d/f3d_material.py
+++ b/fast64_internal/f3d/f3d_material.py
@@ -589,14 +589,15 @@ class F3DPanel(bpy.types.Panel):
         inputGroup = layout.row()
         prop_input_name = inputGroup.column()
         prop_input = inputGroup.column()
+        f3d_mat = material.f3d_mat
         if showCheckBox:
-            prop_input_name.prop(material, setName, text="Chroma Key")
+            prop_input_name.prop(f3d_mat, setName, text="Chroma Key")
         else:
             prop_input_name.label(text="Chroma Key")
-        prop_input.prop(material.f3d_mat, "key_center", text="Center")
-        prop_input.prop(material, "key_scale", text="Scale")
-        prop_input.prop(material, "key_width", text="Width")
-        if material.key_width[0] > 1 or material.key_width[1] > 1 or material.key_width[2] > 1:
+        prop_input.prop(f3d_mat, "key_center", text="Center")
+        prop_input.prop(f3d_mat, "key_scale", text="Scale")
+        prop_input.prop(f3d_mat, "key_width", text="Width")
+        if f3d_mat.key_width[0] > 1 or f3d_mat.key_width[1] > 1 or f3d_mat.key_width[2] > 1:
             layout.box().label(text="NOTE: Keying is disabled for channels with width > 1.")
         prop_input.enabled = setProp
         return inputGroup

--- a/fast64_internal/f3d/f3d_writer.py
+++ b/fast64_internal/f3d/f3d_writer.py
@@ -1396,7 +1396,7 @@ def saveOrGetF3DMaterial(material, fModel, obj, drawLayer, convertTextureData):
         fMaterial.mat_only_DL.commands.extend([SPSetLights(fLights)])  # TODO: handle synching: NO NEED?
 
     if useDict["Key"] and f3dMat.set_key:
-        if material.mat_ver == 4:
+        if material.mat_ver >= 4:
             center = f3dMat.key_center
         else:
             center = nodes["Chroma Key Center"].outputs[0].default_value


### PR DESCRIPTION
Chroma key values were not referencing the correct prop path, and thus were not displaying properly, and also resulted in other props from not displaying.
To see issue, add chroma key scale or center to the combiner, and you will notice missing elements in the sources tab. If you open the console you will also see error messages. These issues are resolved in this PR.