### PR TITLE
[SM64] Fix #352 regression

### DIFF
--- a/fast64_internal/utility.py
+++ b/fast64_internal/utility.py
@@ -788,7 +788,8 @@ def store_original_mtx():
     for obj in yield_children(active_obj):
         # negative scales produce a rotation, we need to remove that since
         # scales will be applied to the transform for each object
-        obj["original_mtx"] = Matrix.LocRotScale(obj.location, obj.rotation_euler, None)
+        loc, rot, _scale = obj.matrix_local.decompose()
+        obj["original_mtx"] = Matrix.LocRotScale(loc, rot, None)
 
 
 def rotate_bounds(bounds, mtx: mathutils.Matrix):


### PR DESCRIPTION
It is not enough to rely on an object's location and rotation as we need a relative position.
[broken graphics parented.blend.zip](https://github.com/user-attachments/files/16657743/broken.graphics.parented.blend.zip)
[Code diff](https://github.com/Lilaa3/sm64/commit/321dedfe3d4d114e0f32cf28343e67f9b76d4069)