### PR TITLE
[SM64] Add better exception processing to combined exporter

### DIFF
--- a/fast64_internal/sm64/sm64_collision.py
+++ b/fast64_internal/sm64/sm64_collision.py
@@ -387,7 +387,7 @@ def exportCollisionCommon(obj, transformMatrix, includeSpecials, includeChildren
     try:
         addCollisionTriangles(tempObj, collisionDict, includeChildren, transformMatrix, areaIndex)
         if not collisionDict:
-            raise PluginError("No collision data to export")
+            raise PluginError("No collision data to export", PluginError.exc_warn)
         cleanupDuplicatedObjects(allObjs)
         obj.select_set(True)
         bpy.context.view_layer.objects.active = obj

--- a/fast64_internal/sm64/sm64_geolayout_writer.py
+++ b/fast64_internal/sm64/sm64_geolayout_writer.py
@@ -504,7 +504,7 @@ def convertObjectToGeolayout(
             convertTextureData,
         )
         if is_actor and not meshGeolayout.has_data():
-            raise PluginError("No gfx data to export, gfx export cancelled")
+            raise PluginError("No gfx data to export, gfx export cancelled", PluginError.exc_warn)
     except Exception as e:
         raise Exception(str(e))
     finally:

--- a/fast64_internal/utility.py
+++ b/fast64_internal/utility.py
@@ -10,7 +10,22 @@ CollectionProperty = Any  # collection prop as defined by using bpy.props.Collec
 
 
 class PluginError(Exception):
-    pass
+    # arguments for exception processing
+    exc_halt = "exc_halt"
+    exc_warn = "exc_warn"
+
+    """
+    because exceptions generally go through multiple funcs
+    and layers, the easiest way to check if we have an exception
+    of a certain type is to check for our input string
+    """
+
+    @classmethod
+    def check_exc_warn(self, exc):
+        for arg in exc.args:
+            if type(arg) is str and self.exc_warn in arg:
+                return True
+        return False
 
 
 class VertexWeightError(PluginError):


### PR DESCRIPTION
Typically when exporting all selected with the combined exporter, exceptions were passed over as it would be common for objects to be selected without gfx or col data and to throw an exception.
Now the exceptions I except to appear during this have an extra argument that I catch during exception processing so that I only pass them (e.g. no data type exceptions), and all other valid exceptions will halt the export