### PR TITLE
[OoT] Remove `global.h`, `macros.h` and `z64.h` in the exported includes

### DIFF
--- a/fast64_internal/oot/animation/exporter/classes.py
+++ b/fast64_internal/oot/animation/exporter/classes.py
@@ -6,8 +6,9 @@ def convertToUnsignedShort(value: int) -> int:
 
 
 class OOTAnimation:
-    def __init__(self, name):
+    def __init__(self, name, filename: str):
         self.name = toAlnum(name)
+        self.filename = filename
         self.segmentID = None
         self.indices = {}
         self.values = []
@@ -22,7 +23,15 @@ class OOTAnimation:
 
     def toC(self):
         data = CData()
-        data.source += '#include "ultra64.h"\n#include "global.h"\n\n'
+
+        data.header = (
+            f"#ifndef {self.filename.upper()}_H\n"
+            + f"#define {self.filename.upper()}_H\n\n"
+            + '#include "ultra64.h"\n'
+            + '#include "array_count.h"\n'
+            + '#include "z64animation.h"\n\n'
+        )
+        data.source = f'#include "{self.filename}.h"\n\n'
 
         # values
         data.source += "s16 " + self.valuesName() + "[" + str(len(self.values)) + "] = {\n"
@@ -68,6 +77,7 @@ class OOTAnimation:
             + " };\n\n"
         )
 
+        data.header += "\n#endif\n"
         return data
 
 
@@ -84,14 +94,29 @@ class OOTLinkAnimation:
         data = CData()
         animHeaderData = CData()
 
-        data.source += '#include "ultra64.h"\n#include "global.h"\n\n'
-        animHeaderData.source += '#include "ultra64.h"\n#include "global.h"\n\n'
+        data.header = (
+            f"#ifndef {self.dataName().upper()}_H\n"
+            + f"#define {self.dataName().upper()}_H\n\n"
+            + '#include "ultra64.h"\n'
+            + '#include "array_count.h"\n'
+            + '#include "z64animation.h"\n\n'
+        )
+        data.source = f'#include "{self.dataName()}.h"\n\n'
+
+        animHeaderData.header = (
+            f"#ifndef {self.headerName.upper()}_H\n"
+            + f"#define {self.headerName.upper()}_H\n\n"
+            + '#include "ultra64.h"\n'
+            + '#include "array_count.h"\n'
+            + '#include "z64animation.h"\n\n'
+        )
+        animHeaderData.source = f'#include "{self.headerName}.h"\n'
 
         # TODO: handle custom import?
         if isCustomExport:
-            animHeaderData.source += f'#include "{self.dataName()}.h"\n'
+            animHeaderData.source += f'#include "{self.dataName()}.h"\n\n'
         else:
-            animHeaderData.source += f'#include "assets/misc/link_animetion/{self.dataName()}.h"\n'
+            animHeaderData.source += f'#include "assets/misc/link_animetion/{self.dataName()}.h"\n\n'
 
         # data
         data.header += f"extern s16 {self.dataName()}[];\n"
@@ -113,4 +138,6 @@ class OOTLinkAnimation:
             f"LinkAnimationHeader {self.headerName} = {{\n\t{{ {str(self.frameCount)} }}, {self.dataName()} \n}};\n\n"
         )
 
+        data.header += "\n#endif\n"
+        animHeaderData.header += "\n#endif\n"
         return data, animHeaderData

