### PR TITLE
Automatically select correct colorspace

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -323,6 +323,7 @@ def upgrade_scene_props_node():
 
 @bpy.app.handlers.persistent
 def after_load(_a, _b):
+    bpy.ops.dialog.update_colorspace("INVOKE_DEFAULT")
     upgrade_changed_props()
     upgrade_scene_props_node()
     resync_scene_props()

--- a/__init__.py
+++ b/__init__.py
@@ -12,7 +12,7 @@ from .fast64_internal.oot import OOT_Properties, oot_register, oot_unregister
 from .fast64_internal.oot.props_panel_main import OOT_ObjectProperties
 from .fast64_internal.utility_anim import utility_anim_register, utility_anim_unregister, ArmatureApplyWithMeshOperator
 
-from .fast64_internal.f3d.f3d_material import mat_register, mat_unregister
+from .fast64_internal.f3d.f3d_material import mat_register, mat_unregister, check_or_ask_color_management
 from .fast64_internal.f3d.f3d_render_engine import render_engine_register, render_engine_unregister
 from .fast64_internal.f3d.f3d_writer import f3d_writer_register, f3d_writer_unregister
 from .fast64_internal.f3d.f3d_parser import f3d_parser_register, f3d_parser_unregister
@@ -175,6 +175,7 @@ class Fast64Settings_Properties(bpy.types.PropertyGroup):
         name="Prefer RGBA Over CI",
         description="When enabled, fast64 will default colored textures's format to RGBA even if they fit CI requirements, with the exception of textures that would not fit into TMEM otherwise",
     )
+    dont_ask_color_management: bpy.props.BoolProperty(name="Don't ask to set color management properties")
 
 
 class Fast64_Properties(bpy.types.PropertyGroup):
@@ -324,7 +325,7 @@ def upgrade_scene_props_node():
 @bpy.app.handlers.persistent
 def after_load(_a, _b):
     if any(mat.is_f3d for mat in bpy.data.materials):
-        bpy.ops.dialog.update_colorspace("INVOKE_DEFAULT")
+        check_or_ask_color_management(bpy.context)
     upgrade_changed_props()
     upgrade_scene_props_node()
     resync_scene_props()

--- a/__init__.py
+++ b/__init__.py
@@ -323,7 +323,8 @@ def upgrade_scene_props_node():
 
 @bpy.app.handlers.persistent
 def after_load(_a, _b):
-    bpy.ops.dialog.update_colorspace("INVOKE_DEFAULT")
+    if any(mat.is_f3d for mat in bpy.data.materials):
+        bpy.ops.dialog.update_colorspace("INVOKE_DEFAULT")
     upgrade_changed_props()
     upgrade_scene_props_node()
     resync_scene_props()

--- a/fast64_internal/f3d/f3d_material.py
+++ b/fast64_internal/f3d/f3d_material.py
@@ -1693,7 +1693,7 @@ def get_color_input_update_callback(attr_name="", prefix=""):
 
 
 def update_node_values_of_material(material: Material, context):
-    nodes = material.node_tree.nodes
+    fixBlenderColorspace(context)
 
     update_blend_method(material, context)
     if not has_f3d_nodes(material):
@@ -1704,6 +1704,8 @@ def update_node_values_of_material(material: Material, context):
     update_combiner_connections(material, context)
 
     set_output_node_groups(material)
+
+    nodes = material.node_tree.nodes
 
     if f3dMat.rdp_settings.g_tex_gen:
         if f3dMat.rdp_settings.g_tex_gen_linear:
@@ -2178,8 +2180,9 @@ def has_f3d_nodes(material: Material):
 
 @persistent
 def load_handler(dummy):
-    logger.info("Checking for base F3D material library.")
+    fixBlenderColorspace(bpy.context)
 
+    logger.info("Checking for base F3D material library.")
     for lib in bpy.data.libraries:
         lib_path = bpy.path.abspath(lib.filepath)
 
@@ -2397,6 +2400,7 @@ def addColorAttributesToModel(obj: Object):
 
 
 def createF3DMat(obj: Object | None, preset="Shaded Solid", index=None):
+    fixBlenderColorspace(bpy.context)
     # link all node_groups + material from addon's data .blend
     link_f3d_material_library()
 

