### PR TITLE
Fix OoT import failing in Blender 4.1

### DIFF
--- a/fast64_internal/f3d/f3d_parser.py
+++ b/fast64_internal/f3d/f3d_parser.py
@@ -1836,7 +1836,9 @@ class F3DContext:
         # else:
 
         if importNormals:
-            mesh.use_auto_smooth = True
+            # Changed in Blender 4.1: "Meshes now always use custom normals if they exist." (and use_auto_smooth was removed)
+            if bpy.app.version < (4, 1, 0):
+                mesh.use_auto_smooth = True
             mesh.normals_split_custom_set([f3dVert.normal for f3dVert in self.verts])
 
         for groupName, indices in self.limbGroups.items():


### PR DESCRIPTION
cf https://developer.blender.org/docs/release_notes/4.1/python_api/
 > use_auto_smooth is removed. [...] Meshes now always use custom normals if they exist.