--- a/fast64_internal/oot/animation/exporter/functions.py
+++ b/fast64_internal/oot/animation/exporter/functions.py
@@ -211,14 +211,14 @@ def ootConvertLinkAnimationData(anim, armatureObj, convertTransformMatrix, *, fr
     return frameData
 
 
-def ootExportNonLinkAnimation(armatureObj, convertTransformMatrix, skeletonName):
+def ootExportNonLinkAnimation(armatureObj, convertTransformMatrix, skeletonName, filename: str):
     if armatureObj.animation_data is None or armatureObj.animation_data.action is None:
         raise PluginError("No active animation selected.")
 
     anim = armatureObj.animation_data.action
     stashActionInArmature(armatureObj, anim)
 
-    ootAnim = OOTAnimation(toAlnum(skeletonName + anim.name.capitalize() + "Anim"))
+    ootAnim = OOTAnimation(toAlnum(skeletonName + anim.name.capitalize() + "Anim"), filename)
 
     skeleton = ootConvertArmatureToSkeletonWithoutMesh(armatureObj, convertTransformMatrix, skeletonName)
 

--- a/fast64_internal/oot/animation/operators.py
+++ b/fast64_internal/oot/animation/operators.py
@@ -63,7 +63,7 @@ def exportAnimationC(armatureObj: bpy.types.Object, settings: OOTAnimExportSetti
             addIncludeFiles("gameplay_keep", headerPath, ootAnim.headerName)
 
     else:
-        ootAnim = ootExportNonLinkAnimation(armatureObj, convertTransformMatrix, name)
+        ootAnim = ootExportNonLinkAnimation(armatureObj, convertTransformMatrix, name, filename)
 
         ootAnimC = ootAnim.toC()
         path = ootGetPath(exportPath, settings.isCustom, "assets/objects/", settings.folderName, True, False)

--- a/fast64_internal/oot/cutscene_docs.md
+++ b/fast64_internal/oot/cutscene_docs.md
@@ -8,7 +8,7 @@
 - "Seq": Sequence, it refers to the audio (most of the time it's the background music)
 
 ### Commands
-More detailed informations and commands' parameters can be found [here](https://github.com/zeldaret/oot/blob/master/include/z64cutscene_commands.h)
+More detailed informations and commands' parameters can be found [here](https://github.com/zeldaret/oot/blob/main/include/z64cutscene_commands.h)
 
 - ``CS_HEADER``: defines the length and the total number of command entries for a cutscene script
 - ``CS_END_OF_SCRIPT``: defines the end of a command list in a cutscene script 
@@ -17,7 +17,7 @@ More detailed informations and commands' parameters can be found [here](https://
 - ``CS_CAM_EYE_SPLINE``: declares a list of "eye" camera points that forms a spline
 - ``CS_CAM_AT_SPLINE``: declares a list of "at" camera points that forms a spline
 - ``CS_CAM_EYE_SPLINE_REL_TO_PLAYER`` and ``CS_CAM_AT_SPLINE_REL_TO_PLAYER``: same as the 2 above except these are relative to the player's position and yaw.
-- ``CS_MISC_LIST``: declares a list of various miscellaneous commands, they're all self-explanatory, you can find the list [here](https://github.com/zeldaret/oot/blob/master/include/z64cutscene.h#L167-L204)
+- ``CS_MISC_LIST``: declares a list of various miscellaneous commands, they're all self-explanatory, you can find the list [here](https://github.com/zeldaret/oot/blob/f7a270655bd974242a286856bd56b490a998ac44/include/z64cutscene.h#L156-L193)
 - ``CS_MISC``: defines a single misc command
 - ``CS_LIGHT_SETTING_LIST``: declares a list of light settings commands
 - ``CS_LIGHT_SETTING``: changes the light settings to the specified index, the lighting is defined in the scene

--- a/fast64_internal/oot/exporter/file.py
+++ b/fast64_internal/oot/exporter/file.py
@@ -60,8 +60,7 @@ class SceneFile:
     def setIncludeData(self):
         """Adds includes at the beginning of each file to write"""
 
-        sceneInclude = f'#include "{self.name}.h"\n\n\n'
-        csInclude = sceneInclude[:-2] + '#include "z64cutscene.h"\n' + '#include "z64cutscene_commands.h"\n\n\n'
+        sceneInclude = f'#include "{self.name}.h"\n\n'
 
         for roomData in self.roomList.values():
             roomData.roomMain = self.getSourceWithSceneInclude(sceneInclude, roomData.roomMain)
@@ -70,9 +69,7 @@ class SceneFile:
                 roomData.roomModelInfo = self.getSourceWithSceneInclude(sceneInclude, roomData.roomModelInfo)
                 roomData.roomModel = self.getSourceWithSceneInclude(sceneInclude, roomData.roomModel)
 
-        self.sceneMain = self.getSourceWithSceneInclude(
-            sceneInclude if not self.hasCutscenes() else csInclude, self.sceneMain
-        )
+        self.sceneMain = self.getSourceWithSceneInclude(sceneInclude, self.sceneMain)
 
         if not self.singleFileExport:
             self.sceneCollision = self.getSourceWithSceneInclude(sceneInclude, self.sceneCollision)
@@ -82,7 +79,7 @@ class SceneFile:
 
             if self.hasCutscenes():
                 for i in range(len(self.sceneCutscenes)):
-                    self.sceneCutscenes[i] = self.getSourceWithSceneInclude(csInclude, self.sceneCutscenes[i])
+                    self.sceneCutscenes[i] = self.getSourceWithSceneInclude(sceneInclude, self.sceneCutscenes[i])
 
     def write(self):
         """Writes the scene files"""

--- a/fast64_internal/oot/exporter/scene/__init__.py
+++ b/fast64_internal/oot/exporter/scene/__init__.py
@@ -220,16 +220,22 @@ class Scene:
         sceneCutsceneData = self.getSceneCutscenesC()
         sceneTexturesData = self.getSceneTexturesC(textureExportSettings)
 
-        includes = (
-            "\n".join(
-                [
-                    '#include "ultra64.h"',
-                    '#include "macros.h"',
-                    '#include "z64.h"',
-                ]
-            )
-            + "\n\n\n"
-        )
+        includes = [
+            '#include "ultra64.h"',
+            '#include "romfile.h"',
+            '#include "array_count.h"',
+            '#include "sequence.h"',
+            '#include "z64actor_profile.h"',
+            '#include "z64bgcheck.h"',
+            '#include "z64camera.h"',
+            '#include "z64cutscene.h"',
+            '#include "z64cutscene_commands.h"',
+            '#include "z64environment.h"',
+            '#include "z64math.h"',
+            '#include "z64object.h"',
+            '#include "z64room.h"',
+            '#include "z64scene.h"',
+        ]
 
         return SceneFile(
             self.name,
@@ -246,7 +252,7 @@ class Scene:
             (
                 f"#ifndef {self.name.upper()}_H\n"
                 + f"#define {self.name.upper()}_H\n\n"
-                + includes
+                + ("\n".join(includes) + "\n\n")
                 + sceneMainData.header
                 + "".join(cs.header for cs in sceneCutsceneData)
                 + sceneCollisionData.header

--- a/fast64_internal/oot/f3d/operators.py
+++ b/fast64_internal/oot/f3d/operators.py
@@ -61,12 +61,14 @@ def ootConvertMeshToC(
         ootCleanupScene(originalObj, allObjs)
         raise Exception(str(e))
 
+    filename = settings.filename if settings.isCustomFilename else name
     data = CData()
-    data.source += '#include "ultra64.h"\n#include "global.h"\n'
+    data.header = f"#ifndef {filename.upper()}_H\n" + f"#define {filename.upper()}_H\n\n" + '#include "ultra64.h"\n'
+    data.source = f'#include "{filename}.h"\n\n'
     if not isCustomExport:
-        data.source += '#include "' + folderName + '.h"\n\n'
+        data.header += f'#include "{folderName}.h"\n\n'
     else:
-        data.source += "\n"
+        data.header += "\n"
 
     path = ootGetPath(exportPath, isCustomExport, "assets/objects/", folderName, False, True)
     includeDir = settings.customAssetIncludeDir if settings.isCustom else f"assets/objects/{folderName}"
@@ -80,7 +82,7 @@ def ootConvertMeshToC(
         textureArrayData = writeTextureArraysNew(fModel, flipbookArrayIndex2D)
         data.append(textureArrayData)
 
-    filename = settings.filename if settings.isCustomFilename else name
+    data.header += "\n#endif\n"
     writeCData(data, os.path.join(path, filename + ".h"), os.path.join(path, filename + ".c"))
 
     if not isCustomExport:

--- a/fast64_internal/oot/skeleton/exporter/functions.py
+++ b/fast64_internal/oot/skeleton/exporter/functions.py
@@ -1,4 +1,8 @@
-import mathutils, bpy, os
+import mathutils
+import bpy
+import os
+
+from pathlib import Path
 from ....f3d.f3d_gbi import DLFormat, FMesh, TextureExportSettings, ScrollMethod
 from ....f3d.f3d_writer import getInfoDict
 from ...oot_f3d_writer import ootProcessVertexGroup, writeTextureArraysNew, writeTextureArraysExisting
@@ -273,12 +277,20 @@ def ootConvertArmatureToC(
             limbList[i].lodDL = lodLimbList[i].DL
             limbList[i].isFlex |= lodLimbList[i].isFlex
 
+    header_filename = Path(filename).parts[-1]
     data = CData()
-    data.source += '#include "ultra64.h"\n#include "global.h"\n'
+    data.header = (
+        f"#ifndef {header_filename.upper()}_H\n"
+        + f"#define {header_filename.upper()}_H\n\n"
+        + '#include "ultra64.h"\n'
+        + '#include "array_count.h"\n'
+        + '#include "z64animation.h"\n'
+    )
+    data.source = f'#include "{header_filename}.h"\n\n'
     if not isCustomExport:
-        data.source += '#include "' + folderName + '.h"\n\n'
+        data.header += f'#include "{folderName}.h"\n\n'
     else:
-        data.source += "\n"
+        data.header += "\n"
 
     path = ootGetPath(exportPath, isCustomExport, "assets/objects/", folderName, True, True)
     includeDir = settings.customAssetIncludeDir if settings.isCustom else f"assets/objects/{folderName}"
@@ -294,6 +306,7 @@ def ootConvertArmatureToC(
         textureArrayData = writeTextureArraysNew(fModel, flipbookArrayIndex2D)
         data.append(textureArrayData)
 
+    data.header += "\n#endif\n"
     writeCData(data, os.path.join(path, filename + ".h"), os.path.join(path, filename + ".c"))
 
     if not isCustomExport:


### PR DESCRIPTION
This removes `global.h`, `macros.h` and `z64.h` includes since these files are now deleted in decomp (well, not `z64.h` but it will be removed soon), this changes skeleton, animation, cutscene, DL and scene exporters, the collision one is already done in another PR. I also updated the documentation's wrong links and added "ifdef-define-endif"s in the headers to make it consistent with the other headers from decomp, it exports properly and it looks right but I didn't try to compile (yet)