### PR TITLE
[F3D] Pass in shade alpha into fog blender instead of disabling it when fog is off

### DIFF
--- a/fast64_internal/f3d/f3d_material.py
+++ b/fast64_internal/f3d/f3d_material.py
@@ -1574,21 +1574,17 @@ def update_node_combiner(material, combinerInputs, cycleIndex):
 def update_fog_nodes(material: Material, context: Context):
     nodes = material.node_tree.nodes
     f3dMat: "F3DMaterialProperty" = material.f3d_mat
-    shade_alpha_is_fog = material.f3d_mat.rdp_settings.g_fog
 
     fogBlender: ShaderNodeGroup = nodes["FogBlender"]
     # if NOT setting rendermode, it is more likely that the user is setting
     # rendermodes in code, so to be safe we'll enable fog. Plus we are checking
     # that fog is enabled in the geometry mode, so if so that's probably the intent.
     fogBlender.node_tree = bpy.data.node_groups[
-        (
-            "FogBlender_On"
-            if shade_alpha_is_fog and is_blender_doing_fog(material.f3d_mat.rdp_settings, True)
-            else "FogBlender_Off"
-        )
+        ("FogBlender_On" if is_blender_doing_fog(material.f3d_mat.rdp_settings, True) else "FogBlender_Off")
     ]
 
-    if shade_alpha_is_fog:
+    remove_first_link_if_exists(material, fogBlender.inputs["FogAmount"].links)
+    if material.f3d_mat.rdp_settings.g_fog:
         inherit_fog = f3dMat.use_global_fog or not f3dMat.set_fog
         if inherit_fog:
             link_if_none_exist(material, nodes["SceneProperties"].outputs["FogColor"], nodes["FogColor"].inputs[0])
@@ -1601,10 +1597,12 @@ def update_fog_nodes(material: Material, context: Context):
             remove_first_link_if_exists(material, nodes["FogBlender"].inputs["Fog Color"].links)
             remove_first_link_if_exists(material, nodes["CalcFog"].inputs["FogNear"].links)
             remove_first_link_if_exists(material, nodes["CalcFog"].inputs["FogFar"].links)
-
-        fogBlender.inputs["Fog Color"].default_value = s_rgb_alpha_1_tuple(f3dMat.fog_color)
-        nodes["CalcFog"].inputs["FogNear"].default_value = f3dMat.fog_position[0]
-        nodes["CalcFog"].inputs["FogFar"].default_value = f3dMat.fog_position[1]
+        material.node_tree.links.new(nodes["CalcFog"].outputs["FogAmount"], fogBlender.inputs["FogAmount"])
+    else:
+        material.node_tree.links.new(nodes["Shade Color"].outputs["Alpha"], fogBlender.inputs["FogAmount"])
+    fogBlender.inputs["Fog Color"].default_value = s_rgb_alpha_1_tuple(f3dMat.fog_color)
+    nodes["CalcFog"].inputs["FogNear"].default_value = f3dMat.fog_position[0]
+    nodes["CalcFog"].inputs["FogFar"].default_value = f3dMat.fog_position[1]
 
 
 def update_noise_nodes(material: Material):

--- a/fast64_internal/f3d/f3d_material.py
+++ b/fast64_internal/f3d/f3d_material.py
@@ -1585,24 +1585,22 @@ def update_fog_nodes(material: Material, context: Context):
 
     remove_first_link_if_exists(material, fogBlender.inputs["FogAmount"].links)
     if material.f3d_mat.rdp_settings.g_fog:
-        inherit_fog = f3dMat.use_global_fog or not f3dMat.set_fog
-        if inherit_fog:
-            link_if_none_exist(material, nodes["SceneProperties"].outputs["FogColor"], nodes["FogColor"].inputs[0])
-            link_if_none_exist(material, nodes["GlobalFogColor"].outputs[0], fogBlender.inputs["Fog Color"])
-            link_if_none_exist(
-                material, nodes["SceneProperties"].outputs["FogNear"], nodes["CalcFog"].inputs["FogNear"]
-            )
-            link_if_none_exist(material, nodes["SceneProperties"].outputs["FogFar"], nodes["CalcFog"].inputs["FogFar"])
-        else:
-            remove_first_link_if_exists(material, nodes["FogBlender"].inputs["Fog Color"].links)
-            remove_first_link_if_exists(material, nodes["CalcFog"].inputs["FogNear"].links)
-            remove_first_link_if_exists(material, nodes["CalcFog"].inputs["FogFar"].links)
         material.node_tree.links.new(nodes["CalcFog"].outputs["FogAmount"], fogBlender.inputs["FogAmount"])
