### PR TITLE
[OoT] Fixed writing to the spec file

### DIFF
--- a/fast64_internal/oot/exporter/decomp_edit/spec.py
+++ b/fast64_internal/oot/exporter/decomp_edit/spec.py
@@ -99,7 +99,11 @@ class SpecFile:
     @staticmethod
     def new(export_path: str):
         # read the file's data
-        data = get_spec_path(export_path).read_text()
+        spec_path = get_spec_path(export_path)
+        try:
+            data = spec_path.read_text()
+        except FileNotFoundError:
+            raise PluginError(f'ERROR: Can\'t find spec file at "{spec_path}"!')
 
         # Find first instance of "/assets/scenes/", indicating a scene file
         first_scene_include_index = data.index("/assets/scenes/")


### PR DESCRIPTION
Recently decomp changed how the spec file is handled, now there's a split for scenes and overlays (also other files that we don't care here), the `spec` file at the root turned to a folder, which contains the spec file with the includes I mentioned. With this fix it should work properly for both legacy and new decomps (untested for legacy). Also there was an issue where the stuff before the first segment would be misinterpreted if it's not present (which is the case for the scene spec includes).

Note: while it should work properly for normal decomp, it's still broken for HackerOoT specifically because of an `#else` in the scene table