### PR TITLE
[SM64] Fix #355 - Fix unaddressed object types in #358

### DIFF
--- a/fast64_internal/sm64/sm64_objects.py
+++ b/fast64_internal/sm64/sm64_objects.py
@@ -854,7 +854,7 @@ def process_sm64_objects(obj, area, rootMatrix, transformMatrix, specialsOnly):
                     SM64_Whirpool(obj.whirlpool_index, obj.whirpool_condition, obj.whirpool_strength, translation)
                 )
             elif obj.sm64_obj_type == "Camera Volume":
-                checkIdentityRotation(obj, rotation, True)
+                checkIdentityRotation(obj, rotation.to_quaternion(), True)
                 if obj.cameraVolumeGlobal:
                     triggerIndex = -1
                 else:
@@ -871,7 +871,7 @@ def process_sm64_objects(obj, area, rootMatrix, transformMatrix, specialsOnly):
                 )
 
             elif obj.sm64_obj_type == "Puppycam Volume":
-                checkIdentityRotation(obj, rotation, False)
+                checkIdentityRotation(obj, rotation.to_quaternion(), False)
 
                 triggerIndex = area.index
                 puppycamProp = obj.puppycamProp


### PR DESCRIPTION
The previous fix was incomplete but the issue was never noticed from how uncommon camera volumes are. 
Previous fix was a fix to a #339 regression.