### PR TITLE
[SM64] Fixed Bug In Water Box Exports

### DIFF
--- a/fast64_internal/sm64/sm64_objects.py
+++ b/fast64_internal/sm64/sm64_objects.py
@@ -821,7 +821,7 @@ def process_sm64_objects(obj, area, rootMatrix, transformMatrix, specialsOnly):
                     )
                 )
             elif obj.sm64_obj_type == "Water Box":
-                checkIdentityRotation(obj, rotation, False)
+                checkIdentityRotation(obj, rotation.to_quaternion(), False)
                 area.water_boxes.append(CollisionWaterBox(obj.waterBoxType, translation, scale, obj.empty_display_size))
         else:
             if obj.sm64_obj_type == "Object":


### PR DESCRIPTION
bug introduced in #339 woops lol.
I just did something simple here, the swap between quats and euler objects should be isomorphic (I can't actually prove this it has been a while since maths) so there is no loss in info.