### PR TITLE
[SM64/F3D] Fix and update Ui Image Exporter

### DIFF
--- a/fast64_internal/f3d/f3d_gbi.py
+++ b/fast64_internal/f3d/f3d_gbi.py
@@ -3262,6 +3262,10 @@ class FImage:
     isLargeTexture: bool = field(init=False, compare=False, default=False)
     converted: bool = field(init=False, compare=False, default=False)
 
+    @property
+    def aligner_name(self):
+        return f"{self.name}_aligner"
+
     def size(self):
         return len(self.data)
 
@@ -3280,7 +3284,7 @@ class FImage:
 
         # This is to force 8 byte alignment
         if bitsPerValue != 64:
-            code.source = f"Gfx {self.name}_aligner[] = {{gsSPEndDisplayList()}};\n"
+            code.source = f"Gfx {self.aligner_name}[] = {{gsSPEndDisplayList()}};\n"
         code.source += f"u{str(bitsPerValue)} {self.name}[] = {{\n\t"
         code.source += texData
         code.source += "\n};\n\n"

--- a/fast64_internal/f3d/f3d_gbi.py
+++ b/fast64_internal/f3d/f3d_gbi.py
@@ -3399,7 +3399,8 @@ class GbiMacro:
         if static:
             return f"g{'s'*static}{type(self).__name__}({', '.join( self.getargs(static) )})"
         else:
-            return f"g{'s'*static}{type(self).__name__}(glistp++, {', '.join( self.getargs(static) )})"
+            args = ["glistp++"] + list(self.getargs(static))
+            return f"g{'s'*static}{type(self).__name__}({', '.join( args )})"
 
     def size(self, f3d):
         return GFX_SIZE

--- a/fast64_internal/f3d/f3d_material.py
+++ b/fast64_internal/f3d/f3d_material.py
@@ -2143,9 +2143,9 @@ def get_textlut_mode(f3d_mat: "F3DMaterialProperty", inherit_from_tex: bool = Fa
     use_dict = all_combiner_uses(f3d_mat)
     textures = [f3d_mat.tex0] if use_dict["Texture 0"] and f3d_mat.tex0.tex_set else []
     textures += [f3d_mat.tex1] if use_dict["Texture 1"] and f3d_mat.tex1.tex_set else []
-    tlut_modes = [tex.ci_format if tex.tex_format.startswith("CI") else "NONE" for tex in textures]
+    tlut_modes = [tex.tlut_mode for tex in textures]
     if tlut_modes and tlut_modes[0] == tlut_modes[-1]:
-        return "G_TT_" + tlut_modes[0]
+        return tlut_modes[0]
     return None if inherit_from_tex else f3d_mat.rdp_settings.g_mdsft_textlut
 
 
@@ -2858,6 +2858,15 @@ class TextureProperty(PropertyGroup):
     )
     tile_scroll: bpy.props.PointerProperty(type=SetTileSizeScrollProperty)
 
+    @property
+    def is_ci(self):
+        self.tex_format: str
+        return self.tex_format.startswith("CI")
+
+    @property
+    def tlut_mode(self):
+        return f"G_TT_{self.ci_format if self.is_ci else 'NONE'}"
+
     def get_tex_size(self) -> list[int]:
         if self.tex or self.use_tex_reference:
             if self.tex is not None:
@@ -2919,6 +2928,7 @@ def ui_image(
     textureProp: TextureProperty,
     name: str,
     showCheckBox: bool,
+    hide_lowhigh=False,
 ):
     inputGroup = layout.box().column()
 
