### PR TITLE
[OoT] Externalize cutscene float values export/import

### DIFF
--- a/fast64_internal/oot/cutscene/classes.py
+++ b/fast64_internal/oot/cutscene/classes.py
@@ -7,6 +7,10 @@ from ..oot_constants import ootData
 from .motion.utility import getBlenderPosition, getBlenderRotation, getRotation, getInteger
 
 
+def cs_import_float(v_str: str):
+    return float(v_str.removesuffix("f"))
+
+
 # NOTE: ``paramNumber`` is the expected number of parameters inside the parsed commands,
 # this account for the unused parameters. Every classes are based on the commands arguments from ``z64cutscene_commands.h``
 
@@ -47,7 +51,7 @@ class CutsceneCmdCamPoint(CutsceneCmdBase):
             self.continueFlag = self.params[0]
             self.camRoll = getInteger(self.params[1])
             self.frame = getInteger(self.params[2])
-            self.viewAngle = float(self.params[3][:-1])
+            self.viewAngle = cs_import_float(self.params[3])
             self.pos = [getInteger(self.params[4]), getInteger(self.params[5]), getInteger(self.params[6])]
 
 

--- a/fast64_internal/oot/cutscene/exporter/classes.py
+++ b/fast64_internal/oot/cutscene/exporter/classes.py
@@ -32,6 +32,10 @@ from ..classes import (
 )
 
 
+def cs_export_float(v: float):
+    return f"{v:f}f"
+
+
 class CutsceneCmdToC:
     """This class contains functions to create the cutscene commands"""
 
@@ -102,7 +106,7 @@ class CutsceneCmdToC:
             + "".join(f"{rot}, " for rot in actorCue.rot)
             + "".join(f"{pos}, " for pos in actorCue.startPos)
             + "".join(f"{pos}, " for pos in actorCue.endPos)
-            + "0.0f, 0.0f, 0.0f),\n"
+            + f"{cs_export_float(0)}, {cs_export_float(0)}, {cs_export_float(0)}),\n"
         )
 
     def getCamListCmd(self, cmdName: str, startFrame: int, endFrame: int):
@@ -133,7 +137,7 @@ class CutsceneCmdToC:
     def getCamPointCmd(self, camPoint: CutsceneCmdCamPoint):
         return indent * 3 + (
             f"CS_CAM_POINT("
-            + f"{camPoint.continueFlag}, {camPoint.camRoll}, {camPoint.frame}, {camPoint.viewAngle}f, "
+            + f"{camPoint.continueFlag}, {camPoint.camRoll}, {camPoint.frame}, {cs_export_float(camPoint.viewAngle)}, "
             + "".join(f"{pos}, " for pos in camPoint.pos)
             + "0),\n"
         )


### PR DESCRIPTION
Planning ahead for
https://github.com/zeldaret/oot/pull/1824
, breaking cutscene import/export due to different handling of floats

This just refactors reading/writing floats into `cs_import_float` and `cs_export_float` functions
Maybe the functions should be put together in a file but idk which?