### PR TITLE
[F3D] Upgrade improvements (+related)

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -80,7 +80,6 @@ class F3D_GlobalSettingsPanel(bpy.types.Panel):
         prop_split(col, context.scene, "f3d_type", "F3D Microcode")
         col.prop(context.scene, "saveTextures")
         col.prop(context.scene, "f3d_simple", text="Simple Material UI")
-        col.prop(context.scene, "generateF3DNodeGraph", text="Generate F3D Node Graph For Materials")
         col.prop(context.scene, "exportInlineF3D", text="Bleed and Inline Material Exports")
         if context.scene.exportInlineF3D:
             multilineLabel(
@@ -243,22 +242,7 @@ class UpgradeF3DMaterialsDialog(bpy.types.Operator):
         layout = self.layout
         if self.done:
             layout.label(text="Success!")
-            box = layout.box()
-            box.label(text="Materials were successfully upgraded.")
-            box.label(text="Please purge your remaining materials.")
-
-            purge_box = box.box()
-            purge_box.scale_y = 0.25
-            purge_box.separator(factor=0.5)
-            purge_box.label(text="How to purge:")
-            purge_box.separator(factor=0.5)
-            purge_box.label(text="Go to the outliner, change the display mode")
-            purge_box.label(text='to "Orphan Data" (broken heart icon)')
-            purge_box.separator(factor=0.25)
-            purge_box.label(text='Click "Purge" in the top right corner.')
-            purge_box.separator(factor=0.25)
-            purge_box.label(text="Purge multiple times until the node groups")
-            purge_box.label(text="are gone.")
+            layout.label(text="Materials were successfully upgraded.")
             layout.separator(factor=0.25)
             layout.label(text="You may click anywhere to close this dialog.")
             return
@@ -282,7 +266,6 @@ class UpgradeF3DMaterialsDialog(bpy.types.Operator):
 
         upgradeF3DVersionAll(
             [obj for obj in bpy.data.objects if obj.type == "MESH"],
-            list(bpy.data.armatures),
             MatUpdateConvert.version,
         )
         self.done = True
@@ -408,7 +391,6 @@ def register():
         name="Game", default="SM64", items=gameEditorEnum, update=gameEditorUpdate
     )
     bpy.types.Scene.saveTextures = bpy.props.BoolProperty(name="Save Textures As PNGs (Breaks CI Textures)")
