### PR TITLE
[OoT] Fixed actor enums overriding actor types

### DIFF
--- a/fast64_internal/oot/actor/properties.py
+++ b/fast64_internal/oot/actor/properties.py
@@ -319,7 +319,7 @@ class OOTActorProperty(PropertyGroup):
                         have_custom_value = True
                         continue
 
-                    if param.type in {"Type", "Enum"}:
+                    if param.type == "Type":
                         type_value = getEvalParamsInt(cur_prop_value)
                     else:
                         param_val = 0
@@ -330,6 +330,8 @@ class OOTActorProperty(PropertyGroup):
                             param_val = ootData.actorData.collectibleItemsByKey[cur_prop_value].value
                         elif param.type == "Message":
                             param_val = ootData.actorData.messageItemsByKey[cur_prop_value].value
+                        elif param.type == "Enum":
+                            param_val = getEvalParamsInt(cur_prop_value)
 
                 if "Rot" in target:
                     type_value = getEvalParamsInt(getattr(self, get_prop_name(actor.key, "Type", None, 1)))


### PR DESCRIPTION
currently if an actor is using an enum in its data it will ignore the actor's type value, this PR fix this issue (hopefully that's the only major issue in the actor panel :pray: )