### PR TITLE
[SM64] Sort Level Objects Alphabetically

### DIFF
--- a/fast64_internal/sm64/sm64_objects.py
+++ b/fast64_internal/sm64/sm64_objects.py
@@ -262,13 +262,14 @@ enumPuppycamFlags = [
 
 
 class SM64_Object:
-    def __init__(self, model, position, rotation, behaviour, bparam, acts):
+    def __init__(self, model, position, rotation, behaviour, bparam, acts, name):
         self.model = model
         self.behaviour = behaviour
         self.bparam = bparam
         self.acts = acts
         self.position = position
         self.rotation = rotation
+        self.name = name  # to sort by when exporting
 
     def to_c(self):
         if self.acts == 0x1F:
@@ -325,6 +326,7 @@ class SM64_Whirpool:
         self.condition = condition
         self.strength = strength
         self.position = position
+        self.name = "whirlpool"  # for sorting
 
     def to_c(self):
         return (
@@ -453,6 +455,7 @@ class SM64_Mario_Start:
         self.area = area
         self.position = position
         self.rotation = rotation
+        self.name = "Mario"  # for sorting
 
     def to_c(self):
         return (
@@ -500,7 +503,8 @@ class SM64_Area:
         data += "\tAREA(" + str(self.index) + ", " + self.geolayout.name + "),\n"
         for warpNode in self.warpNodes:
             data += "\t\t" + warpNode + ",\n"
-        for obj in self.objects:
+        # export objects in name order
+        for obj in sorted(self.objects, key=(lambda obj: obj.name)):
             data += "\t\t" + obj.to_c() + ",\n"
         data += "\t\tTERRAIN(" + self.collision.name + "),\n"
         if includeRooms:
@@ -840,6 +844,7 @@ def process_sm64_objects(obj, area, rootMatrix, transformMatrix, specialsOnly):
                         behaviour,
                         obj.fast64.sm64.game_object.get_behavior_params(),
                         get_act_string(obj),
+                        obj.name,
                     )
                 )
             elif obj.sm64_obj_type == "Macro":


### PR DESCRIPTION
added sorting to object exports in sm64. Actors are sorted alphabetically. This will generally make it so the same type of object all export in a row since these will have names like: coin, coin.001, coin.002 etc.