@@ -3025,7 +3035,8 @@ def ui_image(
                 shift = prop_input.row()
                 shift.prop(textureProp.S, "shift", text="Shift S")
                 shift.prop(textureProp.T, "shift", text="Shift T")
-
+                if hide_lowhigh:
+                    return
                 low = prop_input.row()
                 low.prop(textureProp.S, "low", text="S Low")
                 low.prop(textureProp.T, "low", text="T Low")

--- a/fast64_internal/f3d/f3d_texture_writer.py
+++ b/fast64_internal/f3d/f3d_texture_writer.py
@@ -540,7 +540,7 @@ class TexInfo:
             if self.useTex:
                 self.loadPal = True
             self.palBaseName = self.getPaletteName()
-        if self.tmemSize >= tmem_size:
+        if self.tmemSize > tmem_size:
             if use_large_tex:
                 self.doTexLoad = False
                 return True

--- a/fast64_internal/f3d/f3d_texture_writer.py
+++ b/fast64_internal/f3d/f3d_texture_writer.py
@@ -464,7 +464,7 @@ class TexInfo:
         return True
 
     def materialless_setup(self) -> None:
-        """moreSetupFromModel equivelent that does not handle material properties like OOT flipbooks"""
+        """moreSetupFromModel equivalent that does not handle material properties like OOT flipbooks"""
         if not self.useTex:
             return
 
@@ -485,7 +485,8 @@ class TexInfo:
                     f"Error in Texture {self.indexInMat} uses too many unique colors to fit in format {self.texFormat}."
                 )
         else:
-            self.imDependencies, self.flipbook = [] if self.texProp.tex is None else [self.texProp.tex], None
+            self.imDependencies = [] if self.texProp.tex is None else [self.texProp.tex]
+            self.flipbook = None
 
         self.isPalRef = self.isTexRef and self.flipbook is None
         self.palDependencies = self.imDependencies

