### PR TITLE
[OoT] Update actor scale's default value

### DIFF
--- a/fast64_internal/oot/f3d/operators.py
+++ b/fast64_internal/oot/f3d/operators.py
@@ -123,7 +123,7 @@ class OOT_ImportDL(Operator):
             filedata = getImportData(paths)
             f3dContext = OOTF3DContext(get_F3D_GBI(), [name], basePath)
 
-            scale = getOOTScale(settings.actorScale)
+            scale = None
             if not isCustomImport:
                 filedata = ootGetIncludedAssetData(basePath, paths, filedata) + filedata
 
@@ -131,6 +131,9 @@ class OOT_ImportDL(Operator):
                     ootReadTextureArrays(basePath, overlayName, name, f3dContext, False, flipbookArrayIndex2D)
                 if settings.autoDetectActorScale:
                     scale = ootReadActorScale(basePath, overlayName, False)
+
+            if scale is None:
+                scale = getOOTScale(settings.actorScale)
 
             obj = importMeshC(
                 filedata,

--- a/fast64_internal/oot/f3d/properties.py
+++ b/fast64_internal/oot/f3d/properties.py
@@ -62,7 +62,7 @@ class OOTDLImportSettings(PropertyGroup):
     flipbookUses2DArray: BoolProperty(name="Has 2D Flipbook Array", default=False)
     flipbookArrayIndex2D: IntProperty(name="Index if 2D Array", default=0, min=0)
     autoDetectActorScale: BoolProperty(name="Auto Detect Actor Scale", default=True)
-    actorScale: FloatProperty(name="Actor Scale", min=0, default=100)
+    actorScale: FloatProperty(name="Actor Scale", min=0, default=10)
 
     def draw_props(self, layout: UILayout):
         prop_split(layout, self, "name", "DL")

--- a/fast64_internal/oot/oot_f3d_writer.py
+++ b/fast64_internal/oot/oot_f3d_writer.py
@@ -1,4 +1,9 @@
-import bpy, os, re
+import os
+import re
+import bpy
+
+from typing import Optional
+
 from ..utility import CData, getGroupIndexFromname, readFile, writeFile
 from ..f3d.flipbook import flipbook_to_c, flipbook_2d_to_c, flipbook_data_to_c
 from ..f3d.f3d_material import createF3DMat, F3DMaterial_UpdateLock, update_preset_manual
@@ -327,7 +332,7 @@ def writeTextureArraysExisting2D(data: str, flipbook: TextureFlipbook, flipbookA
 
 
 # Note this does not work well with actors containing multiple "parts". (z_en_honotrap)
-def ootReadActorScale(basePath: str, overlayName: str, isLink: bool) -> float:
+def ootReadActorScale(basePath: str, overlayName: str, isLink: bool) -> Optional[float]:
     if not isLink:
         actorData = ootGetActorData(basePath, overlayName)
     else:
@@ -347,4 +352,4 @@ def ootReadActorScale(basePath: str, overlayName: str, isLink: bool) -> float:
             scale = scale[:-1]
         return getOOTScale(1 / float(scale))
 
-    return getOOTScale(100)
+    return None

--- a/fast64_internal/oot/oot_f3d_writer.py
+++ b/fast64_internal/oot/oot_f3d_writer.py
@@ -352,4 +352,5 @@ def ootReadActorScale(basePath: str, overlayName: str, isLink: bool) -> Optional
             scale = scale[:-1]
         return getOOTScale(1 / float(scale))
 
+    print("WARNING: auto-detection failed, defaulting to this panel's actor scale property value")
     return None

--- a/fast64_internal/oot/skeleton/importer/functions.py
+++ b/fast64_internal/oot/skeleton/importer/functions.py
@@ -280,9 +280,12 @@ def ootImportSkeletonC(basePath: str, importSettings: OOTSkeletonImportSettings)
     f3dContext = OOTF3DContext(get_F3D_GBI(), limbList, basePath)
     f3dContext.mat().draw_layer.oot = drawLayer
 
+    actorScale = None
+
     if overlayName is not None and importSettings.autoDetectActorScale:
         actorScale = ootReadActorScale(basePath, overlayName, isLink)
-    else:
+
+    if actorScale is None:
         actorScale = getOOTScale(importSettings.actorScale)
 
     # print(limbList)

--- a/fast64_internal/oot/skeleton/properties.py
+++ b/fast64_internal/oot/skeleton/properties.py
@@ -122,7 +122,7 @@ class OOTSkeletonImportSettings(PropertyGroup):
     flipbookUses2DArray: BoolProperty(name="Has 2D Flipbook Array", default=False)
     flipbookArrayIndex2D: IntProperty(name="Index if 2D Array", default=0, min=0)
     autoDetectActorScale: BoolProperty(name="Auto Detect Actor Scale", default=True)
-    actorScale: FloatProperty(name="Actor Scale", min=0, default=100)
+    actorScale: FloatProperty(name="Actor Scale", min=0, default=10)
 
     def draw_props(self, layout: UILayout):
         prop_split(layout, self, "drawLayer", "Import Draw Layer")
@@ -172,7 +172,7 @@ def skeleton_props_register():
     for cls in oot_skeleton_classes:
         register_class(cls)
 
-    Object.ootActorScale = FloatProperty(min=0, default=100)
+    Object.ootActorScale = FloatProperty(min=0, default=10)
     Object.ootSkeleton = PointerProperty(type=OOTSkeletonProperty)
     Bone.ootBone = PointerProperty(type=OOTBoneProperty)
 


### PR DESCRIPTION
it was mentioned on discord how annoying the value 100 is when exporting actor stuff, this PR change that to 10 (which was the recommended value), also another change: if the auto-detect don't return a value it will default the scale to the one from the `actorScale` value (which is now 10 by default)

discord discussion: https://discord.com/channels/874816709855440926/874819026629574717/1353518470808997980