### PR TITLE
[SM64] Smarter includes

### DIFF
--- a/fast64_internal/sm64/sm64_anim.py
+++ b/fast64_internal/sm64/sm64_anim.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 import bpy, os, copy, shutil, mathutils, math
 from bpy.utils import register_class, unregister_class
 from ..panels import SM64_Panel
@@ -14,7 +15,6 @@ from ..utility import (
     decodeSegmentedAddr,
     getExportDir,
     toAlnum,
-    writeIfNotFound,
     get64bitAlignedAddr,
     writeInsertableFile,
     getFrameInterval,
@@ -46,7 +46,7 @@ from .sm64_constants import (
     marioAnimations,
 )
 
-from .sm64_utility import export_rom_checks, import_rom_checks
+from .sm64_utility import export_rom_checks, import_rom_checks, update_actor_includes, write_includes
 
 sm64_anim_types = {"ROTATE", "TRANSLATE"}
 
@@ -234,12 +234,7 @@ def exportAnimationC(armatureObj, loopAnim, dirPath, dirName, groupName, customE
     headerFile.write("extern const struct Animation *const " + animsName + "[];\n")
     headerFile.close()
 
-    # write to data.inc.c
-    dataFilePath = os.path.join(animDirPath, "data.inc.c")
-    if not os.path.exists(dataFilePath):
-        dataFile = open(dataFilePath, "w", newline="\n")
-        dataFile.close()
-    writeIfNotFound(dataFilePath, '#include "' + animFileName + '"\n', "")
+    write_includes(Path(animDirPath) / "data.inc.c", [f'"{animFileName}"'])
 
     # write to table.inc.c
     tableFilePath = os.path.join(animDirPath, "table.inc.c")
@@ -275,23 +270,16 @@ def exportAnimationC(armatureObj, loopAnim, dirPath, dirName, groupName, customE
         with open(tableFilePath, "w") as f:
             f.write(stringData)
 
-    if not customExport:
-        if headerType == "Actor":
-            groupPathC = os.path.join(dirPath, groupName + ".c")
-            groupPathH = os.path.join(dirPath, groupName + ".h")
-
-            writeIfNotFound(groupPathC, '\n#include "' + dirName + '/anims/data.inc.c"', "")
-            writeIfNotFound(groupPathC, '\n#include "' + dirName + '/anims/table.inc.c"', "")
-            writeIfNotFound(groupPathH, '\n#include "' + dirName + '/anim_header.h"', "#endif")
-        elif headerType == "Level":
-            groupPathC = os.path.join(dirPath, "leveldata.c")
-            groupPathH = os.path.join(dirPath, "header.h")
-
-            writeIfNotFound(groupPathC, '\n#include "levels/' + levelName + "/" + dirName + '/anims/data.inc.c"', "")
-            writeIfNotFound(groupPathC, '\n#include "levels/' + levelName + "/" + dirName + '/anims/table.inc.c"', "")
-            writeIfNotFound(
-                groupPathH, '\n#include "levels/' + levelName + "/" + dirName + '/anim_header.h"', "\n#endif"
-            )
+    if customExport:
+        headerType = "Custom"
+    update_actor_includes(
+        headerType,
+        groupName,
+        Path(dirPath),
+        dirName,
+        [Path("anims/data.inc.c"), Path("anims/table.inc.c")],
+        [Path("anim_header.h")],
+    )
 
 
 def exportAnimationBinary(romfile, exportRange, armatureObj, DMAAddresses, segmentData, isDMA, loopAnim):

--- a/fast64_internal/sm64/sm64_f3d_writer.py
+++ b/fast64_internal/sm64/sm64_f3d_writer.py
@@ -1,3 +1,4 @@
+from pathlib import Path
 import shutil, copy, bpy, re, os
 from io import BytesIO
 from math import ceil, log, radians
@@ -14,7 +15,7 @@ from ..f3d.f3d_material import (
     update_world_default_rendermode,
 )
 from .sm64_texscroll import modifyTexScrollFiles, modifyTexScrollHeadersGroup
-from .sm64_utility import export_rom_checks, starSelectWarning
+from .sm64_utility import export_rom_checks, starSelectWarning, update_actor_includes, writeMaterialHeaders
 from .sm64_level_parser import parseLevelAtPointer
 from .sm64_rom_tweaks import ExtendBank0x04
 from typing import Tuple, Union, Iterable
@@ -65,7 +66,6 @@ from ..utility import (
     overwriteData,
     getExportDir,
     writeMaterialFiles,
-    writeMaterialHeaders,
     get64bitAlignedAddr,
     writeInsertableFile,
     getPathAndLevel,
@@ -425,24 +425,15 @@ def sm64ExportF3DtoC(
     cDefFile.write(staticData.header)
     cDefFile.close()
 
+    update_actor_includes(headerType, groupName, Path(dirPath), name, ["model.inc.c"], ["header.h"])
     fileStatus = None
     if not customExport:
         if headerType == "Actor":
-            # Write to group files
-            if groupName == "" or groupName is None:
-                raise PluginError("Actor header type chosen but group name not provided.")
-
-            groupPathC = os.path.join(dirPath, groupName + ".c")
-            groupPathH = os.path.join(dirPath, groupName + ".h")
-
-            writeIfNotFound(groupPathC, '\n#include "' + toAlnum(name) + '/model.inc.c"', "")
-            writeIfNotFound(groupPathH, '\n#include "' + toAlnum(name) + '/header.h"', "\n#endif")
-
             if DLFormat != DLFormat.Static:  # Change this
                 writeMaterialHeaders(
                     basePath,
-                    '#include "actors/' + toAlnum(name) + '/material.inc.c"',
-                    '#include "actors/' + toAlnum(name) + '/material.inc.h"',
+                    '"actors/' + toAlnum(name) + '/material.inc.c"',
+                    '"actors/' + toAlnum(name) + '/material.inc.h"',
                 )
 
             texscrollIncludeC = '#include "actors/' + name + '/texscroll.inc.c"'
@@ -451,19 +442,11 @@ def sm64ExportF3DtoC(
             texscrollGroupInclude = '#include "actors/' + groupName + '.h"'
 
         elif headerType == "Level":
-            groupPathC = os.path.join(dirPath, "leveldata.c")
-            groupPathH = os.path.join(dirPath, "header.h")
-
-            writeIfNotFound(groupPathC, '\n#include "levels/' + levelName + "/" + toAlnum(name) + '/model.inc.c"', "")
-            writeIfNotFound(
-                groupPathH, '\n#include "levels/' + levelName + "/" + toAlnum(name) + '/header.h"', "\n#endif"
-            )
-
             if DLFormat != DLFormat.Static:  # Change this
                 writeMaterialHeaders(
                     basePath,
-                    '#include "levels/' + levelName + "/" + toAlnum(name) + '/material.inc.c"',
-                    '#include "levels/' + levelName + "/" + toAlnum(name) + '/material.inc.h"',
+                    '"levels/' + levelName + "/" + toAlnum(name) + '/material.inc.c"',
+                    '"levels/' + levelName + "/" + toAlnum(name) + '/material.inc.h"',
                 )
 
             texscrollIncludeC = '#include "levels/' + levelName + "/" + name + '/texscroll.inc.c"'

--- a/fast64_internal/sm64/sm64_texscroll.py
+++ b/fast64_internal/sm64/sm64_texscroll.py
@@ -1,7 +1,8 @@
+from pathlib import Path
 import os, re, bpy
-from ..utility import PluginError, writeIfNotFound, getDataFromFile, saveDataToFile, CScrollData, CData
+from ..utility import PluginError, getDataFromFile, saveDataToFile, CScrollData, CData
 from .c_templates.tile_scroll import tile_scroll_c, tile_scroll_h
-from .sm64_utility import getMemoryCFilePath
+from .sm64_utility import getMemoryCFilePath, write_includes
 
 # This is for writing framework for scroll code.
 # Actual scroll code found in f3d_gbi.py (FVertexScrollData)
@@ -78,7 +79,7 @@ def writeSegmentROMTable(baseDir):
         memFile.close()
 
     # Add extern definition of segment table
-    writeIfNotFound(os.path.join(baseDir, "src/game/memory.h"), "\nextern uintptr_t sSegmentROMTable[32];", "#endif")
+    write_includes(Path(baseDir) / "src/game/memory.h", externs=["uintptr_t sSegmentROMTable[32]"], before_endif=True)
 
 
 def writeScrollTextureCall(path, include, callString):

--- a/fast64_internal/utility.py
+++ b/fast64_internal/utility.py
@@ -510,11 +510,6 @@ def enableExtendedRAM(baseDir):
         segmentFile.close()
 
 
-def writeMaterialHeaders(exportDir, matCInclude, matHInclude):
-    writeIfNotFound(os.path.join(exportDir, "src/game/materials.c"), "\n" + matCInclude, "")
-    writeIfNotFound(os.path.join(exportDir, "src/game/materials.h"), "\n" + matHInclude, "#endif")
-
-
 def writeMaterialFiles(
     exportDir, assetDir, headerInclude, matHInclude, headerDynamic, dynamic_data, geoString, customExport
 ):
@@ -1716,6 +1711,9 @@ def getTextureSuffixFromFormat(texFmt):
     return texFmt.lower()
 
 
+COMMENT_PATTERN = re.compile(r'//.*?$|/\*.*?\*/|\'(?:\\.|[^\\\'])*\'|"(?:\\.|[^\\"])*"', re.DOTALL | re.MULTILINE)
+
+
 def removeComments(text: str):
     # https://stackoverflow.com/a/241506
 
@@ -1726,9 +1724,7 @@ def removeComments(text: str):
         else:
             return s
 
-    pattern = re.compile(r'//.*?$|/\*.*?\*/|\'(?:\\.|[^\\\'])*\'|"(?:\\.|[^\\"])*"', re.DOTALL | re.MULTILINE)
-
-    return re.sub(pattern, replacer, text)
+    return re.sub(COMMENT_PATTERN, replacer, text)
 
 
 binOps = {


### PR DESCRIPTION
I'd really like some opinions on write_includes's complexity and specifically the fact that it's so specific, I think its a good step foward as is tho.

Added new functions, write_includes and update_actor_includes.

write_includes is a smarter version of writeIfNotFound specifically for includes and externs, it removes comments prior to searching (but doesn't remove comments from the actual file of course) and allows whitespace (where possible, a path including whitespace won´t be found when searching for a file with no whitespace), futhermore it adds a trailing newline to the file instead of adding a leading newline for each include, the logic that finds the `#endif` of .h files is also improved like the logic to find includes and externs (whitespace is tolerated, comments are ignored) but it also allows no endif for files that use the GCC `#pragma once` macro

update_actor_includes standardizes group and level includes into one place for ease of editing, one of the major differences is that level exports no longer use the full path (levels/actor/my_file.c would instead be /actor/my_file.c) this should allow level header type actors to actually update headers on custom non decomp levels but that is not done in this PR.