### PR TITLE
[SM64] Fix usage of sm64 scale in animations

### DIFF
--- a/fast64_internal/sm64/sm64_anim.py
+++ b/fast64_internal/sm64/sm64_anim.py
@@ -451,7 +451,7 @@ def convertAnimationData(anim, armatureObj, *, frame_start, frame_count):
         rootPoseBone = armatureObj.pose.bones[animBones[0]]
 
         translation = (
-            mathutils.Matrix.Scale(bpy.context.scene.blenderToSM64Scale, 4) @ rootPoseBone.matrix_basis
+            mathutils.Matrix.Scale(bpy.context.scene.fast64.sm64.blender_to_sm64_scale, 4) @ rootPoseBone.matrix_basis
         ).decompose()[0]
         saveTranslationFrame(translationData, translation)
 


### PR DESCRIPTION
Happened because of one fix before settings rework, code changed by the fix was never updated to use the new prop