### PR TITLE
[OoT] Update cutscene macro names

### DIFF
--- a/fast64_internal/oot/cutscene/constants.py
+++ b/fast64_internal/oot/cutscene/constants.py
@@ -207,14 +207,14 @@ ootCSListEntryCommands = [
 ]
 
 ootCSSingleCommands = [
-    "CS_BEGIN_CUTSCENE",
-    "CS_END",
+    "CS_HEADER",
+    "CS_END_OF_SCRIPT",
     "CS_TRANSITION",
     "CS_DESTINATION",
 ]
 
 ootCSListAndSingleCommands = ootCSSingleCommands + ootCSListCommands
-ootCSListAndSingleCommands.remove("CS_BEGIN_CUTSCENE")
+ootCSListAndSingleCommands.remove("CS_HEADER")
 ootCutsceneCommandsC = ootCSSingleCommands + ootCSListCommands + ootCSListEntryCommands
 
 cmdToClass = {

--- a/fast64_internal/oot/cutscene/exporter/classes.py
+++ b/fast64_internal/oot/cutscene/exporter/classes.py
@@ -458,5 +458,5 @@ class CutsceneExport(CutsceneCmdToC):
             self.frameCount += self.motionFrameCount - self.frameCount
 
         return (
-            (indent + f"CS_BEGIN_CUTSCENE({self.entryTotal}, {self.frameCount}),\n") + csData + (indent + "CS_END(),\n")
+            (indent + f"CS_HEADER({self.entryTotal}, {self.frameCount}),\n") + csData + (indent + "CS_END_OF_SCRIPT(),\n")
         )

--- a/fast64_internal/oot/cutscene/exporter/classes.py
+++ b/fast64_internal/oot/cutscene/exporter/classes.py
@@ -458,5 +458,7 @@ class CutsceneExport(CutsceneCmdToC):
             self.frameCount += self.motionFrameCount - self.frameCount
 
         return (
-            (indent + f"CS_HEADER({self.entryTotal}, {self.frameCount}),\n") + csData + (indent + "CS_END_OF_SCRIPT(),\n")
+            (indent + f"CS_HEADER({self.entryTotal}, {self.frameCount}),\n")
+            + csData
+            + (indent + "CS_END_OF_SCRIPT(),\n")
         )

--- a/fast64_internal/oot/cutscene/importer/classes.py
+++ b/fast64_internal/oot/cutscene/importer/classes.py
@@ -69,7 +69,7 @@ class CutsceneImport(CutsceneObjectFactory):
         return params
 
     def getNewCutscene(self, csData: str, name: str):
-        params = self.getCmdParams(csData, "CS_BEGIN_CUTSCENE", Cutscene.paramNumber)
+        params = self.getCmdParams(csData, "CS_HEADER", Cutscene.paramNumber)
         return Cutscene(name, getInteger(params[0]), getInteger(params[1]))
 
     def getParsedCutscenes(self):
@@ -158,7 +158,7 @@ class CutsceneImport(CutsceneObjectFactory):
                     if curCmd in ootCutsceneCommandsC:
                         line = line.removesuffix(",") + "\n"
 
-                        if curCmd in ootCSSingleCommands and curCmd != "CS_END":
+                        if curCmd in ootCSSingleCommands and curCmd != "CS_END_OF_SCRIPT":
                             parsedData += line
 
                         if not cmdListFound and curCmd in ootCSListCommands:
@@ -180,7 +180,7 @@ class CutsceneImport(CutsceneObjectFactory):
                                 print(f"{csName}, command:\n{line}")
                                 raise PluginError(f"ERROR: Found a list entry outside a list inside ``{csName}``!")
 
-                        if cmdListFound and nextCmd == "CS_END" or nextCmd in ootCSListAndSingleCommands:
+                        if cmdListFound and nextCmd == "CS_END_OF_SCRIPT" or nextCmd in ootCSListAndSingleCommands:
                             cmdListFound = False
                             parsedCS.append(parsedData)
                             parsedData = ""
@@ -213,7 +213,7 @@ class CutsceneImport(CutsceneObjectFactory):
                 cmdListName = cmdListData.strip().split("(")[0]
 
                 # create a new cutscene data
-                if cmdListName == "CS_BEGIN_CUTSCENE":
+                if cmdListName == "CS_HEADER":
                     cutscene = self.getNewCutscene(data, parsedCS.csName)
 
                 # if we have a cutscene, create and add the commands data in it

--- a/fast64_internal/oot/cutscene/operators.py
+++ b/fast64_internal/oot/cutscene/operators.py
@@ -67,13 +67,13 @@ def insertCutsceneData(filePath: str, csName: str):
                 foundCutscene = True
 
             if foundCutscene:
-                if "CS_BEGIN_CUTSCENE" in line:
+                if "CS_HEADER" in line:
                     # save the index of the line that contains the entry total and the framecount for later use
                     beginIndex = i
 
                 # looking at next line to see if we reached the end of the cs script
                 index = i + 1
-                if index < len(fileLines) and "CS_END" in fileLines[index]:
+                if index < len(fileLines) and "CS_END_OF_SCRIPT" in fileLines[index]:
                     # exporting first to get the new framecount and the total of entries values
                     fileLines.insert(index, motionExporter.getExportData())
 
@@ -90,7 +90,7 @@ def insertCutsceneData(filePath: str, csName: str):
                         frames = re.sub(r"\b([0-9a-fA-F]*)\)", f"{frameCount + motionExporter.frameCount})", beginLine)
                         fileLines[beginIndex] = f"{entries.split(', ')[0]}, {frames.split(', ')[1]}"
                     else:
-                        raise PluginError("ERROR: Can't find `CS_BEGIN_CUTSCENE()` parameters!")
+                        raise PluginError("ERROR: Can't find `CS_HEADER()` parameters!")
                     break
 
     fileData = CData()

--- a/fast64_internal/oot/cutscene_docs.md
+++ b/fast64_internal/oot/cutscene_docs.md
@@ -10,8 +10,8 @@
 ### Commands
 More detailed informations and commands' parameters can be found [here](https://github.com/zeldaret/oot/blob/master/include/z64cutscene_commands.h)
 
-- ``CS_BEGIN_CUTSCENE``: defines the beginning of a cutscene script
-- ``CS_END``: defines the end of a cutscene script 
+- ``CS_HEADER``: defines the length and the total number of command entries for a cutscene script
+- ``CS_END_OF_SCRIPT``: the end of a command list in a cutscene script 
 - ``CS_CAM_POINT``: defines a single camera point, it can be used with any of the "eye" or "at" camera commands
 - ``CS_CAM_EYE``: defines a single eye point, this feature is not used in the final game and lacks polish
 - ``CS_CAM_EYE_SPLINE``: declares a list of "eye" camera points that forms a spline

--- a/fast64_internal/oot/cutscene_docs.md
+++ b/fast64_internal/oot/cutscene_docs.md
@@ -11,7 +11,7 @@
 More detailed informations and commands' parameters can be found [here](https://github.com/zeldaret/oot/blob/master/include/z64cutscene_commands.h)
 
 - ``CS_HEADER``: defines the length and the total number of command entries for a cutscene script
-- ``CS_END_OF_SCRIPT``: the end of a command list in a cutscene script 
+- ``CS_END_OF_SCRIPT``: defines the end of a command list in a cutscene script 
 - ``CS_CAM_POINT``: defines a single camera point, it can be used with any of the "eye" or "at" camera commands
 - ``CS_CAM_EYE``: defines a single eye point, this feature is not used in the final game and lacks polish
 - ``CS_CAM_EYE_SPLINE``: declares a list of "eye" camera points that forms a spline

--- a/fast64_internal/oot/exporter/cutscene/__init__.py
+++ b/fast64_internal/oot/exporter/cutscene/__init__.py
@@ -83,10 +83,10 @@ class Cutscene:
             csData.source = (
                 declarationBase
                 + " = {\n"
-                + (indent + f"CS_BEGIN_CUTSCENE({self.totalEntries}, {self.frameCount}),\n")
+                + (indent + f"CS_HEADER({self.totalEntries}, {self.frameCount}),\n")
                 + (self.data.destination.getCmd() if self.data.destination is not None else "")
                 + "".join(entry.getCmd() for curList in dataListNames for entry in getattr(self.data, curList))
-                + (indent + "CS_END(),\n")
+                + (indent + "CS_END_OF_SCRIPT(),\n")
                 + "};\n\n"
             )
 


### PR DESCRIPTION
Find and replace PR + updated the descriptions to align with what decomp has.
Fixes compatibility issues introduced by https://github.com/zeldaret/oot/pull/2311