### PR TITLE
[F3D] Show tlut othermode in materials and world defaults

### DIFF
--- a/fast64_internal/f3d/f3d_bleed.py
+++ b/fast64_internal/f3d/f3d_bleed.py
@@ -30,8 +30,6 @@ from .f3d_gbi import (
     DPLoadTLUTCmd,
     DPFullSync,
     DPSetRenderMode,
-    DPSetTextureLUT,
-    DPSetCycleType,
     DPSetTextureImage,
     DPPipeSync,
     DPLoadSync,
@@ -107,7 +105,7 @@ class BleedGraphics:
         othermode_H.flagList.append(defaults.g_mdsft_combkey)
         othermode_H.flagList.append(defaults.g_mdsft_textconv)
         othermode_H.flagList.append(defaults.g_mdsft_text_filt)
-        othermode_H.flagList.append("G_TT_NONE")
+        othermode_H.flagList.append(defaults.g_mdsft_textlut)
         othermode_H.flagList.append(defaults.g_mdsft_textlod)
         othermode_H.flagList.append(defaults.g_mdsft_textdetail)
         othermode_H.flagList.append(defaults.g_mdsft_textpersp)
@@ -390,10 +388,6 @@ class BleedGraphics:
             elif cmd_type == SPClearGeometryMode and cmd_use != self.default_clear_geo:
                 reset_cmds.append(self.default_clear_geo)
 
-            elif cmd_type == DPSetTextureLUT:
-                if cmd_use.mode != "G_TT_NONE":
-                    reset_cmds.append(cmd_type("G_TT_NONE"))
-
             elif cmd_type == "G_SETOTHERMODE_H":
                 if cmd_use != self.default_othermode_H:
                     reset_cmds.append(self.default_othermode_H)
@@ -524,21 +518,11 @@ class BleedGfxLists:
     bled_mats: GfxList = field(default_factory=list)
     bled_tex: GfxList = field(default_factory=list)
 
-    @property
-    def reset_command_dict(self):
-        return {
-            SPGeometryMode: (["G_TEXTURE_GEN"], ["G_LIGHTING"]),
-            DPSetCycleType: ("G_CYC_1CYCLE",),
-            DPSetTextureLUT: ("G_TT_NONE",),
-            DPSetRenderMode: (None, None),
-        }
-
     def add_reset_cmd(self, cmd: GbiMacro, reset_cmd_dict: dict[GbiMacro]):
         reset_cmd_list = (
             SPLoadGeometryMode,
             SPSetGeometryMode,
             SPClearGeometryMode,
-            DPSetTextureLUT,
             DPSetRenderMode,
         )
         # separate other mode H and othermode L

--- a/fast64_internal/f3d/f3d_material.py
+++ b/fast64_internal/f3d/f3d_material.py
@@ -2095,7 +2095,7 @@ def update_tex_values_manual(material: Material, context, prop_path=None):
 
     textures = [f3dMat.tex0] if useDict["Texture 0"] else []
     textures += [f3dMat.tex1] if useDict["Texture 1"] else []
-    ci_formats = list(set(tex.ci_format for tex in textures if tex.tex_format.startswith("CI")))
+    ci_formats = list(set(tex.ci_format if tex.tex_format.startswith("CI") else "NONE" for tex in textures))
     if len(ci_formats) != 1:  # if more than one ci format or no ci format textures
         ci_formats = ["NONE"]
     f3dMat.rdp_settings.g_mdsft_textlut = "G_TT_" + ci_formats[0]

--- a/fast64_internal/f3d/f3d_material.py
+++ b/fast64_internal/f3d/f3d_material.py
@@ -3554,6 +3554,7 @@ class RDPSettings(PropertyGroup):
         data = self.attributes_to_dict(self.other_mode_h_attributes)
         if lut_format:
             data["lutFormat"] = lut_format
+        return data
 
     def other_mode_h_from_dict(self, data: dict):
         self.attributes_from_dict(data, self.other_mode_h_attributes)

--- a/fast64_internal/f3d/f3d_material.py
+++ b/fast64_internal/f3d/f3d_material.py
@@ -2088,7 +2088,7 @@ def get_textlut_mode(f3d_mat: "F3DMaterialProperty", inherit_from_tex: bool = Fa
     tlut_modes = [tex.ci_format if tex.tex_format.startswith("CI") else "NONE" for tex in textures]
     if tlut_modes and tlut_modes[0] == tlut_modes[-1]:
         return "G_TT_" + tlut_modes[0]
-    return None if inherit_from_tex else f3d_mat.rdp_settings.g_mdsft_texlut
+    return None if inherit_from_tex else f3d_mat.rdp_settings.g_mdsft_textlut
 
 
 def update_tex_values_manual(material: Material, context, prop_path=None):

--- a/fast64_internal/f3d/f3d_material.py
+++ b/fast64_internal/f3d/f3d_material.py
@@ -546,6 +546,9 @@ def ui_upper_mode(settings, dataHolder, layout: UILayout, useDropdown):
         prop_split(inputGroup, settings, "g_mdsft_combkey", "Chroma Key")
         prop_split(inputGroup, settings, "g_mdsft_textconv", "Texture Convert")
         prop_split(inputGroup, settings, "g_mdsft_text_filt", "Texture Filter")
+        textlut_col = inputGroup.column()
+        textlut_col.enabled = not isinstance(dataHolder, F3DMaterialProperty)
+        prop_split(textlut_col, settings, "g_mdsft_textlut", "Texture LUT")
         prop_split(inputGroup, settings, "g_mdsft_textlod", "Texture LOD (Mipmapping)")
         if settings.g_mdsft_textlod == "G_TL_LOD":
             inputGroup.prop(settings, "num_textures_mipmapped", text="Number of Mipmaps")
@@ -2090,6 +2093,13 @@ def update_tex_values_manual(material: Material, context, prop_path=None):
 
     isTexGen = f3dMat.rdp_settings.g_tex_gen  # linear requires tex gen to be enabled as well
 
+    textures = [f3dMat.tex0] if useDict["Texture 0"] else []
+    textures += [f3dMat.tex1] if useDict["Texture 1"] else []
+    ci_formats = list(set(tex.ci_format for tex in textures if tex.tex_format.startswith("CI")))
+    if len(ci_formats) != 1:  # if more than one ci format or no ci format textures
+        ci_formats = ["NONE"]
+    f3dMat.rdp_settings.g_mdsft_textlut = "G_TT_" + ci_formats[0]
+
     if f3dMat.scale_autoprop:
         if isTexGen:
             tex_size = get_tex_basis_size(f3dMat)
@@ -3515,7 +3525,7 @@ class RDPSettings(PropertyGroup):
         ("chromaKey", "g_mdsft_combkey", "G_CK_NONE"),
         ("textureConvert", "g_mdsft_textconv", "G_TC_CONV"),
         ("textureFilter", "g_mdsft_text_filt", "G_TF_POINT"),
-        # ("lutFormat", "g_mdsft_textlut", "G_TT_NONE")
+        ("lutFormat", "g_mdsft_textlut", "G_TT_NONE"),
         ("textureLoD", "g_mdsft_textlod", "G_TL_TILE"),
         ("textureDetail", "g_mdsft_textdetail", "G_TD_CLAMP"),
         ("perspectiveCorrection", "g_mdsft_textpersp", "G_TP_NONE"),

--- a/fast64_internal/f3d/f3d_material.py
+++ b/fast64_internal/f3d/f3d_material.py
@@ -2081,18 +2081,14 @@ def get_tex_gen_size(tex_size: list[int | float]):
     return (tex_size[0] - 1) / 1024, (tex_size[1] - 1) / 1024
 
 
-def get_textlut_mode(f3d_mat: "F3DMaterialProperty", none_if_not_set: bool = False):
+def get_textlut_mode(f3d_mat: "F3DMaterialProperty", inherit_from_tex: bool = False):
     use_dict = all_combiner_uses(f3d_mat)
     textures = [f3d_mat.tex0] if use_dict["Texture 0"] and f3d_mat.tex0.tex_set else []
     textures += [f3d_mat.tex1] if use_dict["Texture 1"] and f3d_mat.tex1.tex_set else []
-    if textures:
-        ci_formats = list(set(tex.ci_format if tex.tex_format.startswith("CI") else "NONE" for tex in textures))
-        if len(ci_formats) == 1:
-            return "G_TT_" + ci_formats[0]
-        elif len(ci_formats) == 0:
-            return "G_TT_NONE"
-    if not none_if_not_set:
-        return f3d_mat.rdp_settings.g_mdsft_textlut
+    tlut_modes = [tex.ci_format if tex.tex_format.startswith("CI") else "NONE" for tex in textures]
+    if tlut_modes and tlut_modes[0] == tlut_modes[-1]:
+        return "G_TT_" + tlut_modes[0]
+    return None if inherit_from_tex else f3d_mat.rdp_settings.g_mdsft_texlut
 
 
 def update_tex_values_manual(material: Material, context, prop_path=None):

--- a/fast64_internal/f3d/f3d_texture_writer.py
+++ b/fast64_internal/f3d/f3d_texture_writer.py
@@ -612,9 +612,6 @@ class MultitexManager:
 
         self.palFormat = self.ti0.palFormat if self.ti0.useTex else self.ti1.palFormat
 
-    def getTT(self) -> str:
-        return "G_TT_NONE" if not self.isCI else ("G_TT_" + self.palFormat)
-
     def writeAll(
         self, material: bpy.types.Material, fMaterial: FMaterial, fModel: FModel, convertTextureData: bool
     ) -> None:

--- a/fast64_internal/f3d/f3d_writer.py
+++ b/fast64_internal/f3d/f3d_writer.py
@@ -11,6 +11,7 @@ from .f3d_material import (
     all_combiner_uses,
     getMaterialScrollDimensions,
     isTexturePointSampled,
+    get_textlut_mode,
     RDPSettings,
 )
 from .f3d_texture_writer import MultitexManager, TileLoad, maybeSaveSingleLargeTextureSetup
@@ -1440,7 +1441,7 @@ def saveOrGetF3DMaterial(material, fModel, obj, drawLayer, convertTextureData):
     saveOtherModeHDefinition(
         fMaterial,
         f3dMat.rdp_settings,
-        multitexManager.getTT(),
+        get_textlut_mode(f3dMat),
         defaults,
         fModel.matWriteMethod,
         fModel.f3d,

--- a/fast64_internal/f3d/f3d_writer.py
+++ b/fast64_internal/f3d/f3d_writer.py
@@ -1700,7 +1700,7 @@ def saveOtherModeHDefinitionIndividual(fMaterial, settings, tlut, defaults):
     saveModeSetting(fMaterial, settings.g_mdsft_combkey, defaults.g_mdsft_combkey, DPSetCombineKey)
     saveModeSetting(fMaterial, settings.g_mdsft_textconv, defaults.g_mdsft_textconv, DPSetTextureConvert)
     saveModeSetting(fMaterial, settings.g_mdsft_text_filt, defaults.g_mdsft_text_filt, DPSetTextureFilter)
-    saveModeSetting(fMaterial, tlut, "G_TT_NONE", DPSetTextureLUT)
+    saveModeSetting(fMaterial, tlut, defaults.g_mdsft_textlut, DPSetTextureLUT)
     saveModeSetting(fMaterial, settings.g_mdsft_textlod, defaults.g_mdsft_textlod, DPSetTextureLOD)
     saveModeSetting(fMaterial, settings.g_mdsft_textdetail, defaults.g_mdsft_textdetail, DPSetTextureDetail)
     saveModeSetting(fMaterial, settings.g_mdsft_textpersp, defaults.g_mdsft_textpersp, DPSetTexturePersp)


### PR DESCRIPTION
The mode is still automatically set when using CI textures, however the default can now be changed and it hides what's happening under the hood just a bit less,  I also removed some code from f3d_bleed, specifically I removed reset_command_dict (unused) and DPSetTextureLUT from the cmd list in add_reset_cmd because it is always set by SPSetOtherMode like other othermodes.
![image](https://github.com/user-attachments/assets/1c18a687-b44f-4f2a-872a-7f25da236871)
![image](https://github.com/user-attachments/assets/68d604e6-3d0f-4d92-ad02-ed438a456b24)