--- a/fast64_internal/sm64/sm64_f3d_writer.py
+++ b/fast64_internal/sm64/sm64_f3d_writer.py
@@ -200,7 +200,8 @@ def exportTexRectToC(dirPath, texProp, texDir, savePNG, name, exportToProject, p
 
             # Append/Overwrite texture definition to segment2.c
             overwriteData(
-                f"(Gfx\s*{fImage.aligner_name}\[\]\s*=\s*{{gsSPEndDisplayList\(\)}};\s*)?u{str(formater.texArrayBitSize)}\s*",
+                rf"(Gfx\s+{fImage.aligner_name}\s*\[\s*\]\s*=\s*\{{\s*gsSPEndDisplayList\s*\(\s*\)\s*\}}\s*;\s*)?"
+                rf"u{str(formater.texArrayBitSize)}\s*",
                 fImage.name,
                 data.source,
                 seg2CPath,

--- a/fast64_internal/sm64/sm64_f3d_writer.py
+++ b/fast64_internal/sm64/sm64_f3d_writer.py
@@ -207,14 +207,14 @@ def exportTexRectToC(dirPath, texProp, texDir, savePNG, name, exportToProject, p
                 seg2CPath,
                 None,
                 False,
-                post_regex="\s?\s?",  # tex to c includes 2 newlines
+                post_regex=r"\s?\s?",  # tex to c includes 2 newlines
             )
 
             # Append texture declaration to segment2.h
             writeIfNotFound(seg2HPath, data.header, "#endif")
 
         # Write/Overwrite function to hud.c
-        overwriteData("void\s*", fTexRect.name, code, hudPath, projectExportData[1], True)
+        overwriteData("void\s*", fTexRect.name, code, hudPath, projectExportData[1], True, post_regex=r"\s?")
 
     else:
         exportData = fTexRect.to_c(savePNG, texDir, formater)
@@ -296,7 +296,7 @@ def modifyDLForHUD(data):
     # 	data = data[:matchResult.start(7)] + 'segmented_to_virtual(&' + \
     # 		matchResult.group(7) + ")" +data[matchResult.end(7):]
 
-    return data
+    return data.removesuffix("\n")
 
 
 def exportTexRectCommon(texProp, name, convertTextureData):

--- a/fast64_internal/sm64/sm64_f3d_writer.py
+++ b/fast64_internal/sm64/sm64_f3d_writer.py
@@ -173,12 +173,11 @@ def exportTexRectToC(dirPath, texProp, texDir, savePNG, name, exportToProject, p
 
     formater = SM64GfxFormatter(ScrollMethod.Vertex)
 
+    dynamicData = CData()
+    dynamicData.append(fTexRect.draw.to_c(fTexRect.f3d))
     code = modifyDLForHUD(dynamicData.source)
 
     if exportToProject:
-        dynamicData = CData()
-        dynamicData.append(fTexRect.draw.to_c(fTexRect.f3d))
-
         seg2CPath = os.path.join(dirPath, "bin/segment2.c")
         seg2HPath = os.path.join(dirPath, "src/game/segment2.h")
         seg2TexDir = os.path.join(dirPath, "textures/segment2")
@@ -219,7 +218,6 @@ def exportTexRectToC(dirPath, texProp, texDir, savePNG, name, exportToProject, p
     else:
         exportData = fTexRect.to_c(savePNG, texDir, formater)
         staticData = exportData.staticData
-        dynamicData = exportData.dynamicData
 
         declaration = staticData.header
         data = staticData.source

--- a/fast64_internal/sm64/sm64_f3d_writer.py
+++ b/fast64_internal/sm64/sm64_f3d_writer.py
@@ -312,10 +312,16 @@ def exportTexRectCommon(texProp, name, convertTextureData):
     ti.writeAll(fMaterial, fTexRect, convertTextureData)
     fTexRect.materials[texProp] = (fMaterial, ti.imageDims)
 
+    if use_copy_mode:
+        dsdx = 4 << 10
+        dtdy = 1 << 10
+    else:
+        dsdx = dtdy = 4096 // 4
+
     fTexRect.draw.commands.extend(fMaterial.mat_only_DL.commands)
     fTexRect.draw.commands.extend(fMaterial.texture_DL.commands)
     fTexRect.draw.commands.append(
-        SPScisTextureRectangle(0, 0, (ti.imageDims[0] - 1) << 2, (ti.imageDims[1] - 1) << 2, 0, 0, 0)
+        SPScisTextureRectangle(0, 0, (ti.imageDims[0] - 1) << 2, (ti.imageDims[1] - 1) << 2, 0, 0, 0, dsdx, dtdy)
     )
     fTexRect.draw.commands.append(DPPipeSync())
     fTexRect.draw.commands.extend(fMaterial.revert.commands)

--- a/fast64_internal/utility.py
+++ b/fast64_internal/utility.py
@@ -712,7 +712,7 @@ def getExportDir(customExport, dirPath, headerType, levelName, texDir, dirName):
     return dirPath, texDir
 
 
-def overwriteData(headerRegex, name, value, filePath, writeNewBeforeString, isFunction):
+def overwriteData(headerRegex, name, value, filePath, writeNewBeforeString, isFunction, post_regex=""):
     if os.path.exists(filePath):
         dataFile = open(filePath, "r")
         data = dataFile.read()
@@ -721,7 +721,8 @@ def overwriteData(headerRegex, name, value, filePath, writeNewBeforeString, isFu
         matchResult = re.search(
             headerRegex
             + re.escape(name)
-            + ("\s*\((((?!\)).)*)\)\s*\{(((?!\}).)*)\}" if isFunction else "\[\]\s*=\s*\{(((?!;).)*);"),
+            + ("\s*\((((?!\)).)*)\)\s*\{(((?!\}).)*)\}" if isFunction else "\[\]\s*=\s*\{(((?!;).)*);")
+            + post_regex,
             data,
             re.DOTALL,
         )


### PR DESCRIPTION
Fixes #451 

- Updated: Tex prop is now drawn using ui_image, ui_image has been updated to optionally hide low and high props (are handled by size cmd, does not exist for texture rectangles) 
- materialless_setup func for TexInfo, equivelant to moreSetupFromModel for bpy material-less contexts, obviously cannot handle flipbooks 
- setup_single_tex func for TexInfo, sets up a single texture without the context of the multi texture manager
- ignore_tex_set bool for fromProp
- Use only fromProp and updated writeAll
- Use saveModeSetting (and world defaults) instead of manullay appending each DP command (except for blend color)
- Removed syncs except for the sync after the texrect cmd to do the reverts
- Removed deprecated arg for png exporting in save_textures (assumed from fimage)
- Removed the ) part of the delimiter checked when exporting "Menu", refresh 13 made it `(void)` instead of `()`
- Some basic ui reordering to match other panels
- Added 1 cycle variant for non rgba16 exports
- Fix dynamic displaylists adding an extra comma (caused a compiler error)
- Fix overwritedata not handeling the aligner and made it so palletes are handeled correctly as well