### PR TITLE
[OoT] Fixup Quick Import

### DIFF
--- a/fast64_internal/oot/tools/quick_import.py
+++ b/fast64_internal/oot/tools/quick_import.py
@@ -53,7 +53,8 @@ def quick_import_exec(context: bpy.types.Context, sym_name: str):
                 continue
             found_defs = sym_def_pattern.findall(source)
             print(file_p, f"{found_defs=}")
-            all_found_defs[file_p] = found_defs
+            if found_defs:
+                all_found_defs[file_p] = found_defs
 
     # Ideally if for example sym_name was gLinkAdultHookshotTipDL,
     # all_found_defs now contains:


### PR DESCRIPTION
The Quick Import feature works by scanning assets files for symbols, first roughly with just `sym_name in source`, then accurately with a regex if the rough check passed.

However if the first rough check passed, the file was wrongly recorded as having the symbol even if the regex found no match.

This PR fixes this problem.