### PR TITLE
Bump version to v2.2.0

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -40,7 +40,7 @@ from .fast64_internal.render_settings import (
 # info about add on
 bl_info = {
     "name": "Fast64",
-    "version": (2, 1, 0),
+    "version": (2, 2, 0),
     "author": "kurethedead",
     "location": "3DView",
     "description": "Plugin for exporting F3D display lists and other game data related to Nintendo 64 games.",


### PR DESCRIPTION
Can also use this PR to discuss the release (e.g. if we should wait for anything)

Yanies mentioned it may be good to wait for f3dex3 preview, but since that's not anywhere near ready afaik I think it's fine to have a release in between

It's been 2 years since the previous release :sweat_smile: 

If you have permission (I'm not sure who does) there is a release draft for 2.2.0 on the releases page https://github.com/Fast-64/fast64/releases (not visible by everyone apparently)