--- a/fast64_internal/f3d/f3d_material.py
+++ b/fast64_internal/f3d/f3d_material.py
@@ -3,6 +3,7 @@ import bpy, math, os
 from bpy.types import (
     Attribute,
     Context,
+    Event,
     Image,
     Light,
     Material,
@@ -24,7 +25,6 @@ from bpy.types import (
     UILayout,
     VIEW3D_HT_header,
     World,
-    Event,
 )
 from bl_operators.presets import AddPresetBase
 from bpy.utils import register_class, unregister_class

--- a/fast64_internal/f3d/f3d_material.py
+++ b/fast64_internal/f3d/f3d_material.py
@@ -24,7 +24,7 @@ from bpy.types import (
     UILayout,
     VIEW3D_HT_header,
     World,
-    Event
+    Event,
 )
 from bl_operators.presets import AddPresetBase
 from bpy.utils import register_class, unregister_class
@@ -2448,7 +2448,7 @@ class UpdateColorSpacePopup(Operator):
     bl_description = "Update color space"
     bl_options = {"UNDO"}
 
-    already_invoked = False # HACK: used to prevent multiple dialogs from popping up
+    already_invoked = False  # HACK: used to prevent multiple dialogs from popping up
 
     def invoke(self, context: Context, event: Event):
         if UpdateColorSpacePopup.already_invoked:
@@ -2456,8 +2456,7 @@ class UpdateColorSpacePopup(Operator):
         scene = context.scene
         view_settings = scene.view_settings
         # Check if color space is correct
-        if (
-            not scene.dont_ask_colorspace and
+        if not scene.dont_ask_colorspace and (
             scene.display_settings.display_device != "sRGB"
             or view_settings.view_transform != "Standard"
             or view_settings.look != "None"
@@ -2471,12 +2470,15 @@ class UpdateColorSpacePopup(Operator):
 
     def draw(self, context: Context):
         col = self.layout.column()
+        multilineLabel(
+            col,
+            f'The colorspace for the current scene "{context.scene.name}"\nwill cause inaccurate preview compared to N64.\nWould you like to update it?',
+            icon="INFO",
+        )
         col.prop(context.scene, "dont_ask_colorspace")
-        multilineLabel(col, f"The current scene \"{context.scene.name}\" does not use the same color space as n64.\nWould you like to update it?", icon="INFO")
 
     def cancel(self, context: Context):
         UpdateColorSpacePopup.already_invoked = False
-        return {"CANCELLED"}
 
     def execute(self, context):
         try:
@@ -4547,7 +4549,7 @@ def mat_register():
 
     Scene.f3dUserPresetsOnly = bpy.props.BoolProperty(name="User Presets Only")
     Scene.f3d_simple = bpy.props.BoolProperty(name="Display Simple", default=True)
-    Scene.dont_ask_colorspace = bpy.props.BoolProperty(name="Don´t ask again")
+    Scene.dont_ask_colorspace = bpy.props.BoolProperty(name="Don't ask again")
 
     Object.use_f3d_culling = bpy.props.BoolProperty(
         name="Enable Culling (Applies to F3DEX and up)",

--- a/fast64_internal/utility.py
+++ b/fast64_internal/utility.py
@@ -1246,15 +1246,6 @@ def exportColor(lightColor):
     return [scaleToU8(value) for value in gammaCorrect(lightColor)]
 
 
-def fixBlenderColorspace(context):
-    for scene in context.blend_data.scenes:
-        scene.display_settings.display_device = "sRGB"
-        scene.view_settings.view_transform = "Standard"
-        scene.view_settings.look = "None"
-        scene.view_settings.exposure = 0.0
-        scene.view_settings.gamma = 1.0
-
-
 def printBlenderMessage(msgSet, message, blenderOp):
     if blenderOp is not None:
         blenderOp.report(msgSet, message)

--- a/fast64_internal/utility.py
+++ b/fast64_internal/utility.py
@@ -1246,6 +1246,15 @@ def exportColor(lightColor):
     return [scaleToU8(value) for value in gammaCorrect(lightColor)]
 
 
+def fixBlenderColorspace(context):
+    for scene in context.blend_data.scenes:
+        scene.display_settings.display_device = "sRGB"
+        scene.view_settings.view_transform = "Standard"
+        scene.view_settings.look = "None"
+        scene.view_settings.exposure = 0.0
+        scene.view_settings.gamma = 1.0
+
+
 def printBlenderMessage(msgSet, message, blenderOp):
     if blenderOp is not None:
         blenderOp.report(msgSet, message)


### PR DESCRIPTION
Whenever a material is created or edited, or a scene is loaded, this PR sets the Blender colorspace settings so that preview of vertex colors is accurate (or more accurate than otherwise).