### PR TITLE
[F3D] F3D bleed render mode reset fix

### DIFF
--- a/fast64_internal/f3d/f3d_bleed.py
+++ b/fast64_internal/f3d/f3d_bleed.py
@@ -393,7 +393,7 @@ class BleedGraphics:
                     reset_cmds.append(self.default_othermode_H)
 
             # render mode takes up most bits of the lower half, so seeing high bit usage is enough to determine render mode was used
-            elif cmd_type == DPSetRenderMode or (cmd_type == "G_SETOTHERMODE_L" and cmd_use.length >= 31):
+            elif cmd_type == DPSetRenderMode or cmd_type == "G_SETOTHERMODE_L":
                 if default_render_mode:
                     reset_cmds.append(
                         SPSetOtherMode(
@@ -403,10 +403,6 @@ class BleedGraphics:
                             [*self.default_othermode_L.flagList, *default_render_mode],
                         )
                     )
-
-            elif cmd_type == "G_SETOTHERMODE_L":
-                if cmd_use != self.default_othermode_L:
-                    reset_cmds.append(self.default_othermode_L)
         return reset_cmds
 
     def bleed_individual_cmd(self, cmd_list: GfxList, cmd: GbiMacro, bleed_state: int, last_cmd_list: GfxList = None):


### PR DESCRIPTION
If you had a material with a changed render mode, and followed that up with a material that only changed the lowest 3 bits (alpha comapre/z src sel) then the bleed reset dictionary would only know to reset the low 3 bits instead of the full render mode.
I have elected to just always change the full othermode_L whenever it is changed.