### PR TITLE
[SM64] Fix zoomout masks

### DIFF
--- a/fast64_internal/sm64/sm64_level_writer.py
+++ b/fast64_internal/sm64/sm64_level_writer.py
@@ -148,22 +148,7 @@ class ZoomOutMasks:
     def updateMaskCount(self, levelCount):
         if len(self.masks) - 1 < int(levelCount / 2):
             while len(self.masks) - 1 < int(levelCount / 2):
-                self.masks.append(
-                    [
-                        "ZOOMOUT_AREA_MASK",
-                        [
-                            "0",
-                            "0",
-                            "0",
-                            "0",
-                            "0",
-                            "0",
-                            "0",
-                            "0",
-                        ],
-                        "",
-                    ]
-                )
+                self.masks.append(Macro("ZOOMOUT_AREA_MASK", ["0"] * 8, ""))
         else:
             self.masks = self.masks[: int(levelCount / 2) + 1]
 
@@ -537,6 +522,7 @@ def stringToMacros(data):
 
 
 def macroToString(macro_cmd, comma=True):
+    print(macro_cmd)
     return f"{macro_cmd.function}({', '.join(macro_cmd.args)}){',' if comma else ''} {macro_cmd.comment}"
 
 


### PR DESCRIPTION
I went over the file again to make sure there are no other old macro appends that don´t used the new named tuple but couldn´t find any other, weird that this never triggered for me even when using the test file provided by @Reonu 