### PR TITLE
[SM64/F3D] Area fog improvements

### DIFF
--- a/fast64_internal/f3d/f3d_gbi.py
+++ b/fast64_internal/f3d/f3d_gbi.py
@@ -2232,7 +2232,7 @@ class FAreaData:
 
 class FGlobalData:
     def __init__(self):
-        # dict of area index : FFogData
+        # dict of area index : FAreaData
         self.area_data = {}
         self.current_area_index = 1
 

--- a/fast64_internal/f3d/f3d_writer.py
+++ b/fast64_internal/f3d/f3d_writer.py
@@ -1416,8 +1416,9 @@ def saveOrGetF3DMaterial(material, fModel, obj, drawLayer, convertTextureData):
         fMaterial.mat_only_DL.commands.append(SPAttrOffsetZ(f3dMat.attroffs_z))
 
     if f3dMat.set_fog and f3dMat.rdp_settings.using_fog:
-        if f3dMat.use_global_fog and fModel.global_data.getCurrentAreaData() is not None:
-            fogData = fModel.global_data.getCurrentAreaData().fog_data
+        area = fModel.global_data.getCurrentAreaData()
+        if f3dMat.use_global_fog and area and area.fog_data:
+            fogData = area.fog_data
             fog_position = fogData.position
             fog_color = fogData.color
         else:

--- a/fast64_internal/sm64/sm64_geolayout_writer.py
+++ b/fast64_internal/sm64/sm64_geolayout_writer.py
@@ -473,9 +473,11 @@ def convertObjectToGeolayout(
         # cameraObj = getCameraObj(camera)
         meshGeolayout = saveCameraSettingsToGeolayout(geolayoutGraph, areaObj, obj, name + "_geo")
         rootObj = areaObj
-        fModel.global_data.addAreaData(
-            areaObj.areaIndex, FAreaData(FFogData(areaObj.area_fog_position, areaObj.area_fog_color))
-        )
+        if areaObj.fast64.sm64.area.set_fog:
+            fog_data = FFogData(areaObj.area_fog_position, areaObj.area_fog_color)
+        else:
+            fog_data = None
+        fModel.global_data.addAreaData(areaObj.areaIndex, FAreaData(fog_data))
 
     else:
         geolayoutGraph = GeolayoutGraph(name + "_geo")


### PR DESCRIPTION
Area fog is now a toggle in the area root
Renamed the text for global fog to area fog
Materials now by default show color and position if set fog is on, then in sm64 mode, if they are parented to an area that sets fog the option for area fog shows up with the area name in the text, if it's on a disabled column with the area's fog properties will also show
![image](https://github.com/Fast-64/fast64/assets/87947656/56deddc4-5a24-4854-8307-453d6609661f)
![image](https://github.com/Fast-64/fast64/assets/87947656/bffb439b-352b-4080-8328-ef3f9222aa99)
And now the toggle for global fog will not show in oot or homebrew!
![image](https://github.com/Fast-64/fast64/assets/87947656/913649b4-4c6c-47a5-8f3b-3b81096e1cc9)
