### PR TITLE
[F3D] Fix issues in the GBI macros

### DIFF
--- a/fast64_internal/f3d/f3d_gbi.py
+++ b/fast64_internal/f3d/f3d_gbi.py
@@ -4826,9 +4826,9 @@ class DPSetOtherMode(GbiMacro):
     def to_binary(self, f3d, segments):
         mode0 = mode1 = 0
         for mode in self.mode0:
-            mode0 |= getattr(f3d, mode) if hasattr(f3d, str(mode)) else mode
+            mode0 |= getattr(f3d, str(mode), mode)
         for mode in self.mode1:
-            mode1 |= getattr(f3d, mode) if hasattr(f3d, str(mode)) else mode
+            mode1 |= getattr(f3d, str(mode), mode)
         words = _SHIFTL(f3d.G_RDPSETOTHERMODE, 24, 8) | _SHIFTL(mode0, 0, 24), mode1
         return words[0].to_bytes(4, "big") + words[1].to_bytes(4, "big")
 

--- a/fast64_internal/f3d/f3d_gbi.py
+++ b/fast64_internal/f3d/f3d_gbi.py
@@ -3811,7 +3811,7 @@ class SPAmbOcclusion(GbiMacro):
         return SPAmbOcclusionAmbDir(self.amb, self.dir).to_binary(f3d, segments) + SPAmbOcclusionPoint(
             self.point
         ).to_binary(f3d, segments)
-    
+
     def size(self, f3d):
         return GFX_SIZE * 2
 
@@ -4027,7 +4027,7 @@ class SPLightColor(GbiMacro):
     def to_c(self, static=True):
         header = "gsSPLightColor(" if static else "gSPLightColor(glistp++, "
         return header + f"{self.n}, 0x" + format(self.color_to_int(), "08X") + ")"
-    
+
     def size(self, _f3d):
         return GFX_SIZE * 2
 

--- a/fast64_internal/f3d/f3d_gbi.py
+++ b/fast64_internal/f3d/f3d_gbi.py
@@ -4321,9 +4321,9 @@ class SPSetOtherMode(GbiMacro):
     def to_binary(self, f3d, segments):
         data = 0
         for flag in self.flagList:
-            data |= getattr(f3d, flag) if hasattr(f3d, str(flag)) else flag
-        cmd = getattr(f3d, self.cmd) if hasattr(f3d, str(self.cmd)) else self.cmd
-        sft = getattr(f3d, self.sft) if hasattr(f3d, str(self.sft)) else self.sft
+            data |= getattr(f3d, str(flag), flag)
+        cmd = getattr(f3d, str(self.cmd), self.cmd)
+        sft = getattr(f3d, str(self.sft), self.sft)
         return gsSPSetOtherMode(cmd, sft, self.length, data, f3d)
 
 


### PR DESCRIPTION
Add size() of 2 for SPAmbOcclusion and SPLightColor, fixes SPPerspNormalize in ex3, DPSetOtherMode and DPSetTileSize.is_LOADTILE (was that one ever used?).
Also cleans up SPSetOtherMode to use getattr default instead of checking with hasattr.