### PR TITLE
[OoT] Add move cutscene bone operator

### DIFF
--- a/fast64_internal/oot/cutscene/motion/operators.py
+++ b/fast64_internal/oot/cutscene/motion/operators.py
@@ -3,6 +3,8 @@ import bpy
 from bpy.types import Object, Operator, Context, Armature
 from bpy.utils import register_class, unregister_class
 from bpy.props import StringProperty, EnumProperty, BoolProperty
+import mathutils
+from dataclasses import dataclass
 from ....utility import PluginError
 from ...oot_constants import ootData
 from ..classes import CutsceneObjectFactory
@@ -290,6 +292,126 @@ class CutsceneCmdCreateActorCueList(Operator):
             return {"CANCELLED"}
 
 
+@dataclass
+class SavedBone:
+    name: str
+    head: mathutils.Vector
+    tail: mathutils.Vector
+    shotPointFrame: int
+    shotPointViewAngle: float
+    shotPointRoll: int
+
+    @staticmethod
+    def from_bone(bone: bpy.types.Bone):
+        return SavedBone(
+            bone.name,
+            bone.head,
+            bone.tail,
+            bone.ootCamShotPointProp.shotPointFrame,
+            bone.ootCamShotPointProp.shotPointViewAngle,
+            bone.ootCamShotPointProp.shotPointRoll,
+        )
+
+    def to_edit_bone(self, edit_bone: bpy.types.EditBone):
+        edit_bone.name = self.name
+        edit_bone.head = self.head
+        edit_bone.tail = self.tail
+
+    def to_bone(self, bone: bpy.types.Bone):
+        bone.name = self.name
+        bone.ootCamShotPointProp.shotPointFrame = self.shotPointFrame
+        bone.ootCamShotPointProp.shotPointViewAngle = self.shotPointViewAngle
+        bone.ootCamShotPointProp.shotPointRoll = self.shotPointRoll
+
+
+class CutsceneCmdMoveBone(Operator):
+    bl_idname = "object.fast64_cs_move_bone"
+    bl_label = "Move bone"
+    bl_options = {"REGISTER", "UNDO"}
+
+    direction: EnumProperty(
+        items=(
+            ("UP", "Up", "Up"),
+            ("DOWN", "Down", "Down"),
+        )
+    )
+
+    @classmethod
+    def poll(cls, context: Context):
+        return (
+            context.object is not None
+            and context.object.type == "ARMATURE"
+            and context.object.mode in {"OBJECT", "EDIT"}
+            and context.active_bone is not None
+        )
+
+    def execute(self, context):
+        assert context.object is not None
+        assert context.active_bone is not None
+        armature = context.object.data
+        assert isinstance(armature, bpy.types.Armature)
+
+        if context.object.mode == "EDIT":
+            prev_mode = "EDIT"
+            bpy.ops.object.mode_set(mode="OBJECT")
+        else:
+            prev_mode = "OBJECT"
+
+        saved_bones = [SavedBone.from_bone(_b) for _b in armature.bones.values()]
+
+        target_bone_name = context.active_bone.name
+
+        i_bone_to_move = None
+        for i, sb in enumerate(saved_bones):
+            if sb.name == target_bone_name:
+                i_bone_to_move = i
+                break
+        assert i_bone_to_move is not None
+
+        if (i_bone_to_move == 0 and self.direction == "UP") or (
+            i_bone_to_move == len(saved_bones) - 1 and self.direction == "DOWN"
+        ):
+            # Can't move bone further
+            return {"FINISHED"}
+
+        if self.direction == "UP":
+            assert i_bone_to_move != 0
+            saved_bones_new_order = (
+                saved_bones[: i_bone_to_move - 1]
+                + [saved_bones[i_bone_to_move], saved_bones[i_bone_to_move - 1]]
+                + saved_bones[i_bone_to_move + 1 :]
+            )
+        elif self.direction == "DOWN":
+            assert i_bone_to_move != len(saved_bones) - 1
+            saved_bones_new_order = (
+                saved_bones[:i_bone_to_move]
+                + [saved_bones[i_bone_to_move + 1], saved_bones[i_bone_to_move]]
+                + saved_bones[i_bone_to_move + 2 :]
+            )
+        else:
+            assert False, self.direction
+
+        bpy.ops.object.mode_set(mode="EDIT")
+        while armature.edit_bones:
+            armature.edit_bones.remove(armature.edit_bones[0])
+        for sb in saved_bones_new_order:
+            edit_bone = armature.edit_bones.new(sb.name)
+            sb.to_edit_bone(edit_bone)
+
+            # If head==tail the edit_bone disappears when leaving edit mode
+            assert edit_bone.head != edit_bone.tail, edit_bone
+
+        bpy.ops.object.mode_set(mode="OBJECT")
+        for sb, bone in zip(saved_bones_new_order, armature.bones):
+            sb.to_bone(bone)
+
+        armature.bones[target_bone_name].select = True
+        armature.bones.active = armature.bones[target_bone_name]
+
+        bpy.ops.object.mode_set(mode=prev_mode)
+        return {"FINISHED"}
+
+
 class OOT_SearchActorCueCmdTypeEnumOperator(Operator):
     bl_idname = "object.oot_search_actorcue_cmdtype_enum_operator"
     bl_label = "Select Command Type"
