### PR TITLE
[OoT] Scene/Cutscene Export Fixes

### DIFF
--- a/fast64_internal/oot/cutscene/operators.py
+++ b/fast64_internal/oot/cutscene/operators.py
@@ -50,7 +50,9 @@ def ootCutsceneIncludes(headerfilename):
             + '#include "sequence.h"\n'
             + '#include "z64math.h"\n'
             + '#include "z64cutscene.h"\n'
-            + '#include "z64cutscene_commands.h"\n\n'
+            + '#include "z64cutscene_commands.h"\n'
+            + '#include "z64ocarina.h"\n'
+            + '#include "z64player.h"\n\n'
         )
 
     if len(headerfilename) > 0:

--- a/fast64_internal/oot/exporter/cutscene/actor_cue.py
+++ b/fast64_internal/oot/exporter/cutscene/actor_cue.py
@@ -46,7 +46,7 @@ class CutsceneCmdActorCue(CutsceneCmdBase):
             + "".join(f"{rot}, " for rot in self.rot)
             + "".join(f"{pos}, " for pos in self.startPos)
             + "".join(f"{pos}, " for pos in self.endPos)
-            + "0.0f, 0.0f, 0.0f),\n"
+            + "CS_FLOAT(0, 0.0f), CS_FLOAT(0, 0.0f), CS_FLOAT(0, 0.0f)),\n"
         )
 
 

--- a/fast64_internal/oot/exporter/cutscene/camera.py
+++ b/fast64_internal/oot/exporter/cutscene/camera.py
@@ -1,3 +1,5 @@
+import struct
+
 from dataclasses import dataclass, field
 from ....utility import PluginError, indent
 from ...cutscene.motion.utility import getInteger
@@ -32,8 +34,9 @@ class CutsceneCmdCamPoint(CutsceneCmdBase):
         if len(self.pos) == 0:
             raise PluginError("ERROR: Pos list is empty!")
 
+        angle_ieee = f"0x{struct.unpack('<I', struct.pack('<f', self.viewAngle))[0]:X}"
         return indent * 3 + (
-            f"CS_CAM_POINT({self.continueFlag}, {self.camRoll}, {self.frame}, DEG_TO_BINANG({self.viewAngle}f), "
+            f"CS_CAM_POINT({self.continueFlag}, {self.camRoll}, {self.frame}, CS_FLOAT({angle_ieee}, {self.viewAngle}f), "
             + "".join(f"{pos}, " for pos in self.pos)
             + "0),\n"
         )

--- a/fast64_internal/oot/exporter/cutscene/camera.py
+++ b/fast64_internal/oot/exporter/cutscene/camera.py
@@ -33,7 +33,7 @@ class CutsceneCmdCamPoint(CutsceneCmdBase):
             raise PluginError("ERROR: Pos list is empty!")
 
         return indent * 3 + (
-            f"CS_CAM_POINT({self.continueFlag}, {self.camRoll}, {self.frame}, {self.viewAngle}f, "
+            f"CS_CAM_POINT({self.continueFlag}, {self.camRoll}, {self.frame}, DEG_TO_BINANG({self.viewAngle}f), "
             + "".join(f"{pos}, " for pos in self.pos)
             + "0),\n"
         )

--- a/fast64_internal/oot/exporter/cutscene/camera.py
+++ b/fast64_internal/oot/exporter/cutscene/camera.py
@@ -34,9 +34,9 @@ class CutsceneCmdCamPoint(CutsceneCmdBase):
         if len(self.pos) == 0:
             raise PluginError("ERROR: Pos list is empty!")
 
-        angle_ieee = f"0x{struct.unpack('<I', struct.pack('<f', self.viewAngle))[0]:X}"
+        viewAngle_ieee = f"0x{struct.unpack('<I', struct.pack('<f', self.viewAngle))[0]:X}"
         return indent * 3 + (
-            f"CS_CAM_POINT({self.continueFlag}, {self.camRoll}, {self.frame}, CS_FLOAT({angle_ieee}, {self.viewAngle}f), "
+            f"CS_CAM_POINT({self.continueFlag}, {self.camRoll}, {self.frame}, CS_FLOAT({viewAngle_ieee}, {self.viewAngle}f), "
             + "".join(f"{pos}, " for pos in self.pos)
             + "0),\n"
         )

