### PR TITLE
[F3D] Homebrew Mode Improvements

### DIFF
--- a/fast64_internal/f3d/f3d_material.py
+++ b/fast64_internal/f3d/f3d_material.py
@@ -3407,7 +3407,7 @@ class DefaultRDPSettingsPanel(Panel):
 
     @classmethod
     def poll(cls, context):
-        return context.scene.gameEditorMode == "SM64"
+        return context.scene.gameEditorMode in {"SM64", "Homebrew"}
 
     def draw(self, context):
         world = context.scene.world

--- a/fast64_internal/f3d/f3d_material.py
+++ b/fast64_internal/f3d/f3d_material.py
@@ -3405,10 +3405,6 @@ class DefaultRDPSettingsPanel(Panel):
     bl_context = "world"
     bl_options = {"HIDE_HEADER"}
 
-    @classmethod
-    def poll(cls, context):
-        return context.scene.gameEditorMode != "OOT"
-
     def draw(self, context):
         world = context.scene.world
         layout = self.layout

--- a/fast64_internal/f3d/f3d_material.py
+++ b/fast64_internal/f3d/f3d_material.py
@@ -3407,7 +3407,7 @@ class DefaultRDPSettingsPanel(Panel):
 
     @classmethod
     def poll(cls, context):
-        return context.scene.gameEditorMode in {"SM64", "Homebrew"}
+        return context.scene.gameEditorMode != "OOT"
 
     def draw(self, context):
         world = context.scene.world

--- a/fast64_internal/f3d/f3d_material.py
+++ b/fast64_internal/f3d/f3d_material.py
@@ -1275,6 +1275,29 @@ class F3DPanel(Panel):
             r.label(text="Use Cel Shading (requires F3DEX3)", icon="TRIA_RIGHT")
 
 
+class F3DMeshPanel(Panel):
+    bl_label = "F3D Mesh Inspector"
+    bl_idname = "F3D_PT_Mesh_Inspector"
+    bl_space_type = "PROPERTIES"
+    bl_region_type = "WINDOW"
+    bl_context = "object"
+    bl_options = {"HIDE_HEADER"}
+
+    @classmethod
+    def poll(cls, context):
+        return context.object.type == "MESH"
+
+    def draw(self, context):
+        is_f3dex = get_F3D_GBI().F3DEX_GBI
+        col = self.layout.box().column()
+        col.box().label(text=self.bl_label, icon="MESH_DATA")
+        row = col.row()
+        row.enabled = is_f3dex
+        row.prop(context.object, "use_f3d_culling")
+        if not is_f3dex:
+            col.label(text="Only available in F3DEX and up", icon="INFO")
+
+
 def ui_tileScroll(tex, name, layout):
     row = layout.row()
     row.label(text=name)
@@ -4429,6 +4452,7 @@ mat_classes = (
     ReloadDefaultF3DPresets,
     UpdateF3DNodes,
     F3DRenderSettingsPanel,
+    F3DMeshPanel,
 )
 
 
@@ -4493,8 +4517,7 @@ def mat_register():
     Scene.f3d_simple = bpy.props.BoolProperty(name="Display Simple", default=True)
 
     Object.use_f3d_culling = bpy.props.BoolProperty(
-        name="Enable Culling (Applies to F3DEX and up)",
-        default=True,
+        name="Use Culling", description="F3DEX: Adds culling vertices", default=True
     )
     Object.ignore_render = bpy.props.BoolProperty(name="Ignore Render")
     Object.ignore_collision = bpy.props.BoolProperty(name="Ignore Collision")

--- a/fast64_internal/f3d/f3d_material.py
+++ b/fast64_internal/f3d/f3d_material.py
@@ -1288,13 +1288,13 @@ class F3DMeshPanel(Panel):
         return context.object.type == "MESH"
 
     def draw(self, context):
-        is_f3dex = get_F3D_GBI().F3DEX_GBI
+        new_gbi = not get_F3D_GBI().F3D_OLD_GBI
         col = self.layout.box().column()
         col.box().label(text=self.bl_label, icon="MESH_DATA")
         row = col.row()
-        row.enabled = is_f3dex
+        row.enabled = new_gbi
         row.prop(context.object, "use_f3d_culling")
-        if not is_f3dex:
+        if not new_gbi:
             col.label(text="Only available in F3DEX and up", icon="INFO")
 
 

