### PR TITLE
Add Opaque (No AA, No Zbuf) to cycle2 render mode list 

### DIFF
--- a/fast64_internal/f3d/f3d_enums.py
+++ b/fast64_internal/f3d/f3d_enums.py
@@ -330,6 +330,7 @@ enumRenderModesCycle2 = [
     ("G_RM_ZB_CLD_SURF2", "Cloud (No AA)", "G_RM_ZB_CLD_SURF2"),
     ("G_RM_ZB_OVL_SURF2", "Overlay (No AA)", "G_RM_ZB_OVL_SURF2"),
     ("G_RM_AA_ZB_TEX_TERR2", "Terrain", "G_RM_AA_ZB_TEX_TERR2"),
+    ("G_RM_OPA_SURF2", "Opaque (No AA, No ZBuf)", "G_RM_OPA_SURF2"),
 ]
 
 enumTexFormat = [


### PR DESCRIPTION
I didn't delete my fork, you did