### PR TITLE
Add missing versions to `oot_versions_items` and add overlay support for quick import

### DIFF
--- a/fast64_internal/oot/__init__.py
+++ b/fast64_internal/oot/__init__.py
@@ -60,14 +60,19 @@ from .tools import (
 
 oot_versions_items = [
     ("Custom", "Custom", "Custom"),
+    ("ntsc-1.0", "ntsc-1.0", "ntsc-1.0"),
+    ("ntsc-1.1", "ntsc-1.1", "ntsc-1.1"),
+    ("pal-1.0", "pal-1.0", "pal-1.0"),
+    ("ntsc-1.2", "ntsc-1.2", "ntsc-1.2"),
+    ("pal-1.1", "pal-1.1", "pal-1.1"),
     ("gc-jp", "gc-jp", "gc-jp"),
     ("gc-jp-mq", "gc-jp-mq", "gc-jp-mq"),
-    ("gc-jp-ce", "gc-jp-ce", "gc-jp-ce"),
     ("gc-us", "gc-us", "gc-us"),
     ("gc-us-mq", "gc-us-mq", "gc-us-mq"),
+    ("gc-eu-mq-dbg", "gc-eu-mq-dbg", "gc-eu-mq-dbg"),
     ("gc-eu", "gc-eu", "gc-eu"),
     ("gc-eu-mq", "gc-eu-mq", "gc-eu-mq"),
-    ("gc-eu-mq-dbg", "gc-eu-mq-dbg", "gc-eu-mq-dbg"),
+    ("gc-jp-ce", "gc-jp-ce", "gc-jp-ce"),
     ("hackeroot-mq", "HackerOoT", "hackeroot-mq"),  # TODO: force this value if HackerOoT features are enabled?
     ("legacy", "Legacy", "Older Decomp Version"),
 ]

--- a/fast64_internal/oot/cutscene/importer/classes.py
+++ b/fast64_internal/oot/cutscene/importer/classes.py
@@ -115,6 +115,7 @@ class CutsceneImport(CutsceneObjectFactory):
                     if csName in existingCutsceneNames:
                         continue
                     foundCutscene = True
+                    print(f"INFO: Found cutscene '{csName}' in the file data.")
 
                 if foundCutscene:
                     sLine = line.strip()
@@ -129,7 +130,8 @@ class CutsceneImport(CutsceneObjectFactory):
 
                     if "};" in line:
                         foundCutscene = False
-                        cutsceneList.append(csData)
+                        if len(csData) > 0:
+                            cutsceneList.append(csData)
                         csData = []
 
         if len(cutsceneList) == 0:
@@ -187,7 +189,11 @@ class CutsceneImport(CutsceneObjectFactory):
                     elif not "CutsceneData" in curCmd and not "};" in curCmd:
                         print(f"WARNING: Unknown command found: ``{curCmd}``")
                         cmdListFound = False
-            parsedCutscenes.append(ParsedCutscene(csName, parsedCS))
+
+            if csName is not None and len(parsedCS) > 0:
+                parsedCutscenes.append(ParsedCutscene(csName, parsedCS))
+            else:
+                raise PluginError("ERROR: Something wrong happened during the parsing of the cutscene.")
 
         return parsedCutscenes
 
@@ -199,6 +205,9 @@ class CutsceneImport(CutsceneObjectFactory):
         if parsedCutscenes is None:
             # if it's none then there's no cutscene in the file
             return None
+
+        if len(parsedCutscenes) == 0:
+            raise PluginError("ERROR: No cutscene was found.")
 
         cutsceneList: list[Cutscene] = []
 
@@ -485,6 +494,9 @@ class CutsceneImport(CutsceneObjectFactory):
         if cutsceneList is None:
             # if it's none then there's no cutscene in the file
             return csNumber
+
+        if len(cutsceneList) == 0:
+            raise PluginError("ERROR: No cutscene was found.")
 
         for i, cutscene in enumerate(cutsceneList, csNumber):
             print(f'Found Cutscene "{cutscene.name}"! Importing...')


### PR DESCRIPTION
The quick import file was a bit messy so I decided to improve it a bit in the process, also I wanted to add the missing versions to the enum

Now you can use the quick import feature to import data from overlays, I tested it with [`D_808BCE20`](https://github.com/zeldaret/oot/blob/bdc774058ddeabd78cbe961afda61e3c836135f0/src/overlays/actors/ovl_Bg_Treemouth/z_bg_treemouth_cutscene_data.c#L5)