--- a/fast64_internal/oot/exporter/cutscene/data.py
+++ b/fast64_internal/oot/exporter/cutscene/data.py
@@ -1,5 +1,6 @@
 import bpy
 import math
+import struct
 
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING
@@ -125,7 +126,14 @@ class CutsceneData:
             return hex(r & 0xFFFF)
 
         rotXYZ = [conv(obj.rotation_euler[0]), conv(obj.rotation_euler[2]), conv(obj.rotation_euler[1])]
-        return [f"DEG_TO_BINANG({(int(rot, base=16) * (180 / 0x8000)):.3f}f)" for rot in rotXYZ]
+
+        rotations = []
+        for rot in rotXYZ:
+            rot_float = int(rot, 16) * (180 / 0x8000)
+            rot_ieee = f"0x{struct.unpack('<I', struct.pack('<f', rot_float))[0]:X}"
+            rotations.append(f"CS_FLOAT({rot_ieee}, {rot_float:.3f}f)")
+
+        return rotations
 
     def getOoTPosition(self, pos):
         """Returns the converted Blender position"""

--- a/fast64_internal/oot/exporter/cutscene/data.py
+++ b/fast64_internal/oot/exporter/cutscene/data.py
@@ -126,14 +126,7 @@ class CutsceneData:
             return hex(r & 0xFFFF)
 
         rotXYZ = [conv(obj.rotation_euler[0]), conv(obj.rotation_euler[2]), conv(obj.rotation_euler[1])]
-
-        rotations = []
-        for rot in rotXYZ:
-            rot_float = int(rot, 16) * (180 / 0x8000)
-            rot_ieee = f"0x{struct.unpack('<I', struct.pack('<f', rot_float))[0]:X}"
-            rotations.append(f"CS_FLOAT({rot_ieee}, {rot_float:.3f}f)")
-
-        return rotations
+        return [f"DEG_TO_BINANG({(int(rot, base=16) * (180 / 0x8000)):.3f})" for rot in rotXYZ]
 
     def getOoTPosition(self, pos):
         """Returns the converted Blender position"""

--- a/fast64_internal/oot/exporter/cutscene/data.py
+++ b/fast64_internal/oot/exporter/cutscene/data.py
@@ -125,7 +125,7 @@ class CutsceneData:
             return hex(r & 0xFFFF)
 
         rotXYZ = [conv(obj.rotation_euler[0]), conv(obj.rotation_euler[2]), conv(obj.rotation_euler[1])]
-        return [f"DEG_TO_BINANG({(int(rot, base=16) * (180 / 0x8000)):.3f})" for rot in rotXYZ]
+        return [f"DEG_TO_BINANG({(int(rot, base=16) * (180 / 0x8000)):.3f}f)" for rot in rotXYZ]
 
     def getOoTPosition(self, pos):
         """Returns the converted Blender position"""

--- a/fast64_internal/oot/exporter/cutscene/data.py
+++ b/fast64_internal/oot/exporter/cutscene/data.py
@@ -1,6 +1,5 @@
 import bpy
 import math
-import struct
 
 from dataclasses import dataclass, field
 from typing import TYPE_CHECKING

--- a/fast64_internal/oot/exporter/scene/__init__.py
+++ b/fast64_internal/oot/exporter/scene/__init__.py
@@ -242,6 +242,9 @@ class Scene:
                 '#include "z64environment.h"',
                 '#include "z64math.h"',
                 '#include "z64object.h"',
+                '#include "z64ocarina.h"',
+                '#include "z64path.h"',
+                '#include "z64player.h"',
                 '#include "z64room.h"',
                 '#include "z64scene.h"',
             ]


### PR DESCRIPTION
Addresses #526 and #527, I added 3 missing includes and make camera points use `DEG_TO_BINANG` to fix compile issues with IDO (I tested and it seems to work properly now), also I noticed `getOoTRotation` was exporting floats as doubles I think so I fixed that too (though it probably doesn't matter because of the macro but it bothered me)