-    else:
+    else: # If fog is not being calculated, pass in shade alpha
         material.node_tree.links.new(nodes["Shade Color"].outputs["Alpha"], fogBlender.inputs["FogAmount"])
-    fogBlender.inputs["Fog Color"].default_value = s_rgb_alpha_1_tuple(f3dMat.fog_color)
-    nodes["CalcFog"].inputs["FogNear"].default_value = f3dMat.fog_position[0]
-    nodes["CalcFog"].inputs["FogFar"].default_value = f3dMat.fog_position[1]
+
+    if f3dMat.use_global_fog or not f3dMat.set_fog: # Inherit fog
+        link_if_none_exist(material, nodes["SceneProperties"].outputs["FogColor"], nodes["FogColor"].inputs[0])
+        link_if_none_exist(material, nodes["GlobalFogColor"].outputs[0], fogBlender.inputs["Fog Color"])
+        link_if_none_exist(material, nodes["SceneProperties"].outputs["FogNear"], nodes["CalcFog"].inputs["FogNear"])
+        link_if_none_exist(material, nodes["SceneProperties"].outputs["FogFar"], nodes["CalcFog"].inputs["FogFar"])
+    else:
+        remove_first_link_if_exists(material, nodes["FogBlender"].inputs["Fog Color"].links)
+        remove_first_link_if_exists(material, nodes["CalcFog"].inputs["FogNear"].links)
+        remove_first_link_if_exists(material, nodes["CalcFog"].inputs["FogFar"].links)
+        fogBlender.inputs["Fog Color"].default_value = s_rgb_alpha_1_tuple(f3dMat.fog_color)
+        nodes["CalcFog"].inputs["FogNear"].default_value = f3dMat.fog_position[0]
+        nodes["CalcFog"].inputs["FogFar"].default_value = f3dMat.fog_position[1]
 
 
 def update_noise_nodes(material: Material):

--- a/fast64_internal/f3d/f3d_material.py
+++ b/fast64_internal/f3d/f3d_material.py
@@ -1586,10 +1586,10 @@ def update_fog_nodes(material: Material, context: Context):
     remove_first_link_if_exists(material, fogBlender.inputs["FogAmount"].links)
     if material.f3d_mat.rdp_settings.g_fog:
         material.node_tree.links.new(nodes["CalcFog"].outputs["FogAmount"], fogBlender.inputs["FogAmount"])
-    else: # If fog is not being calculated, pass in shade alpha
+    else:  # If fog is not being calculated, pass in shade alpha
         material.node_tree.links.new(nodes["Shade Color"].outputs["Alpha"], fogBlender.inputs["FogAmount"])
 
-    if f3dMat.use_global_fog or not f3dMat.set_fog: # Inherit fog
+    if f3dMat.use_global_fog or not f3dMat.set_fog:  # Inherit fog
         link_if_none_exist(material, nodes["SceneProperties"].outputs["FogColor"], nodes["FogColor"].inputs[0])
         link_if_none_exist(material, nodes["GlobalFogColor"].outputs[0], fogBlender.inputs["Fog Color"])
         link_if_none_exist(material, nodes["SceneProperties"].outputs["FogNear"], nodes["CalcFog"].inputs["FogNear"])


### PR DESCRIPTION
Fixes preview of fogshade with no fog geo mode enabled
![image](https://github.com/user-attachments/assets/a4b4efab-0e25-462b-9c9a-f2cdfdeec8b2)
![image](https://github.com/user-attachments/assets/73a2e36e-7137-4121-85cf-accd47054d9d)
