### PR TITLE
Fix SM64 default light direction for F3DEX3 compatibility

### DIFF
--- a/fast64_internal/f3d/f3d_parser.py
+++ b/fast64_internal/f3d/f3d_parser.py
@@ -513,13 +513,13 @@ class F3DContext:
 
         # Here these are ints, but when parsing the values will be normalized.
         self.lights.l = [
-            Light([0, 0, 0], [0x28, 0x28, 0x28]),
-            Light([0, 0, 0], [0x28, 0x28, 0x28]),
-            Light([0, 0, 0], [0x28, 0x28, 0x28]),
-            Light([0, 0, 0], [0x28, 0x28, 0x28]),
-            Light([0, 0, 0], [0x28, 0x28, 0x28]),
-            Light([0, 0, 0], [0x28, 0x28, 0x28]),
-            Light([0, 0, 0], [0x28, 0x28, 0x28]),
+            Light([0, 0, 0], [0x49, 0x49, 0x49]),
+            Light([0, 0, 0], [0x49, 0x49, 0x49]),
+            Light([0, 0, 0], [0x49, 0x49, 0x49]),
+            Light([0, 0, 0], [0x49, 0x49, 0x49]),
+            Light([0, 0, 0], [0x49, 0x49, 0x49]),
+            Light([0, 0, 0], [0x49, 0x49, 0x49]),
+            Light([0, 0, 0], [0x49, 0x49, 0x49]),
         ]
         self.lights.a = Ambient([0, 0, 0])
         self.numLights: int = 0
@@ -579,13 +579,13 @@ class F3DContext:
 
         self.lights = Lights("lights_context", self.f3d)
         self.lights.l = [
-            Light([0, 0, 0], [0x28, 0x28, 0x28]),
-            Light([0, 0, 0], [0x28, 0x28, 0x28]),
-            Light([0, 0, 0], [0x28, 0x28, 0x28]),
-            Light([0, 0, 0], [0x28, 0x28, 0x28]),
-            Light([0, 0, 0], [0x28, 0x28, 0x28]),
-            Light([0, 0, 0], [0x28, 0x28, 0x28]),
-            Light([0, 0, 0], [0x28, 0x28, 0x28]),
+            Light([0, 0, 0], [0x49, 0x49, 0x49]),
+            Light([0, 0, 0], [0x49, 0x49, 0x49]),
+            Light([0, 0, 0], [0x49, 0x49, 0x49]),
+            Light([0, 0, 0], [0x49, 0x49, 0x49]),
+            Light([0, 0, 0], [0x49, 0x49, 0x49]),
+            Light([0, 0, 0], [0x49, 0x49, 0x49]),
+            Light([0, 0, 0], [0x49, 0x49, 0x49]),
         ]
         self.lights.a = Ambient([0, 0, 0])
         self.numLights = 0
@@ -1281,7 +1281,7 @@ class F3DContext:
             lightList.append(Light(color, direction))
 
         while len(lightList) < 7:
-            lightList.append(Light(Vector([0, 0, 0]), Vector([0x28, 0x28, 0x28])))
+            lightList.append(Light(Vector([0, 0, 0]), Vector([0x49, 0x49, 0x49])))
 
         # normally a and l are Ambient and Light objects,
         # but here they will be a color and blender light object array.

--- a/fast64_internal/f3d/f3d_writer.py
+++ b/fast64_internal/f3d/f3d_writer.py
@@ -1438,7 +1438,7 @@ def saveLightsDefinition(fModel, fMaterial, material, lightsName):
 
     if material.use_default_lighting:
         lights.a = Ambient(exportColor(material.ambient_light_color))
-        lights.l.append(Light(exportColor(material.default_light_color), [0x28, 0x28, 0x28]))
+        lights.l.append(Light(exportColor(material.default_light_color), [0x49, 0x49, 0x49]))
     else:
         lights.a = Ambient(exportColor(material.ambient_light_color))
 


### PR DESCRIPTION
Vanilla SM64 uses a fixed direction of (0x28, 0x28, 0x28) for one directional light for the entire game (in camera space).

This vector is not normalized; its length is about 0.55f. However, F3D through F3DEX2 microcodes normalize light directions after transforming them, so it doesn't matter that this is too short. In contrast, F3DEX3 does not normalize light directions, because it transforms and normalizes vertex normals instead. So, this light direction being too short means that all the lighting is too dark.

The correctly normalized version of (0x28, 0x28, 0x28) is (0x49, 0x49, 0x49). This PR replaces this value. For projects using F3D - F3DEX2, this will change the exported data, but won't change the in-game appearance because the vector gets normalized anyway.