-    bpy.types.Scene.generateF3DNodeGraph = bpy.props.BoolProperty(name="Generate F3D Node Graph", default=True)
     bpy.types.Scene.exportHiddenGeometry = bpy.props.BoolProperty(name="Export Hidden Geometry", default=True)
     bpy.types.Scene.exportInlineF3D = bpy.props.BoolProperty(
         name="Bleed and Inline Material Exports",
@@ -444,7 +426,6 @@ def unregister():
     del bpy.types.Scene.ignoreTextureRestrictions
     del bpy.types.Scene.saveTextures
     del bpy.types.Scene.gameEditorMode
-    del bpy.types.Scene.generateF3DNodeGraph
     del bpy.types.Scene.exportHiddenGeometry
     del bpy.types.Scene.blenderF3DScale
 

--- a/fast64_internal/f3d/f3d_material.py
+++ b/fast64_internal/f3d/f3d_material.py
@@ -2572,8 +2572,8 @@ class RecreateF3DNodes(Operator):
             self.report({"ERROR"}, "No active material.")
         else:
             node_tree_copy(get_f3d_node_tree(), material.node_tree)
-            update_all_node_values(material, context)
             createScenePropertiesForMaterial(material)
+            update_all_node_values(material, context)
             self.report({"INFO"}, "Success!")
         return {"FINISHED"}
 

--- a/fast64_internal/f3d/f3d_material_helpers.py
+++ b/fast64_internal/f3d/f3d_material_helpers.py
@@ -1,4 +1,5 @@
 import bpy
+from bpy.types import NodeTree
 
 
 class F3DMaterial_UpdateLock:
@@ -34,3 +35,60 @@ class F3DMaterial_UpdateLock:
     def unlock_material(self):
         if hasattr(self.material, "f3d_update_flag"):
             self.material.f3d_update_flag = False
+
+
+EXCLUDE_FROM_NODE = (
+    "rna_type",
+    "type",
+    "inputs",
+    "outputs",
+    "dimensions",
+    "interface",
+    "internal_links",
+    "texture_mapping",
+    "color_mapping",
+    "image_user",
+)
+EXCLUDE_FROM_INPUT_OUTPUT = (
+    "rna_type",
+    "label",
+    "identifier",
+    "is_output",
+    "is_linked",
+    "is_multi_input",
+    "node",
+    "bl_idname",
+    "default_value",
+)
+
+
+def node_tree_copy(src: NodeTree, dst: NodeTree):
+    def copy_attributes(src, dst, excludes=None):
+        fails, excludes = [], excludes if excludes else []
+        attributes = (attr.identifier for attr in src.bl_rna.properties if attr.identifier not in excludes)
+        for attr in attributes:
+            try:
+                setattr(dst, attr, getattr(src, attr))
+            except Exception as exc:  # pylint: disable=broad-except
+                fails.append(exc)
+        if fails:
+            raise AttributeError("Failed to copy all attributes: " + str(fails))
+
+    dst.nodes.clear()
+    dst.links.clear()
+
+    node_mapping = {}  # To not have to look up the new node for linking
+    for src_node in src.nodes:  # Copy all nodes
+        new_node = dst.nodes.new(src_node.bl_idname)
+        copy_attributes(src_node, new_node, excludes=EXCLUDE_FROM_NODE)
+        node_mapping[src_node] = new_node
+    for src_node, dst_node in node_mapping.items():
+        for i, src_input in enumerate(src_node.inputs):  # Link all nodes
+            for link in src_input.links:
+                connected_node = dst.nodes[link.from_node.name]
+                dst.links.new(connected_node.outputs[link.from_socket.name], dst_node.inputs[i])
+
+        for src_input, dst_input in zip(src_node.inputs, dst_node.inputs):  # Copy all inputs
+            copy_attributes(src_input, dst_input, excludes=EXCLUDE_FROM_INPUT_OUTPUT)
+        for src_output, dst_output in zip(src_node.outputs, dst_node.outputs):  # Copy all outputs
+            copy_attributes(src_output, dst_output, excludes=EXCLUDE_FROM_INPUT_OUTPUT)

--- a/fast64_internal/f3d/f3d_material_helpers.py
+++ b/fast64_internal/f3d/f3d_material_helpers.py
@@ -59,6 +59,7 @@ EXCLUDE_FROM_INPUT_OUTPUT = (
     "node",
     "bl_idname",
     "default_value",
+    "is_unavailable",
 )
 
 

--- a/fast64_internal/f3d_material_converter.py
+++ b/fast64_internal/f3d_material_converter.py
@@ -267,7 +267,7 @@ class MatUpdateConvert(bpy.types.Operator):
     version = 5
     bl_idname = "object.convert_f3d_update"
     bl_label = "Recreate F3D Materials As v" + str(version)
-    bl_options = {"REGISTER", "UNDO", "PRESET"}
+    bl_options = {"UNDO"}
 
     update_conv_all: bpy.props.BoolProperty(default=True)
 

--- a/fast64_internal/f3d_material_converter.py
+++ b/fast64_internal/f3d_material_converter.py
@@ -154,9 +154,9 @@ def convertF3DtoNewVersion(
         material.is_f3d, material.f3d_update_flag = True, False
         material.mat_ver = 5
 
+        createScenePropertiesForMaterial(material)
         with bpy.context.temp_override(material=material):
             update_all_node_values(material, bpy.context)  # Reload everything
-        createScenePropertiesForMaterial(material)
 
     except Exception as exc:
         print("Failed to upgrade", material.name)

--- a/fast64_internal/f3d_material_converter.py
+++ b/fast64_internal/f3d_material_converter.py
@@ -143,7 +143,7 @@ def convertF3DtoNewVersion(
             oldPreset = material.get("f3d_preset")
 
         update_preset_manual_v4(material, getV4PresetName(oldPreset))
-        material.is_f3d = False # TODO: We can´t just lock, so make this temporarly false
+        material.is_f3d = False  # TODO: We can´t just lock, so make this temporarly false
         # Convert before node tree changes, as old materials store some values in the actual nodes
         if material.mat_ver <= 3:
             convertToNewMat(material, material)

--- a/fast64_internal/f3d_material_converter.py
+++ b/fast64_internal/f3d_material_converter.py
@@ -143,14 +143,15 @@ def convertF3DtoNewVersion(
             oldPreset = material.get("f3d_preset")
 
         update_preset_manual_v4(material, getV4PresetName(oldPreset))
-        material.is_f3d = False  # TODO: We can´t just lock, so make this temporarly false
+        # HACK: We can´t just lock, so make is_f3d temporarly false
+        material.is_f3d, material.f3d_update_flag = False, True
         # Convert before node tree changes, as old materials store some values in the actual nodes
         if material.mat_ver <= 3:
             convertToNewMat(material, material)
 
         node_tree_copy(f3d_node_tree, material.node_tree)
 
-        material.is_f3d = True
+        material.is_f3d, material.f3d_update_flag = True, False
         material.mat_ver = 5
 
         with bpy.context.temp_override(material=material):

--- a/fast64_internal/f3d_material_converter.py
+++ b/fast64_internal/f3d_material_converter.py
@@ -1,14 +1,16 @@
 # This is not in the f3d package since copying materials requires copying collision settings from all games as well.
 
-import bpy, math
+import bpy
 from bpy.utils import register_class, unregister_class
 from .f3d.f3d_material import *
-from .sm64.sm64_collision import CollisionSettings
+from .f3d.f3d_material_helpers import node_tree_copy
 from .utility import *
 from bl_operators.presets import AddPresetBase
 
 
-def upgradeF3DVersionAll(objs, armatures, version):
+def upgradeF3DVersionAll(objs, version):
+    f3d_node_tree = get_f3d_node_tree()
+
     # Remove original v2 node groups so that they can be recreated.
     deleteGroups = []
     for node_tree in bpy.data.node_groups:
@@ -23,33 +25,15 @@ def upgradeF3DVersionAll(objs, armatures, version):
     # handles cases where materials are used in multiple objects
     materialDict = {}
     for obj in objs:
-        upgradeF3DVersionOneObject(obj, materialDict, version)
-
-    for armature in armatures:
-        for bone in armature.bones:
-            if bone.geo_cmd == "Switch":
-                for switchOption in bone.switch_options:
-                    if switchOption.switchType == "Material":
-                        if switchOption.materialOverride in materialDict:
-                            switchOption.materialOverride = materialDict[switchOption.materialOverride]
-                        for i in range(len(switchOption.specificOverrideArray)):
-                            material = switchOption.specificOverrideArray[i].material
-                            if material in materialDict:
-                                switchOption.specificOverrideArray[i].material = materialDict[material]
-                        for i in range(len(switchOption.specificIgnoreArray)):
-                            material = switchOption.specificIgnoreArray[i].material
-                            if material in materialDict:
-                                switchOption.specificIgnoreArray[i].material = materialDict[material]
+        upgradeF3DVersionOneObject(obj, materialDict, f3d_node_tree)
 
 
-def upgradeF3DVersionOneObject(obj, materialDict, version):
+def upgradeF3DVersionOneObject(obj, materialDict, f3d_node_tree: bpy.types.NodeTree):
     for index in range(len(obj.material_slots)):
         material = obj.material_slots[index].material
-        if material is not None and material.is_f3d:
-            if material in materialDict:
-                obj.material_slots[index].material = materialDict[material]
-            else:
-                convertF3DtoNewVersion(obj, index, material, materialDict, version)
+        if material is not None and material.is_f3d and material not in materialDict:
+            convertF3DtoNewVersion(obj, index, material, f3d_node_tree)
+            materialDict[material] = material
 
 
 V4PresetName = {
@@ -113,9 +97,10 @@ def set_best_draw_layer_for_materials():
             mat: bpy.types.Material = obj.material_slots[p.material_index].material
             if not has_valid_mat_ver(mat) or mat.mat_ver >= 4 or mat.name in finished_mats:
                 continue
-
+            mat.f3d_update_flag = True
             # default to object's draw layer
-            mat.f3d_mat.draw_layer.sm64 = obj.draw_layer_static
+            with bpy.context.temp_override(material=mat):
+                mat.f3d_mat.draw_layer.sm64 = obj.draw_layer_static
 
             if len(obj.vertex_groups) == 0:
                 continue  # object doesn't have vertex groups
@@ -126,8 +111,10 @@ def set_best_draw_layer_for_materials():
                 # check for matching bone from group name
                 bone = bone_map.get(group.name)
                 if bone is not None:
+                    mat.f3d_update_flag = True
                     # override material draw later with bone's draw layer
-                    mat.f3d_mat.draw_layer.sm64 = bone.draw_layer
+                    with bpy.context.temp_override(material=mat):
+                        mat.f3d_mat.draw_layer.sm64 = bone.draw_layer
             finished_mats.add(mat.name)
 
     for obj in objects:
@@ -138,11 +125,15 @@ def set_best_draw_layer_for_materials():
             if not has_valid_mat_ver(mat) or mat.mat_ver >= 4 or mat.name in finished_mats:
                 continue
 
-            mat.f3d_mat.draw_layer.sm64 = obj.draw_layer_static
+            mat.f3d_update_flag = True
+            with bpy.context.temp_override(material=mat):
+                mat.f3d_mat.draw_layer.sm64 = obj.draw_layer_static
             finished_mats.add(mat.name)
 
 
-def convertF3DtoNewVersion(obj: bpy.types.Object | bpy.types.Bone, index, material, materialDict, version):
+def convertF3DtoNewVersion(
+    obj: bpy.types.Object | bpy.types.Bone, index: int, material, f3d_node_tree: bpy.types.NodeTree
+):
     try:
         if not has_valid_mat_ver(material):
             return
@@ -151,27 +142,24 @@ def convertF3DtoNewVersion(obj: bpy.types.Object | bpy.types.Bone, index, materi
         else:
             oldPreset = material.get("f3d_preset")
 
-        newMat = createF3DMat(obj, preset=getV4PresetName(oldPreset), index=index)
+        update_preset_manual_v4(material, getV4PresetName(oldPreset))
+        material.is_f3d = False # TODO: We can´t just lock, so make this temporarly false
+        # Convert before node tree changes, as old materials store some values in the actual nodes
+        if material.mat_ver <= 3:
+            convertToNewMat(material, material)
 
-        if material.mat_ver > 3:
-            copyPropertyGroup(material.f3d_mat, newMat.f3d_mat)
-        else:
-            convertToNewMat(newMat, material)
+        node_tree_copy(f3d_node_tree, material.node_tree)
 
-        newMat.f3d_mat.draw_layer.sm64 = material.f3d_mat.draw_layer.sm64
+        material.is_f3d = True
+        material.mat_ver = 5
 
-        copyPropertyGroup(material.ootMaterial, newMat.ootMaterial)
-        copyPropertyGroup(material.flipbookGroup, newMat.flipbookGroup)
-        copyPropertyGroup(material.ootCollisionProperty, newMat.ootCollisionProperty)
+        with bpy.context.temp_override(material=material):
+            update_all_node_values(material, bpy.context)  # Reload everything
+        createScenePropertiesForMaterial(material)
 
-        colSettings = CollisionSettings()
-        colSettings.load(material)
-        colSettings.apply(newMat)
-
-        updateMatWithNewVersionName(newMat, material, materialDict, version)
     except Exception as exc:
         print("Failed to upgrade", material.name)
-        print(exc)
+        traceback.print_exc()
 
 
 def convertAllBSDFtoF3D(objs, renameUV):
@@ -238,14 +226,6 @@ def updateMatWithName(f3dMat, oldMat, materialDict):
     materialDict[oldMat] = f3dMat
 
 
-def updateMatWithNewVersionName(f3dMat, oldMat, materialDict, version):
-    name = oldMat.name
-    f3dMat.name = name
-    oldMat.name = name + "_v" + str(oldMat.mat_ver)
-    update_preset_manual(f3dMat, bpy.context)
-    materialDict[oldMat] = f3dMat
-
-
 class BSDFConvert(bpy.types.Operator):
     # set bl_ properties
     bl_idname = "object.convert_bsdf"
@@ -288,6 +268,8 @@ class MatUpdateConvert(bpy.types.Operator):
     bl_label = "Recreate F3D Materials As v" + str(version)
     bl_options = {"REGISTER", "UNDO", "PRESET"}
 
+    update_conv_all: bpy.props.BoolProperty(default=True)
+
     # Called on demand (i.e. button press, menu item)
     # Can also be called from operator search menu (Spacebar)
     def execute(self, context):
@@ -295,10 +277,9 @@ class MatUpdateConvert(bpy.types.Operator):
             if context.mode != "OBJECT":
                 raise PluginError("Operator can only be used in object mode.")
 
-            if context.scene.update_conv_all:
+            if self.update_conv_all:
                 upgradeF3DVersionAll(
                     [obj for obj in bpy.data.objects if obj.type == "MESH"],
-                    bpy.data.armatures,
                     self.version,
                 )
             else:
@@ -308,7 +289,7 @@ class MatUpdateConvert(bpy.types.Operator):
                     raise PluginError("Mesh not selected.")
 
                 obj = context.selected_objects[0]
-                upgradeF3DVersionOneObject(obj, {}, self.version)
+                upgradeF3DVersionOneObject(obj, {}, get_f3d_node_tree())
 
         except Exception as e:
             raisePluginError(self, e)
@@ -336,7 +317,8 @@ class F3DMaterialConverterPanel(bpy.types.Panel):
         self.layout.operator(BSDFConvert.bl_idname)
         self.layout.prop(context.scene, "bsdf_conv_all")
         self.layout.prop(context.scene, "rename_uv_maps")
-        self.layout.operator(MatUpdateConvert.bl_idname)
+        op = self.layout.operator(MatUpdateConvert.bl_idname)
+        op.update_conv_all = context.scene.update_conv_all
         self.layout.prop(context.scene, "update_conv_all")
         self.layout.operator(ReloadDefaultF3DPresets.bl_idname)
 

--- a/fast64_internal/sm64/sm64_collision.py
+++ b/fast64_internal/sm64/sm64_collision.py
@@ -470,32 +470,6 @@ def collisionVertIndex(vert, vertArray):
     return None
 
 
-class CollisionSettings:
-    def __init__(self):
-        self.collision_type = "SURFACE_DEFAULT"
-        self.collision_type_simple = "SURFACE_DEFAULT"
-        self.collision_custom = "SURFACE_DEFAULT"
-        self.collision_all_options = False
-        self.use_collision_param = False
-        self.collision_param = "0x0000"
-
-    def load(self, material):
-        self.collision_type = material.collision_type
-        self.collision_type_simple = material.collision_type_simple
-        self.collision_custom = material.collision_custom
-        self.collision_all_options = material.collision_all_options
-        self.use_collision_param = material.use_collision_param
-        self.collision_param = material.collision_param
-
-    def apply(self, material):
-        material.collision_type = self.collision_type
-        material.collision_type_simple = self.collision_type_simple
-        material.collision_custom = self.collision_custom
-        material.collision_all_options = self.collision_all_options
-        material.use_collision_param = self.use_collision_param
-        material.collision_param = self.collision_param
-
-
 class SM64_ExportCollision(bpy.types.Operator):
     # set bl_ properties
     bl_idname = "object.sm64_export_collision"

--- a/fast64_internal/utility.py
+++ b/fast64_internal/utility.py
@@ -281,8 +281,16 @@ def recursiveCopyOldPropertyGroup(oldProp, newProp):
         ):
             newCollection = getattr(newProp, sub_value_attr)
             recursiveCopyOldPropertyGroup(sub_value, newCollection)
-        else:
-            setattr(newProp, sub_value_attr, sub_value)
+        elif not isinstance(getattr(newProp, sub_value_attr), bpy.types.PropertyGroup) and not type(
+            getattr(newProp, sub_value_attr, None)
+        ).__name__ in (
+            "bpy_prop_collection_idprop",
+            "IDPropertyGroup",
+        ):
+            try:
+                setattr(newProp, sub_value_attr, sub_value)
+            except Exception as e:
+                print(e)
 
 
 def propertyCollectionEquals(oldProp, newProp):

--- a/fast64_internal/utility.py
+++ b/fast64_internal/utility.py
@@ -251,6 +251,8 @@ def get_attr_or_property(prop: dict | object, attr: str, newProp: dict | object)
                 # change type hint to proper type
                 newPropDef: bpy.types.EnumProperty = newPropDef
                 return newPropDef.enum_items[val].identifier
+            elif "Bool" in newPropDef.bl_rna.name: # Should be "Boolean Definition"
+                return bool(val)
         except Exception as e:
             pass
     return val
@@ -274,19 +276,15 @@ def recursiveCopyOldPropertyGroup(oldProp, newProp):
         if sub_value_attr == "rna_type":
             continue
         sub_value = get_attr_or_property(oldProp, sub_value_attr, newProp)
+        new_value = get_attr_or_property(newProp, sub_value_attr, newProp)
 
-        if isinstance(sub_value, bpy.types.PropertyGroup) or type(sub_value).__name__ in (
+        if isinstance(new_value, bpy.types.PropertyGroup) or type(new_value).__name__ in (
             "bpy_prop_collection_idprop",
             "IDPropertyGroup",
         ):
             newCollection = getattr(newProp, sub_value_attr)
             recursiveCopyOldPropertyGroup(sub_value, newCollection)
-        elif not isinstance(getattr(newProp, sub_value_attr), bpy.types.PropertyGroup) and not type(
-            getattr(newProp, sub_value_attr, None)
-        ).__name__ in (
-            "bpy_prop_collection_idprop",
-            "IDPropertyGroup",
-        ):
+        else:
             try:
                 setattr(newProp, sub_value_attr, sub_value)
             except Exception as e:

--- a/fast64_internal/utility.py
+++ b/fast64_internal/utility.py
@@ -251,7 +251,7 @@ def get_attr_or_property(prop: dict | object, attr: str, newProp: dict | object)
                 # change type hint to proper type
                 newPropDef: bpy.types.EnumProperty = newPropDef
                 return newPropDef.enum_items[val].identifier
-            elif "Bool" in newPropDef.bl_rna.name: # Should be "Boolean Definition"
+            elif "Bool" in newPropDef.bl_rna.name:  # Should be "Boolean Definition"
                 return bool(val)
         except Exception as e:
             pass


### PR DESCRIPTION
Changes:
1. Upgrades now copy over the current f3d library node tree onto the existing material, this has a lot of benifits such as no longer needing to purge materials, no naming changes, carying over all props, removal of hacks for material pointer propreties a̶n̶d̶ ̶t̶h̶e̶ ̶s̶p̶e̶e̶d̶ ̶o̶f̶ ̶u̶p̶g̶r̶a̶d̶e̶s̶  and on par speed (sometimes faster and sometimes slower?). Orphan data text is removed from upgrade popup.
2. Removed generateF3DNodeGraph.
3. Added warning for old materials and an early return for such.
![image](https://github.com/Fast-64/fast64/assets/87947656/6ba36f76-9210-4105-9a90-ddb0cfe26af8)

4. Added "Recreate F3D Shader Nodes" operator, copies over the node tree from the f3d library and updates everything, useful for broken nodes of any kind.
5. Fixed f3d_light upgrading, along with now popping the props instead of just getting them.
6. Fixed recursiveCopyOldPropertyGroup which was interperting non set data as a non group, and trying to set new prop to it, it can also now fail and continue (for some reason not an issue before? maybe I should look into that).
7. Failed material upgrades now print traceback.
8. Fixed all the errors during draw layer updates by locking the updates and passing in a correct material context, fixed auto props error (Same as 6?? It should be having a lot of errors but it was somehow avoiding them previously?).