--- a/fast64_internal/f3d/f3d_material_presets.py
+++ b/fast64_internal/f3d/f3d_material_presets.py
@@ -6402,7 +6402,8 @@ homebrew_and_oot = {
 material_presets = {
     "homebrew": homebrew_and_oot,
     "oot": {
-        f"oot_{key}": value + 'f3d_mat.presetName = "Oot " +  f3d_mat.presetName' for key, value in homebrew_and_oot.items()
+        f"oot_{key}": value + 'f3d_mat.presetName = "Oot " +  f3d_mat.presetName'
+        for key, value in homebrew_and_oot.items()
     },
     "oot_f3dex3": {
         "oot_cel_4_blend_tex_vcol_ao": oot_cel_4_blend_tex_vcol_ao,

--- a/fast64_internal/f3d/f3d_material_presets.py
+++ b/fast64_internal/f3d/f3d_material_presets.py
@@ -2,7 +2,7 @@
 # Setting f3d_mat.rdp_settings.rendermode_preset_cycle_1/2 will be propagated to the individual rendermode props
 # f3d_mat.presetName is set last because changing any prop sets the preset to Custom
 
-oot_shaded_environment_mapped = """
+shaded_environment_mapped = """
 import bpy
 f3d_mat = bpy.context.material.f3d_mat
 
@@ -112,10 +112,10 @@ f3d_mat.draw_layer.sm64 = '1'
 f3d_mat.draw_layer.oot = 'Opaque'
 bpy.context.material.f3d_update_flag = False
 f3d_mat.use_default_lighting = f3d_mat.use_default_lighting # Force nodes update
-f3d_mat.presetName = 'Oot Shaded Environment Mapped'
+f3d_mat.presetName = 'Shaded Environment Mapped'
 """
 
-oot_shaded_environment_mapped_transparent = """
+shaded_environment_mapped_transparent = """
 import bpy
 f3d_mat = bpy.context.material.f3d_mat
 
@@ -225,10 +225,10 @@ f3d_mat.draw_layer.sm64 = '5'
 f3d_mat.draw_layer.oot = 'Transparent'
 bpy.context.material.f3d_update_flag = False
 f3d_mat.use_default_lighting = f3d_mat.use_default_lighting # Force nodes update
-f3d_mat.presetName = 'Oot Shaded Environment Mapped Transparent'
+f3d_mat.presetName = 'Shaded Environment Mapped Transparent'
 """
 
-oot_shaded_multitexture_lerp = """
+shaded_multitexture_lerp = """
 import bpy
 f3d_mat = bpy.context.material.f3d_mat
 
@@ -338,10 +338,10 @@ f3d_mat.draw_layer.sm64 = '1'
 f3d_mat.draw_layer.oot = 'Opaque'
 bpy.context.material.f3d_update_flag = False
 f3d_mat.use_default_lighting = f3d_mat.use_default_lighting # Force nodes update
-f3d_mat.presetName = 'Oot Shaded Multitexture Lerp'
+f3d_mat.presetName = 'Shaded Multitexture Lerp'
 """
 
-oot_shaded_multitexture_lerp_transparent = """
+shaded_multitexture_lerp_transparent = """
 import bpy
 f3d_mat = bpy.context.material.f3d_mat
 
@@ -451,10 +451,10 @@ f3d_mat.draw_layer.sm64 = '5'
 f3d_mat.draw_layer.oot = 'Transparent'
 bpy.context.material.f3d_update_flag = False
 f3d_mat.use_default_lighting = f3d_mat.use_default_lighting # Force nodes update
-f3d_mat.presetName = 'Oot Shaded Multitexture Lerp Transparent'
+f3d_mat.presetName = 'Shaded Multitexture Lerp Transparent'
 """
 
-oot_shaded_solid = """
+shaded_solid = """
 import bpy
 f3d_mat = bpy.context.material.f3d_mat
 
@@ -564,10 +564,10 @@ f3d_mat.draw_layer.sm64 = '1'
 f3d_mat.draw_layer.oot = 'Opaque'
 bpy.context.material.f3d_update_flag = False
 f3d_mat.use_default_lighting = f3d_mat.use_default_lighting # Force nodes update
-f3d_mat.presetName = 'Oot Shaded Solid'
+f3d_mat.presetName = 'Shaded Solid'
 """
 
-oot_shaded_solid_transparent = """
+shaded_solid_transparent = """
 import bpy
 f3d_mat = bpy.context.material.f3d_mat
 
@@ -677,10 +677,10 @@ f3d_mat.draw_layer.sm64 = '5'
 f3d_mat.draw_layer.oot = 'Transparent'
 bpy.context.material.f3d_update_flag = False
 f3d_mat.use_default_lighting = f3d_mat.use_default_lighting # Force nodes update
-f3d_mat.presetName = 'Oot Shaded Solid Transparent'
+f3d_mat.presetName = 'Shaded Solid Transparent'
 """
 
-oot_shaded_texture = """
+shaded_texture = """
 import bpy
 f3d_mat = bpy.context.material.f3d_mat
 
@@ -790,10 +790,10 @@ f3d_mat.draw_layer.sm64 = '1'
 f3d_mat.draw_layer.oot = 'Opaque'
 bpy.context.material.f3d_update_flag = False
 f3d_mat.use_default_lighting = f3d_mat.use_default_lighting # Force nodes update
-f3d_mat.presetName = 'Oot Shaded Texture'
+f3d_mat.presetName = 'Shaded Texture'
 """
 
-oot_shaded_texture_cutout = """
+shaded_texture_cutout = """
 import bpy
 f3d_mat = bpy.context.material.f3d_mat
 
@@ -903,10 +903,10 @@ f3d_mat.draw_layer.sm64 = '1'
 f3d_mat.draw_layer.oot = 'Opaque'
 bpy.context.material.f3d_update_flag = False
 f3d_mat.use_default_lighting = f3d_mat.use_default_lighting # Force nodes update
-f3d_mat.presetName = 'Oot Shaded Texture Cutout'
+f3d_mat.presetName = 'Shaded Texture Cutout'
 """
 
-oot_shaded_texture_transparent = """
+shaded_texture_transparent = """
 import bpy
 f3d_mat = bpy.context.material.f3d_mat
 
@@ -1016,10 +1016,10 @@ f3d_mat.draw_layer.sm64 = '5'
 f3d_mat.draw_layer.oot = 'Transparent'
 bpy.context.material.f3d_update_flag = False
 f3d_mat.use_default_lighting = f3d_mat.use_default_lighting # Force nodes update
-f3d_mat.presetName = 'Oot Shaded Texture Transparent'
+f3d_mat.presetName = 'Shaded Texture Transparent'
 """
 
-oot_unlit_texture = """
+unlit_texture = """
 import bpy
 f3d_mat = bpy.context.material.f3d_mat
 
@@ -1129,10 +1129,10 @@ f3d_mat.draw_layer.sm64 = '1'
 f3d_mat.draw_layer.oot = 'Opaque'
 bpy.context.material.f3d_update_flag = False
 f3d_mat.use_default_lighting = f3d_mat.use_default_lighting # Force nodes update
-f3d_mat.presetName = 'Oot Unlit Texture'
+f3d_mat.presetName = 'Unlit Texture'
 """
 
-oot_unlit_texture_cutout = """
+unlit_texture_cutout = """
 import bpy
 f3d_mat = bpy.context.material.f3d_mat
 
@@ -1242,10 +1242,10 @@ f3d_mat.draw_layer.sm64 = '1'
 f3d_mat.draw_layer.oot = 'Opaque'
 bpy.context.material.f3d_update_flag = False
 f3d_mat.use_default_lighting = f3d_mat.use_default_lighting # Force nodes update
-f3d_mat.presetName = 'Oot Unlit Texture Cutout'
+f3d_mat.presetName = 'Unlit Texture Cutout'
 """
 
-oot_unlit_texture_transparent = """
+unlit_texture_transparent = """
 import bpy
 f3d_mat = bpy.context.material.f3d_mat
 
@@ -1355,10 +1355,10 @@ f3d_mat.draw_layer.sm64 = '5'
 f3d_mat.draw_layer.oot = 'Transparent'
 bpy.context.material.f3d_update_flag = False
 f3d_mat.use_default_lighting = f3d_mat.use_default_lighting # Force nodes update
-f3d_mat.presetName = 'Oot Unlit Texture Transparent'
+f3d_mat.presetName = 'Unlit Texture Transparent'
 """
 
-oot_vertex_colored_texture = """
+vertex_colored_texture = """
 import bpy
 f3d_mat = bpy.context.material.f3d_mat
 
@@ -1468,10 +1468,10 @@ f3d_mat.draw_layer.sm64 = '1'
 f3d_mat.draw_layer.oot = 'Opaque'
 bpy.context.material.f3d_update_flag = False
 f3d_mat.use_default_lighting = f3d_mat.use_default_lighting # Force nodes update
-f3d_mat.presetName = 'Oot Vertex Colored Texture'
+f3d_mat.presetName = 'Vertex Colored Texture'
 """
 
-oot_vertex_colored_texture_cutout = """
+vertex_colored_texture_cutout = """
 import bpy
 f3d_mat = bpy.context.material.f3d_mat
 
@@ -1581,10 +1581,10 @@ f3d_mat.draw_layer.sm64 = '1'
 f3d_mat.draw_layer.oot = 'Opaque'
 bpy.context.material.f3d_update_flag = False
 f3d_mat.use_default_lighting = f3d_mat.use_default_lighting # Force nodes update
-f3d_mat.presetName = 'Oot Vertex Colored Texture Cutout'
+f3d_mat.presetName = 'Vertex Colored Texture Cutout'
 """
 
-oot_vertex_colored_texture_transparent = """
+vertex_colored_texture_transparent = """
 import bpy
 f3d_mat = bpy.context.material.f3d_mat
 
@@ -1694,7 +1694,7 @@ f3d_mat.draw_layer.sm64 = '5'
 f3d_mat.draw_layer.oot = 'Transparent'
 bpy.context.material.f3d_update_flag = False
 f3d_mat.use_default_lighting = f3d_mat.use_default_lighting # Force nodes update
-f3d_mat.presetName = 'Oot Vertex Colored Texture Transparent'
+f3d_mat.presetName = 'Vertex Colored Texture Transparent'
 """
 
 sm64_decal = """
@@ -3265,7 +3265,7 @@ f3d_mat.use_default_lighting = f3d_mat.use_default_lighting # Force nodes update
 f3d_mat.presetName = 'Sm64 Vertex Colored Texture Transparent'
 """
 
-oot_shaded_multitexture_lerp_transparent_vertex_alpha = """
+shaded_multitexture_lerp_transparent_vertex_alpha = """
 
 import bpy
 f3d_mat = bpy.context.material.f3d_mat
@@ -3376,10 +3376,10 @@ f3d_mat.draw_layer.sm64 = '5'
 f3d_mat.draw_layer.oot = 'Transparent'
 bpy.context.material.f3d_update_flag = False
 f3d_mat.use_default_lighting = f3d_mat.use_default_lighting # Force nodes update
-f3d_mat.presetName = 'Oot Shaded Multitexture Lerp Transparent Vertex Alpha'
+f3d_mat.presetName = 'Shaded Multitexture Lerp Transparent Vertex Alpha'
 """
 
-oot_shaded_texture_transparent_vertex_alpha = """
+shaded_texture_transparent_vertex_alpha = """
 
 import bpy
 f3d_mat = bpy.context.material.f3d_mat
@@ -3490,7 +3490,7 @@ f3d_mat.draw_layer.sm64 = '5'
 f3d_mat.draw_layer.oot = 'Transparent'
 bpy.context.material.f3d_update_flag = False
 f3d_mat.use_default_lighting = f3d_mat.use_default_lighting # Force nodes update
-f3d_mat.presetName = 'Oot Shaded Texture Transparent Vertex Alpha'
+f3d_mat.presetName = 'Shaded Texture Transparent Vertex Alpha'
 """
 
 oot_cel_4_blend_tex_vcol_ao = """
@@ -6380,25 +6380,29 @@ f3d_mat.use_default_lighting = f3d_mat.use_default_lighting # Force nodes update
 f3d_mat.presetName = 'Oot Water Mult Specular Fresnel'
 """
 
+homebrew_and_oot = {
+    "shaded_environment_mapped": shaded_environment_mapped,
+    "shaded_environment_mapped_transparent": shaded_environment_mapped_transparent,
+    "shaded_multitexture_lerp": shaded_multitexture_lerp,
+    "shaded_multitexture_lerp_transparent": shaded_multitexture_lerp_transparent,
+    "shaded_solid": shaded_solid,
+    "shaded_multitexture_lerp_transparent_vertex_alpha": shaded_multitexture_lerp_transparent_vertex_alpha,
+    "shaded_solid_transparent": shaded_solid_transparent,
+    "shaded_texture": shaded_texture,
+    "shaded_texture_cutout": shaded_texture_cutout,
+    "shaded_texture_transparent": shaded_texture_transparent,
+    "shaded_texture_transparent_vertex_alpha": shaded_texture_transparent_vertex_alpha,
+    "unlit_texture": unlit_texture,
+    "unlit_texture_cutout": unlit_texture_cutout,
+    "unlit_texture_transparent": unlit_texture_transparent,
+    "vertex_colored_texture": vertex_colored_texture,
+    "vertex_colored_texture_cutout": vertex_colored_texture_cutout,
+    "vertex_colored_texture_transparent": vertex_colored_texture_transparent,
+}
 material_presets = {
+    "homebrew": homebrew_and_oot,
     "oot": {
-        "oot_shaded_environment_mapped": oot_shaded_environment_mapped,
-        "oot_shaded_environment_mapped_transparent": oot_shaded_environment_mapped_transparent,
-        "oot_shaded_multitexture_lerp": oot_shaded_multitexture_lerp,
-        "oot_shaded_multitexture_lerp_transparent": oot_shaded_multitexture_lerp_transparent,
-        "oot_shaded_multitexture_lerp_transparent_vertex_alpha": oot_shaded_multitexture_lerp_transparent_vertex_alpha,
-        "oot_shaded_solid": oot_shaded_solid,
-        "oot_shaded_solid_transparent": oot_shaded_solid_transparent,
-        "oot_shaded_texture": oot_shaded_texture,
-        "oot_shaded_texture_cutout": oot_shaded_texture_cutout,
-        "oot_shaded_texture_transparent": oot_shaded_texture_transparent,
-        "oot_shaded_texture_transparent_vertex_alpha": oot_shaded_texture_transparent_vertex_alpha,
-        "oot_unlit_texture": oot_unlit_texture,
-        "oot_unlit_texture_cutout": oot_unlit_texture_cutout,
-        "oot_unlit_texture_transparent": oot_unlit_texture_transparent,
-        "oot_vertex_colored_texture": oot_vertex_colored_texture,
-        "oot_vertex_colored_texture_cutout": oot_vertex_colored_texture_cutout,
-        "oot_vertex_colored_texture_transparent": oot_vertex_colored_texture_transparent,
+        key: value + 'f3d_mat.presetName = "OOT " +  f3d_mat.presetName' for key, value in homebrew_and_oot.items()
     },
     "oot_f3dex3": {
         "oot_cel_4_blend_tex_vcol_ao": oot_cel_4_blend_tex_vcol_ao,

--- a/fast64_internal/f3d/f3d_material_presets.py
+++ b/fast64_internal/f3d/f3d_material_presets.py
@@ -6402,7 +6402,7 @@ homebrew_and_oot = {
 material_presets = {
     "homebrew": homebrew_and_oot,
     "oot": {
-        key: value + 'f3d_mat.presetName = "OOT " +  f3d_mat.presetName' for key, value in homebrew_and_oot.items()
+        f"oot_{key}": value + 'f3d_mat.presetName = "Oot " +  f3d_mat.presetName' for key, value in homebrew_and_oot.items()
     },
     "oot_f3dex3": {
         "oot_cel_4_blend_tex_vcol_ao": oot_cel_4_blend_tex_vcol_ao,

--- a/fast64_internal/f3d/f3d_writer.py
+++ b/fast64_internal/f3d/f3d_writer.py
@@ -447,7 +447,7 @@ def saveStaticModel(
             fMesh = fModel.addMesh(obj.original_name, ownerName, drawLayerName, False, obj)
             fMeshes[drawLayer] = fMesh
 
-            if obj.use_f3d_culling and (fModel.f3d.F3DEX_GBI or fModel.f3d.F3DEX_GBI_2):
+            if obj.use_f3d_culling and fModel.f3d.F3DEX_GBI:
                 addCullCommand(obj, fMesh, transformMatrix, fModel.matWriteMethod)
         else:
             fMesh = fMeshes[drawLayer]

--- a/fast64_internal/f3d/f3d_writer.py
+++ b/fast64_internal/f3d/f3d_writer.py
@@ -447,7 +447,7 @@ def saveStaticModel(
             fMesh = fModel.addMesh(obj.original_name, ownerName, drawLayerName, False, obj)
             fMeshes[drawLayer] = fMesh
 
-            if obj.use_f3d_culling and fModel.f3d.F3DEX_GBI:
+            if obj.use_f3d_culling and not fModel.f3d.F3D_OLD_GBI:
                 addCullCommand(obj, fMesh, transformMatrix, fModel.matWriteMethod)
         else:
             fMesh = fMeshes[drawLayer]

--- a/fast64_internal/sm64/sm64_geolayout_bone.py
+++ b/fast64_internal/sm64/sm64_geolayout_bone.py
@@ -255,7 +255,6 @@ class GeolayoutObjectPanel(Panel):
             box.prop(obj, "is_occlusion_planes")
             if obj.is_occlusion_planes and (not obj.ignore_render or not obj.ignore_collision):
                 box.label(icon="INFO", text="Suggest Ignore Render & Ignore Collision.")
-        col.prop(obj, "use_f3d_culling")
         if context.scene.exportInlineF3D:
             col.prop(obj, "bleed_independently")
         if obj_scale_is_unified(obj) and len(obj.modifiers) == 0:


### PR DESCRIPTION
1. Moved culling into a new f3d model panel
2. Show default rdp world defaults in all game modes 
3. Use OOT's material presets for homebrew mode as they are versatile enough to be used in a homebrew context in my opinion, please comment on this