### PR TITLE
Check if parent object exists

### DIFF
--- a/fast64_internal/oot/props_panel_main.py
+++ b/fast64_internal/oot/props_panel_main.py
@@ -211,7 +211,10 @@ class OOT_ObjectProperties(bpy.types.PropertyGroup):
                         else:
                             print("WARNING: An Actor Cue has been detected outside an Actor Cue List: " + obj.name)
             elif obj.type == "ARMATURE":
-                if obj.parent.name.startswith("Cutscene.") or obj.parent.ootEmptyType == "Cutscene":
+                parentObj = obj.parent
+                if parentObj is not None and (
+                    parentObj.name.startswith("Cutscene.") or parentObj.ootEmptyType == "Cutscene"
+                ):
                     OOTCutsceneMotionProperty.upgrade_object(obj)
 
                 if obj.ootEmptyType == "Cutscene":


### PR DESCRIPTION
should fix the mario.blend error