### PR TITLE
[OoT] Move collection operators/functions from oot_utility.py

### DIFF
--- a/fast64_internal/oot/__init__.py
+++ b/fast64_internal/oot/__init__.py
@@ -7,7 +7,8 @@ from .scene.panels import scene_panels_register, scene_panels_unregister
 
 from .props_panel_main import oot_obj_panel_register, oot_obj_panel_unregister, oot_obj_register, oot_obj_unregister
 from .skeleton.properties import OOTSkeletonImportSettings, OOTSkeletonExportSettings
-from .oot_utility import oot_utility_register, oot_utility_unregister, setAllActorsVisibility
+from .collection_utility import collections_register, collections_unregister
+from .oot_utility import setAllActorsVisibility
 from .file_settings import file_register, file_unregister
 from .collision.properties import OOTCollisionExportSettings
 
@@ -141,7 +142,7 @@ def oot_panel_unregister():
 
 def oot_register(registerPanels):
     oot_operator_register()
-    oot_utility_register()
+    collections_register()
     collision_ops_register()  # register first, so panel goes above mat panel
     collision_props_register()
     cutscene_props_register()
@@ -180,7 +181,7 @@ def oot_unregister(unregisterPanels):
         unregister_class(cls)
 
     oot_operator_unregister()
-    oot_utility_unregister()
+    collections_unregister()
     collision_ops_unregister()  # register first, so panel goes above mat panel
     collision_props_unregister()
     oot_obj_unregister()

--- a/fast64_internal/oot/actor/properties.py
+++ b/fast64_internal/oot/actor/properties.py
@@ -6,15 +6,9 @@ from ..oot_constants import ootData, ootEnumCamTransition
 from ..oot_upgrade import upgradeActors
 from ..scene.properties import OOTAlternateSceneHeaderProperty
 from ..room.properties import OOTAlternateRoomHeaderProperty
+from ..collection_utility import drawAddButton, drawCollectionOps
+from ..oot_utility import getRoomObj, getEnumName, drawEnumWithCustom
 from .operators import OOT_SearchActorIDEnumOperator
