### PR TITLE
[F3D] Don´t hide properties that will get exported (specifically geo modes)

### DIFF
--- a/fast64_internal/f3d/f3d_material.py
+++ b/fast64_internal/f3d/f3d_material.py
@@ -411,14 +411,14 @@ def ui_geo_mode(settings, dataHolder, layout, useDropdown):
     if not useDropdown or dataHolder.menu_geo:
         disable_dependent = False  # Don't disable dependent props in world defaults
 
-        def indentGroup(
-            parent: UILayout, textOrProp: Union[str, "F3DMaterialProperty"], isText: bool, enable=True
-        ) -> UILayout:
+        def indentGroup(parent: UILayout, textOrProp: Union[str, "F3DMaterialProperty"], isText: bool) -> UILayout:
             c = parent.column(align=True)
             if isText:
                 c.label(text=textOrProp)
+                enable = True
             else:
                 c.prop(settings, textOrProp)
+                enable = getattr(settings, textOrProp)
             c = c.split(factor=0.1)
             c.label(text="")
             c = c.column(align=True)
@@ -441,14 +441,14 @@ def ui_geo_mode(settings, dataHolder, layout, useDropdown):
 
         inputGroup.prop(settings, "g_shade_smooth")
 
-        c = indentGroup(inputGroup, "g_lighting", False, settings.g_lighting)
+        c = indentGroup(inputGroup, "g_lighting", False)
         if ccWarnings and not shadeInCC and settings.g_lighting and not settings.g_tex_gen:
             multilineLabel(c, "Shade not used in CC, can disable\nlighting.", icon="INFO")
         if isF3DEX3:
             c.prop(settings, "g_packed_normals")
             c.prop(settings, "g_lighting_specular")
             c.prop(settings, "g_ambocclusion")
-        d = indentGroup(c, "g_tex_gen", False, settings.g_tex_gen)
+        d = indentGroup(c, "g_tex_gen", False)
         d.prop(settings, "g_tex_gen_linear")
 
         if lightFxPrereq and settings.g_fresnel_color:

--- a/fast64_internal/f3d/f3d_material.py
+++ b/fast64_internal/f3d/f3d_material.py
@@ -448,6 +448,7 @@ def ui_geo_mode(settings, dataHolder, layout, useDropdown):
             c.prop(settings, "g_packed_normals")
             c.prop(settings, "g_lighting_specular")
             c.prop(settings, "g_ambocclusion")
+            c.prop(settings, "g_fresnel_color")
         d = indentGroup(c, "g_tex_gen", False)
         d.prop(settings, "g_tex_gen_linear")
 
@@ -459,11 +460,7 @@ def ui_geo_mode(settings, dataHolder, layout, useDropdown):
             shadeColorLabel = "Lighting * vertex color"
         else:
             shadeColorLabel = "Lighting"
-        if isF3DEX3:
-            c = indentGroup(inputGroup, f"Shade color = {shadeColorLabel}:", True)
-            c.prop(settings, "g_fresnel_color")
-        else:
-            inputGroup.label(text=f"Shade color = {shadeColorLabel}:")
+        inputGroup.label(text=f"Shade color = {shadeColorLabel}:")
 
         shadowMapInShadeAlpha = False
         if settings.g_fog:

--- a/fast64_internal/f3d/f3d_material.py
+++ b/fast64_internal/f3d/f3d_material.py
@@ -460,7 +460,7 @@ def ui_geo_mode(settings, dataHolder, layout, useDropdown):
         else:
             shadeColorLabel = "Lighting"
         if isF3DEX3:
-            c = indentGroup(inputGroup, f"Shade color = {shadeColorLabel}:", True, settings.g_lighting)
+            c = indentGroup(inputGroup, f"Shade color = {shadeColorLabel}:", True)
             c.prop(settings, "g_fresnel_color")
         else:
             inputGroup.label(text=f"Shade color = {shadeColorLabel}:")

--- a/fast64_internal/f3d/f3d_material.py
+++ b/fast64_internal/f3d/f3d_material.py
@@ -460,7 +460,7 @@ def ui_geo_mode(settings, dataHolder, layout, useDropdown):
             shadeColorLabel = "Lighting * vertex color"
         else:
             shadeColorLabel = "Lighting"
-        inputGroup.label(text=f"Shade color = {shadeColorLabel}:")
+        inputGroup.label(text=f"Shade color = {shadeColorLabel}")
 
         shadowMapInShadeAlpha = False
         if settings.g_fog:


### PR DESCRIPTION
There was two options in fixing this:
Not exporting hidden modes or always showing all modes
I went with the latter in this pr as its more logical, nonsense example but if a game always defaults to packed normals but doesn´t default to lighting, that should still be setable AND visible in the world settings. Or maybe one could use a hack that revolves around checking for an unused mode being on. In my opinion this is the best way to do it and it doesn´t add much bloat to the UI even in ex3.
I also fixed a bug where if texgen was on without lighting it would still emulate texgen, even though it was neither visible or correct