### PR TITLE
preview vertex colors on packed materials (temporary solution)

### DIFF
--- a/fast64_internal/f3d/f3d_material.py
+++ b/fast64_internal/f3d/f3d_material.py
@@ -1735,6 +1735,8 @@ def update_node_values_of_material(material: Material, context):
     else:
         nodes["UV"].node_tree = bpy.data.node_groups["UV"]
 
+    if f3dMat.rdp_settings.g_packed_normals:
+        nodes["Shade Color"].node_tree = bpy.data.node_groups["ShdCol_V"] # This is a temporary measure to be able to see the vertex colors in packed materials.
     if f3dMat.rdp_settings.g_lighting:
         nodes["Shade Color"].node_tree = bpy.data.node_groups["ShdCol_L"]
     else:

--- a/fast64_internal/f3d/f3d_material.py
+++ b/fast64_internal/f3d/f3d_material.py
@@ -1735,12 +1735,13 @@ def update_node_values_of_material(material: Material, context):
     else:
         nodes["UV"].node_tree = bpy.data.node_groups["UV"]
 
-    if f3dMat.rdp_settings.g_packed_normals:
+    if bpy.context.scene.f3d_type == "F3DEX3" and f3dMat.rdp_settings.g_packed_normals:
         nodes["Shade Color"].node_tree = bpy.data.node_groups["ShdCol_V"] # This is a temporary measure to be able to see the vertex colors in packed materials.
-    if f3dMat.rdp_settings.g_lighting:
+    elif f3dMat.rdp_settings.g_lighting:
         nodes["Shade Color"].node_tree = bpy.data.node_groups["ShdCol_L"]
     else:
         nodes["Shade Color"].node_tree = bpy.data.node_groups["ShdCol_V"]
+
 
     update_light_colors(material, context)
 

--- a/fast64_internal/f3d/f3d_material.py
+++ b/fast64_internal/f3d/f3d_material.py
@@ -1742,7 +1742,6 @@ def update_node_values_of_material(material: Material, context):
     else:
         nodes["Shade Color"].node_tree = bpy.data.node_groups["ShdCol_V"]
 
-
     update_light_colors(material, context)
 
     combiner_inputs = nodes["CombinerInputs"].inputs

--- a/fast64_internal/f3d/f3d_material.py
+++ b/fast64_internal/f3d/f3d_material.py
@@ -1735,8 +1735,9 @@ def update_node_values_of_material(material: Material, context):
     else:
         nodes["UV"].node_tree = bpy.data.node_groups["UV"]
 
+    # This is a temporary measure to be able to see the vertex colors in packed materials.
     if bpy.context.scene.f3d_type == "F3DEX3" and f3dMat.rdp_settings.g_packed_normals:
-        nodes["Shade Color"].node_tree = bpy.data.node_groups["ShdCol_V"] # This is a temporary measure to be able to see the vertex colors in packed materials.
+        nodes["Shade Color"].node_tree = bpy.data.node_groups["ShdCol_V"]
     elif f3dMat.rdp_settings.g_lighting:
         nodes["Shade Color"].node_tree = bpy.data.node_groups["ShdCol_L"]
     else:


### PR DESCRIPTION
simply preview vertex colors instead of lighting as a stopgap solution until support for previewing both is added 