### PR TITLE
SM64: Add missing typecasts from Gfx* to SetTileSize* to suppress compiler warnings

### DIFF
--- a/fast64_internal/sm64/c_templates/tile_scroll.py
+++ b/fast64_internal/sm64/c_templates/tile_scroll.py
@@ -13,28 +13,28 @@ tile_scroll_c = """#include <ultra64.h>
  */
 
 void shift_s(Gfx *dl, u32 cmd, u16 s) {
-    SetTileSize *tile = dl;
+    SetTileSize *tile = (SetTileSize *) dl;
     tile += cmd;
     tile->s += s;
     tile->u += s;
 }
 
 void shift_t(Gfx *dl, u32 cmd, u16 t) {
-    SetTileSize *tile = dl;
+    SetTileSize *tile = (SetTileSize *) dl;
     tile += cmd;
     tile->t += t;
     tile->v += t;
 }
 
 void shift_s_down(Gfx *dl, u32 cmd, u16 s) {
-    SetTileSize *tile = dl;
+    SetTileSize *tile = (SetTileSize *) dl;
     tile += cmd;
     tile->s -= s;
     tile->u += s;
 }
 
 void shift_t_down(Gfx *dl, u32 cmd, u16 t) {
-    SetTileSize *tile = dl;
+    SetTileSize *tile = (SetTileSize *) dl;
     tile += cmd;
     tile->t -= t;
     tile->v += t;


### PR DESCRIPTION
Only took me 3 years to finally address this lol