-
-from ..oot_utility import (
-    getRoomObj,
-    getEnumName,
-    drawAddButton,
-    drawCollectionOps,
-    drawEnumWithCustom,
-)
 
 ootEnumSceneSetupPreset = [
     ("Custom", "Custom", "Custom"),

--- a/fast64_internal/oot/collection_utility.py
+++ b/fast64_internal/oot/collection_utility.py
@@ -1,0 +1,177 @@
+import bpy
+
+from bpy.types import Operator
+from bpy.utils import register_class, unregister_class
+from bpy.props import IntProperty, StringProperty
+from ..utility import PluginError, ootGetSceneOrRoomHeader
+
+
+class OOTCollectionAdd(Operator):
+    bl_idname = "object.oot_collection_add"
+    bl_label = "Add Item"
+    bl_options = {"REGISTER", "UNDO"}
+
+    option: IntProperty()
+    collectionType: StringProperty(default="Actor")
+    subIndex: IntProperty(default=0)
+    objName: StringProperty()
+
+    def execute(self, context):
+        collection = getCollection(self.objName, self.collectionType, self.subIndex)
+
+        collection.add()
+        collection.move(len(collection) - 1, self.option)
+        return {"FINISHED"}
+
+
+class OOTCollectionRemove(Operator):
+    bl_idname = "object.oot_collection_remove"
+    bl_label = "Remove Item"
+    bl_options = {"REGISTER", "UNDO"}
+
+    option: IntProperty()
+    collectionType: StringProperty(default="Actor")
+    subIndex: IntProperty(default=0)
+    objName: StringProperty()
+
+    def execute(self, context):
+        collection = getCollection(self.objName, self.collectionType, self.subIndex)
+        collection.remove(self.option)
+        return {"FINISHED"}
+
+
+class OOTCollectionMove(Operator):
+    bl_idname = "object.oot_collection_move"
+    bl_label = "Move Item"
+    bl_options = {"REGISTER", "UNDO"}
+
+    option: IntProperty()
+    offset: IntProperty()
+    subIndex: IntProperty(default=0)
+    objName: StringProperty()
+
+    collectionType: StringProperty(default="Actor")
+
+    def execute(self, context):
+        collection = getCollection(self.objName, self.collectionType, self.subIndex)
+        collection.move(self.option, self.option + self.offset)
+        return {"FINISHED"}
+
+
+def getCollectionFromIndex(obj, prop, subIndex, isRoom):
+    header = ootGetSceneOrRoomHeader(obj, subIndex, isRoom)
+    return getattr(header, prop)
+
+
+# Operators cannot store mutable references (?), so to reuse PropertyCollection modification code we do this.
+# Save a string identifier in the operator, then choose the member variable based on that.
+# subIndex is for a collection within a collection element
+def getCollection(objName, collectionType, subIndex):
+    obj = bpy.data.objects[objName]
+    if collectionType == "Actor":
+        collection = obj.ootActorProperty.headerSettings.cutsceneHeaders
+    elif collectionType == "Transition Actor":
+        collection = obj.ootTransitionActorProperty.actor.headerSettings.cutsceneHeaders
+    elif collectionType == "Entrance":
+        collection = obj.ootEntranceProperty.actor.headerSettings.cutsceneHeaders
+    elif collectionType == "Room":
+        collection = obj.ootAlternateRoomHeaders.cutsceneHeaders
+    elif collectionType == "Scene":
+        collection = obj.ootAlternateSceneHeaders.cutsceneHeaders
+    elif collectionType == "Light":
+        collection = getCollectionFromIndex(obj, "lightList", subIndex, False)
+    elif collectionType == "Exit":
+        collection = getCollectionFromIndex(obj, "exitList", subIndex, False)
+    elif collectionType == "Object":
+        collection = getCollectionFromIndex(obj, "objectList", subIndex, True)
+    elif collectionType == "Curve":
+        collection = obj.ootSplineProperty.headerSettings.cutsceneHeaders
+    elif collectionType.startswith("CSHdr."):
+        # CSHdr.HeaderNumber[.ListType]
+        # Specifying ListType means uses subIndex
+        toks = collectionType.split(".")
+        assert len(toks) in [2, 3]
+        hdrnum = int(toks[1])
+        collection = getCollectionFromIndex(obj, "csLists", hdrnum, False)
+        if len(toks) == 3:
+            collection = getattr(collection[subIndex], toks[2])
+    elif collectionType.startswith("Cutscene."):
+        # Cutscene.ListType
+        toks = collectionType.split(".")
+        assert len(toks) == 2
+        collection = obj.ootCutsceneProperty.csLists
+        collection = getattr(collection[subIndex], toks[1])
+    elif collectionType == "Cutscene":
+        collection = obj.ootCutsceneProperty.csLists
+    elif collectionType == "extraCutscenes":
+        collection = obj.ootSceneHeader.extraCutscenes
+    elif collectionType == "BgImage":
+        collection = obj.ootRoomHeader.bgImageList
+    else:
+        raise PluginError("Invalid collection type: " + collectionType)
+
+    return collection
+
+
+def drawAddButton(layout, index, collectionType, subIndex, objName):
+    if subIndex is None:
+        subIndex = 0
+    addOp = layout.operator(OOTCollectionAdd.bl_idname)
+    addOp.option = index
+    addOp.collectionType = collectionType
+    addOp.subIndex = subIndex
+    addOp.objName = objName
+
+
+def drawCollectionOps(layout, index, collectionType, subIndex, objName, allowAdd=True, compact=False):
+    if subIndex is None:
+        subIndex = 0
+
+    if not compact:
+        buttons = layout.row(align=True)
+    else:
+        buttons = layout
+
+    if allowAdd:
+        addOp = buttons.operator(OOTCollectionAdd.bl_idname, text="Add" if not compact else "", icon="ADD")
+        addOp.option = index + 1
+        addOp.collectionType = collectionType
+        addOp.subIndex = subIndex
+        addOp.objName = objName
+
+    removeOp = buttons.operator(OOTCollectionRemove.bl_idname, text="Delete" if not compact else "", icon="REMOVE")
+    removeOp.option = index
+    removeOp.collectionType = collectionType
+    removeOp.subIndex = subIndex
+    removeOp.objName = objName
+
+    moveUp = buttons.operator(OOTCollectionMove.bl_idname, text="Up" if not compact else "", icon="TRIA_UP")
+    moveUp.option = index
+    moveUp.offset = -1
+    moveUp.collectionType = collectionType
+    moveUp.subIndex = subIndex
+    moveUp.objName = objName
+
+    moveDown = buttons.operator(OOTCollectionMove.bl_idname, text="Down" if not compact else "", icon="TRIA_DOWN")
+    moveDown.option = index
+    moveDown.offset = 1
+    moveDown.collectionType = collectionType
+    moveDown.subIndex = subIndex
+    moveDown.objName = objName
+
+
+collections_classes = (
+    OOTCollectionAdd,
+    OOTCollectionRemove,
+    OOTCollectionMove,
+)
+
+
+def collections_register():
+    for cls in collections_classes:
+        register_class(cls)
+
+
+def collections_unregister():
+    for cls in reversed(collections_classes):
+        unregister_class(cls)

--- a/fast64_internal/oot/cutscene/operators.py
+++ b/fast64_internal/oot/cutscene/operators.py
@@ -8,7 +8,7 @@ from bpy.props import StringProperty, EnumProperty, IntProperty
 from bpy.types import Scene, Operator, Context
 from bpy.utils import register_class, unregister_class
 from ...utility import CData, PluginError, writeCData, raisePluginError
-from ..oot_utility import getCollection
+from ..collection_utility import getCollection
 from ..oot_constants import ootData
 from .constants import ootEnumCSTextboxType, ootEnumCSListType
 from .importer import importCutsceneData

--- a/fast64_internal/oot/cutscene/properties.py
+++ b/fast64_internal/oot/cutscene/properties.py
@@ -2,7 +2,8 @@ from bpy.types import PropertyGroup, Object, UILayout, Scene, Context
 from bpy.props import StringProperty, EnumProperty, IntProperty, BoolProperty, CollectionProperty, PointerProperty
 from bpy.utils import register_class, unregister_class
 from ...utility import PluginError, prop_split
-from ..oot_utility import OOTCollectionAdd, drawCollectionOps, getEnumName
+from ..collection_utility import OOTCollectionAdd, drawCollectionOps
+from ..oot_utility import getEnumName
 from ..oot_constants import ootData
 from ..oot_upgrade import upgradeCutsceneSubProps, upgradeCSListProps, upgradeCutsceneProperty
 from .operators import OOTCSTextAdd, OOT_SearchCSDestinationEnumOperator, OOTCSListAdd, OOT_SearchCSSeqOperator

--- a/fast64_internal/oot/oot_utility.py
+++ b/fast64_internal/oot/oot_utility.py
@@ -6,8 +6,6 @@ import re
 from ast import parse, Expression, Num, UnaryOp, USub, Invert, BinOp
 from mathutils import Vector
 from bpy.types import Object
-from bpy.utils import register_class, unregister_class
-from bpy.types import Object
 from typing import Callable, Optional, TYPE_CHECKING, List
 from .oot_constants import ootSceneIDToName
 from dataclasses import dataclass
@@ -21,7 +19,6 @@ from ..utility import (
     setOrigin,
     applyRotation,
     cleanupDuplicatedObjects,
-    ootGetSceneOrRoomHeader,
     hexOrDecInt,
     binOps,
 )
@@ -645,160 +642,6 @@ def getCutsceneName(obj):
     return name
 
 
-def getCollectionFromIndex(obj, prop, subIndex, isRoom):
-    header = ootGetSceneOrRoomHeader(obj, subIndex, isRoom)
-    return getattr(header, prop)
-
-
-# Operators cannot store mutable references (?), so to reuse PropertyCollection modification code we do this.
-# Save a string identifier in the operator, then choose the member variable based on that.
-# subIndex is for a collection within a collection element
-def getCollection(objName, collectionType, subIndex):
-    obj = bpy.data.objects[objName]
-    if collectionType == "Actor":
-        collection = obj.ootActorProperty.headerSettings.cutsceneHeaders
-    elif collectionType == "Transition Actor":
-        collection = obj.ootTransitionActorProperty.actor.headerSettings.cutsceneHeaders
-    elif collectionType == "Entrance":
-        collection = obj.ootEntranceProperty.actor.headerSettings.cutsceneHeaders
-    elif collectionType == "Room":
-        collection = obj.ootAlternateRoomHeaders.cutsceneHeaders
-    elif collectionType == "Scene":
-        collection = obj.ootAlternateSceneHeaders.cutsceneHeaders
-    elif collectionType == "Light":
-        collection = getCollectionFromIndex(obj, "lightList", subIndex, False)
-    elif collectionType == "Exit":
-        collection = getCollectionFromIndex(obj, "exitList", subIndex, False)
-    elif collectionType == "Object":
-        collection = getCollectionFromIndex(obj, "objectList", subIndex, True)
-    elif collectionType == "Curve":
-        collection = obj.ootSplineProperty.headerSettings.cutsceneHeaders
-    elif collectionType.startswith("CSHdr."):
-        # CSHdr.HeaderNumber[.ListType]
-        # Specifying ListType means uses subIndex
-        toks = collectionType.split(".")
-        assert len(toks) in [2, 3]
-        hdrnum = int(toks[1])
-        collection = getCollectionFromIndex(obj, "csLists", hdrnum, False)
-        if len(toks) == 3:
-            collection = getattr(collection[subIndex], toks[2])
-    elif collectionType.startswith("Cutscene."):
-        # Cutscene.ListType
-        toks = collectionType.split(".")
-        assert len(toks) == 2
-        collection = obj.ootCutsceneProperty.csLists
-        collection = getattr(collection[subIndex], toks[1])
-    elif collectionType == "Cutscene":
-        collection = obj.ootCutsceneProperty.csLists
-    elif collectionType == "extraCutscenes":
-        collection = obj.ootSceneHeader.extraCutscenes
-    elif collectionType == "BgImage":
-        collection = obj.ootRoomHeader.bgImageList
-    else:
-        raise PluginError("Invalid collection type: " + collectionType)
-
-    return collection
-
-
-def drawAddButton(layout, index, collectionType, subIndex, objName):
-    if subIndex is None:
-        subIndex = 0
-    addOp = layout.operator(OOTCollectionAdd.bl_idname)
-    addOp.option = index
-    addOp.collectionType = collectionType
-    addOp.subIndex = subIndex
-    addOp.objName = objName
-
-
-def drawCollectionOps(layout, index, collectionType, subIndex, objName, allowAdd=True, compact=False):
-    if subIndex is None:
-        subIndex = 0
-
-    if not compact:
-        buttons = layout.row(align=True)
-    else:
-        buttons = layout
-
-    if allowAdd:
-        addOp = buttons.operator(OOTCollectionAdd.bl_idname, text="Add" if not compact else "", icon="ADD")
-        addOp.option = index + 1
-        addOp.collectionType = collectionType
-        addOp.subIndex = subIndex
-        addOp.objName = objName
-
-    removeOp = buttons.operator(OOTCollectionRemove.bl_idname, text="Delete" if not compact else "", icon="REMOVE")
-    removeOp.option = index
-    removeOp.collectionType = collectionType
-    removeOp.subIndex = subIndex
-    removeOp.objName = objName
-
-    moveUp = buttons.operator(OOTCollectionMove.bl_idname, text="Up" if not compact else "", icon="TRIA_UP")
-    moveUp.option = index
-    moveUp.offset = -1
-    moveUp.collectionType = collectionType
-    moveUp.subIndex = subIndex
-    moveUp.objName = objName
-
-    moveDown = buttons.operator(OOTCollectionMove.bl_idname, text="Down" if not compact else "", icon="TRIA_DOWN")
-    moveDown.option = index
-    moveDown.offset = 1
-    moveDown.collectionType = collectionType
-    moveDown.subIndex = subIndex
-    moveDown.objName = objName
-
-
-class OOTCollectionAdd(bpy.types.Operator):
-    bl_idname = "object.oot_collection_add"
-    bl_label = "Add Item"
-    bl_options = {"REGISTER", "UNDO"}
-
-    option: bpy.props.IntProperty()
-    collectionType: bpy.props.StringProperty(default="Actor")
-    subIndex: bpy.props.IntProperty(default=0)
-    objName: bpy.props.StringProperty()
-
-    def execute(self, context):
-        collection = getCollection(self.objName, self.collectionType, self.subIndex)
-
-        collection.add()
-        collection.move(len(collection) - 1, self.option)
-        return {"FINISHED"}
-
-
-class OOTCollectionRemove(bpy.types.Operator):
-    bl_idname = "object.oot_collection_remove"
-    bl_label = "Remove Item"
-    bl_options = {"REGISTER", "UNDO"}
-
-    option: bpy.props.IntProperty()
-    collectionType: bpy.props.StringProperty(default="Actor")
-    subIndex: bpy.props.IntProperty(default=0)
-    objName: bpy.props.StringProperty()
-
-    def execute(self, context):
-        collection = getCollection(self.objName, self.collectionType, self.subIndex)
-        collection.remove(self.option)
-        return {"FINISHED"}
-
-
-class OOTCollectionMove(bpy.types.Operator):
-    bl_idname = "object.oot_collection_move"
-    bl_label = "Move Item"
-    bl_options = {"REGISTER", "UNDO"}
-
-    option: bpy.props.IntProperty()
-    offset: bpy.props.IntProperty()
-    subIndex: bpy.props.IntProperty(default=0)
-    objName: bpy.props.StringProperty()
-
-    collectionType: bpy.props.StringProperty(default="Actor")
-
-    def execute(self, context):
-        collection = getCollection(self.objName, self.collectionType, self.subIndex)
-        collection.move(self.option, self.option + self.offset)
-        return {"FINISHED"}
-
-
 def getHeaderSettings(actorObj: bpy.types.Object):
     itemType = actorObj.ootEmptyType
     if actorObj.type == "EMPTY":
@@ -816,23 +659,6 @@ def getHeaderSettings(actorObj: bpy.types.Object):
         headerSettings = None
 
     return headerSettings
-
-
-oot_utility_classes = (
-    OOTCollectionAdd,
-    OOTCollectionRemove,
-    OOTCollectionMove,
-)
-
-
-def oot_utility_register():
-    for cls in oot_utility_classes:
-        register_class(cls)
-
-
-def oot_utility_unregister():
-    for cls in reversed(oot_utility_classes):
-        unregister_class(cls)
 
 
 def getActiveHeaderIndex() -> int:

--- a/fast64_internal/oot/room/properties.py
+++ b/fast64_internal/oot/room/properties.py
@@ -2,7 +2,8 @@ import bpy
 from bpy.types import PropertyGroup, UILayout, Image, Object
 from bpy.utils import register_class, unregister_class
 from ...utility import prop_split
-from ..oot_utility import drawCollectionOps, onMenuTabChange, onHeaderMenuTabChange, drawEnumWithCustom, drawAddButton
+from ..collection_utility import drawCollectionOps, drawAddButton
+from ..oot_utility import onMenuTabChange, onHeaderMenuTabChange, drawEnumWithCustom
 from ..oot_upgrade import upgradeRoomHeaders
 from .operators import OOT_SearchObjectEnumOperator
 

--- a/fast64_internal/oot/scene/properties.py
+++ b/fast64_internal/oot/scene/properties.py
@@ -13,14 +13,8 @@ from bpy.utils import register_class, unregister_class
 from ...render_settings import on_update_oot_render_settings
 from ...utility import prop_split, customExportWarning
 from ..cutscene.constants import ootEnumCSWriteType
-
-from ..oot_utility import (
-    onMenuTabChange,
-    onHeaderMenuTabChange,
-    drawCollectionOps,
-    drawEnumWithCustom,
-    drawAddButton,
-)
+from ..collection_utility import drawCollectionOps, drawAddButton
+from ..oot_utility import onMenuTabChange, onHeaderMenuTabChange, drawEnumWithCustom
 
 from ..oot_constants import (
     ootEnumMusicSeq,


### PR DESCRIPTION
There's few things to do before having MM support, the main change being making the OoT module of Fast64 a common thing for both games (during my tests I realised it was basically using the same things as OoT so it's better to merge both)

Anyway, I got lost into MM and then I did that, the next step is using `pathlib` everywhere because I had issues with how it's done currently and using that library fixed it