### PR TITLE
[OoT] Default ``fromRoom`` to the parented room is it's parented to a room

### DIFF
--- a/fast64_internal/oot/actor/properties.py
+++ b/fast64_internal/oot/actor/properties.py
@@ -1,3 +1,5 @@
+import bpy
+
 from bpy.types import Object, PropertyGroup, UILayout
 from bpy.utils import register_class, unregister_class
 from bpy.props import EnumProperty, StringProperty, IntProperty, BoolProperty, CollectionProperty, PointerProperty
@@ -165,7 +167,22 @@ class OOTTransitionActorProperty(PropertyGroup):
     cameraTransitionBackCustom: StringProperty(default="0x00")
     isRoomTransition: BoolProperty(name="Is Room Transition", default=True)
 
+    # internal usage only
+    isFromRoomSet: BoolProperty(name="isFromRoomSet", default=False, get=lambda self: self.updateFromRoom())
+
     actor: PointerProperty(type=OOTActorProperty)
+
+    def updateFromRoom(self):
+        if self.fromRoom is None:
+            for obj in bpy.data.objects:
+                if (
+                    obj.type == "EMPTY"
+                    and obj.ootEmptyType == "Room"
+                    and bpy.context.view_layer.objects.active in obj.children_recursive
+                ):
+                    self.fromRoom = obj
+                    return True
+        return False
 
     def isRoomEmptyObject(self, obj: Object):
         return obj.type == "EMPTY" and obj.ootEmptyType == "Room"
@@ -203,6 +220,9 @@ class OOTTransitionActorProperty(PropertyGroup):
 
         headerProps: OOTActorHeaderProperty = self.actor.headerSettings
         headerProps.draw_props(actorIDBox, "Transition Actor", altSceneProp, objName)
+
+        # execute fromRoom get function
+        _ = self.isFromRoomSet
 
 
 class OOTEntranceProperty(PropertyGroup):


### PR DESCRIPTION
This is a feature request I tried to implement, it's not great and the main limitation is the active object requirement, too bad you can't set default values for ``PointerProperty``...

This is a draft until I find a solution I'm happy with, feel free to make suggestions