### PR TITLE
Blender Version 4.1 Fix

### DIFF
--- a/fast64_internal/f3d/f3d_writer.py
+++ b/fast64_internal/f3d/f3d_writer.py
@@ -138,8 +138,6 @@ def getInfoDict_impl(obj: bpy.types.Object):
     # check mesh.loop_triangles (now that we computed them), used below
     check_face_materials(get_original_name(obj), material_slots, mesh.loop_triangles)
 
-    mesh.calc_normals_split()
-
     infoDict = MeshInfo()
 
     vertDict = infoDict.vert

--- a/fast64_internal/f3d/f3d_writer.py
+++ b/fast64_internal/f3d/f3d_writer.py
@@ -138,6 +138,10 @@ def getInfoDict_impl(obj: bpy.types.Object):
     # check mesh.loop_triangles (now that we computed them), used below
     check_face_materials(get_original_name(obj), material_slots, mesh.loop_triangles)
 
+    # in blender version 4.1 func was removed, in 4.1+ normals are always calculated
+    if bpy.app.version < (4, 1, 0):
+        mesh.calc_normals_split()
+
     infoDict = MeshInfo()
 
     vertDict = infoDict.vert


### PR DESCRIPTION
Title
Normals are always calculated from version 4.1 onwards, making the use of `calc_normals_split()` unnecessary