### PR TITLE
[UI] [OOT] More informative text regarding culling

### DIFF
--- a/fast64_internal/oot/props_panel_main.py
+++ b/fast64_internal/oot/props_panel_main.py
@@ -229,7 +229,7 @@ class OOTCullGroupProperty(bpy.types.PropertyGroup):
         col.prop(self, "sizeControlsCull")
         if not self.sizeControlsCull:
             prop_split(col, self, "manualRadius", "Radius (OOT Units)")
-        col.label(text="RSP culling is automatic. This is for CPU culling.", icon="INFO")
+        col.label(text="RSP culling is automatic. The 'Custom Cull Group' empty type is for CPU culling.", icon="INFO")
         col.label(text="This will create custom cull group shape entries to be used in Cullable rooms.")
         col.label(text="Use Options -> Transform -> Affect Only -> Parent ", icon="INFO")
         col.label(text="to move object without affecting children.")

--- a/fast64_internal/oot/props_panel_main.py
+++ b/fast64_internal/oot/props_panel_main.py
@@ -229,8 +229,8 @@ class OOTCullGroupProperty(bpy.types.PropertyGroup):
         col.prop(self, "sizeControlsCull")
         if not self.sizeControlsCull:
             prop_split(col, self, "manualRadius", "Radius (OOT Units)")
-        col.label(text="Meshes generate cull groups automatically.", icon="INFO")
-        col.label(text="This is only for custom cull group shapes.")
+        col.label(text="RSP culling is automatic. This is for CPU culling.", icon="INFO")
+        col.label(text="This will create custom cull group shape entries to be used in Cullable rooms.")
         col.label(text="Use Options -> Transform -> Affect Only -> Parent ", icon="INFO")
         col.label(text="to move object without affecting children.")
 

--- a/fast64_internal/oot/room/properties.py
+++ b/fast64_internal/oot/room/properties.py
@@ -172,7 +172,8 @@ class OOTRoomHeaderProperty(PropertyGroup):
                 if self.roomShape == "ROOM_SHAPE_TYPE_IMAGE":
                     self.drawBGImageList(general, objName)
                 if self.roomShape == "ROOM_SHAPE_TYPE_CULLABLE":
-                    general.label(text="Cull regions are generated automatically.", icon="INFO")
+                    general.label(text="This is for CPU culling, and requires meshes to be parented to Custom Cull Group empties.", icon="INFO")
+                    general.label(text="RSP culling is done automatically regardless of room shape.")
                     prop_split(general, self, "defaultCullDistance", "Default Cull (Blender Units)")
             # Behaviour
             behaviourBox = layout.column()

--- a/fast64_internal/oot/room/properties.py
+++ b/fast64_internal/oot/room/properties.py
@@ -172,7 +172,7 @@ class OOTRoomHeaderProperty(PropertyGroup):
                 if self.roomShape == "ROOM_SHAPE_TYPE_IMAGE":
                     self.drawBGImageList(general, objName)
                 if self.roomShape == "ROOM_SHAPE_TYPE_CULLABLE":
-                    general.label(text="This is for CPU culling, and requires meshes to be parented to Custom Cull Group empties.", icon="INFO")
+                    general.label(text="The 'Cullable' room shape type is for CPU culling, and requires meshes to be parented to Custom Cull Group empties.", icon="INFO")
                     general.label(text="RSP culling is done automatically regardless of room shape.")
                     prop_split(general, self, "defaultCullDistance", "Default Cull (Blender Units)")
             # Behaviour

--- a/fast64_internal/oot/room/properties.py
+++ b/fast64_internal/oot/room/properties.py
@@ -172,7 +172,8 @@ class OOTRoomHeaderProperty(PropertyGroup):
                 if self.roomShape == "ROOM_SHAPE_TYPE_IMAGE":
                     self.drawBGImageList(general, objName)
                 if self.roomShape == "ROOM_SHAPE_TYPE_CULLABLE":
-                    general.label(text="The 'Cullable' room shape type is for CPU culling, and requires meshes to be parented to Custom Cull Group empties.", icon="INFO")
+                    general.label(text="The 'Cullable' room shape type is for CPU culling,", icon="INFO")
+                    general.label(text="and requires meshes to be parented to Custom Cull Group empties.")
                     general.label(text="RSP culling is done automatically regardless of room shape.")
                     prop_split(general, self, "defaultCullDistance", "Default Cull (Blender Units)")
             # Behaviour


### PR DESCRIPTION
Changes some text labels that might be misleading. 

This one only shows up when you select the Cullable room type which leads you to believe it sets up CPU culling automatically. It doesn't. The only thing fast64 sets up automatically is RSP culling, and it does so regardless of whether the room type is "Cullable" or "Normal".
![imagen](https://github.com/user-attachments/assets/966bd245-12ab-4e18-bea5-21af757a3aef)

Therefore I changed it to: 
![imagen](https://github.com/user-attachments/assets/1a03ebda-6c6c-4404-a6c3-a3b37911c7f4)

This text which shows up when you select  "Custom Cull Group" empty type is also misleading. It can lead the user to believe that what they're doing is unnecessary since fast64 is already doing it:
![imagen](https://github.com/user-attachments/assets/d25a38b9-98b1-4e09-99f1-4139b0a18c02)

So I changed it to:
![imagen](https://github.com/user-attachments/assets/a7c3db18-eea3-4150-a3c8-a90fda4853e9)

