### PR TITLE
[OoT] Fix 2 minor issues

### DIFF
--- a/fast64_internal/oot/actor/properties.py
+++ b/fast64_internal/oot/actor/properties.py
@@ -331,7 +331,7 @@ class OOTActorProperty(PropertyGroup):
                         elif param.type == "Message":
                             param_val = ootData.actorData.messageItemsByKey[cur_prop_value].value
 
-                if "Rot" in target:
+                if "Rot" in target and param.type == "Type":
                     type_value = getEvalParamsInt(getattr(self, get_prop_name(actor.key, "Type", None, 1)))
 
                 if type_value is not None and type_value in param.tiedTypes or len(param.tiedTypes) == 0:

--- a/fast64_internal/oot/room/properties.py
+++ b/fast64_internal/oot/room/properties.py
@@ -49,6 +49,9 @@ class OOTObjectProperty(PropertyGroup):
 
         if isLegacy:
             objectName = ootData.objectData.ootEnumObjectIDLegacy[self["objectID"]][1]
+        elif self.objectKey == "":
+            # just in case there's invalid objects keys, allows users to delete them
+            objectName = "DELETE ME!"
         elif self.objectKey != "Custom":
             objectName = ootData.objectData.objectsByKey[self.objectKey].name
         else:


### PR DESCRIPTION
found two minor issues, the first one is a bug causing the draw to fail if an object has an empty key value, and while investigating this I found another one where rotations would look for an actor's type without checking if it's using one, which caused another bug with the UI

"fixed" the first one by simply checking if the key is empty, and draw a "delete me" label so users can delete the wrong entries (still no idea how it happened though), and fixed the second one simply by checking if the type is used (now that I think about this might not work after all?)