@@ -342,6 +464,7 @@ classes = (
     CutsceneCmdCreateCameraShot,
     CutsceneCmdCreatePlayerCueList,
     CutsceneCmdCreateActorCueList,
+    CutsceneCmdMoveBone,
     OOT_SearchActorCueCmdTypeEnumOperator,
     OOT_SearchPlayerCueIdEnumOperator,
 )

--- a/fast64_internal/oot/cutscene/motion/properties.py
+++ b/fast64_internal/oot/cutscene/motion/properties.py
@@ -231,8 +231,8 @@ class CutsceneCmdCameraShotPointProperty(PropertyGroup):
             row.prop(self, propName)
 
         row = box.row()
-        row.operator("object.fast64_cs_move_bone", text="Move up", icon="TRIA_UP").direction = "UP"
-        row.operator("object.fast64_cs_move_bone", text="Move down", icon="TRIA_DOWN").direction = "DOWN"
+        row.operator(CutsceneCmdMoveBone.bl_idname, text="Move up", icon="TRIA_UP").direction = "UP"
+        row.operator(CutsceneCmdMoveBone.bl_idname, text="Move down", icon="TRIA_DOWN").direction = "DOWN"
 
 
 class OOTCutsceneMotionProperty(PropertyGroup):

--- a/fast64_internal/oot/cutscene/motion/properties.py
+++ b/fast64_internal/oot/cutscene/motion/properties.py
@@ -13,6 +13,7 @@ from .operators import (
     CutsceneCmdCreateActorCuePreview,
     OOT_SearchActorCueCmdTypeEnumOperator,
     CutsceneCmdAddBone,
+    CutsceneCmdMoveBone,
     OOT_SearchPlayerCueIdEnumOperator,
 )
 
@@ -228,6 +229,10 @@ class CutsceneCmdCameraShotPointProperty(PropertyGroup):
         row = box.row()
         for propName in ["shotPointFrame", "shotPointViewAngle", "shotPointRoll"]:
             row.prop(self, propName)
+
+        row = box.row()
+        row.operator("object.fast64_cs_move_bone", text="Move up", icon="TRIA_UP").direction = "UP"
+        row.operator("object.fast64_cs_move_bone", text="Move down", icon="TRIA_DOWN").direction = "DOWN"
 
 
 class OOTCutsceneMotionProperty(PropertyGroup):

--- a/fast64_internal/oot/cutscene/motion/properties.py
+++ b/fast64_internal/oot/cutscene/motion/properties.py
@@ -231,8 +231,8 @@ class CutsceneCmdCameraShotPointProperty(PropertyGroup):
             row.prop(self, propName)
 
         row = box.row()
-        row.operator(CutsceneCmdMoveBone.bl_idname, text="Move up", icon="TRIA_UP").direction = "UP"
-        row.operator(CutsceneCmdMoveBone.bl_idname, text="Move down", icon="TRIA_DOWN").direction = "DOWN"
+        row.operator(CutsceneCmdMoveBone.bl_idname, text="Move Up", icon="TRIA_UP").direction = "UP"
+        row.operator(CutsceneCmdMoveBone.bl_idname, text="Move Down", icon="TRIA_DOWN").direction = "DOWN"
 
 
 class OOTCutsceneMotionProperty(PropertyGroup):

--- a/fast64_internal/oot/cutscene/motion/utility.py
+++ b/fast64_internal/oot/cutscene/motion/utility.py
@@ -225,7 +225,6 @@ def getCameraShotBoneData(shotObj: Object, runChecks: bool):
             print("Camera armature bones are not allowed to have parent bones")
             return None
         boneDataList.append(BoneData(shotObj, bone))
-    boneDataList.sort(key=lambda b: b.name)
 
     if runChecks:
         if boneDataList is None:


### PR DESCRIPTION
Add buttons to move cutscene bones around in OoT cutscenes, since the exporter (and preview *as of this PR*) use them in the order they're displayed in.
Note rather than being actually *moved*, the bones are deleted and re-created

screenshot:

<details>

![image](https://github.com/user-attachments/assets/2e61c95c-b50e-4b59-9868-f0c6f4d36883)

</details>