### PR TITLE
[OoT] Fix player flipbooks export

### DIFF
--- a/fast64_internal/oot/oot_f3d_writer.py
+++ b/fast64_internal/oot/oot_f3d_writer.py
@@ -290,12 +290,12 @@ def writeTextureArraysExisting2D(data: str, flipbook: TextureFlipbook, flipbookA
     array2DMatch = re.search(
         r"(static\s*)?void\s*\*\s*"
         + re.escape(flipbook.name)
-        + r"\s*\[\s*\]\s*\[\s*[0-9a-fA-Fx]*\s*\]\s*=\s*\{(.*?)\}\s*;",
+        + r"\s*\[\s*\]\s*\[\s*[0-9a-zA-Z_]*\s*\]\s*=\s*\{(.*?)\}\s*;",
         newData,
         flags=re.DOTALL,
     )
 
-    newArrayData = "{ " + flipbook_data_to_c(flipbook) + " }"
+    newArrayData = "{\n" + flipbook_data_to_c(flipbook) + " }"
 
     # build a list of arrays here
     # replace existing element if list is large enough


### PR DESCRIPTION
Before, texture arrays were written after the includes (because the addon couldn't find the arrays to edit):
```diff
diff --git a/src/code/z_player_lib.c b/src/code/z_player_lib.c
index 1ac27fdb6..d047f898a 100644
--- a/src/code/z_player_lib.c
+++ b/src/code/z_player_lib.c
@@ -16,6 +16,34 @@
 #include "assets/objects/gameplay_keep/gameplay_keep.h"
 #include "assets/objects/object_link_boy/object_link_boy.h"
 #include "assets/objects/object_link_child/object_link_child.h"
+{     gLinkAdultSkel_mouth_closed_ci8_png_001_ci8,
+    gLinkAdultSkel_mouth_half_ci8_png_001_ci8,
+    gLinkAdultSkel_mouth_open_ci8_png_001_ci8,
+    gLinkAdultSkel_mouth_smile_ci8_png_001_ci8,
+ }
+{     gLinkAdultSkel_eyes_open_ci8_png_001_ci8,
+    gLinkAdultSkel_eyes_half_ci8_png_001_ci8,
+    gLinkAdultSkel_eyes_closed_ci8_png_001_ci8,
+    gLinkAdultSkel_eyes_left_ci8_png_001_ci8,
+    gLinkAdultSkel_eyes_right_ci8_png_001_ci8,
+    gLinkAdultSkel_eyes_wide_ci8_png_001_ci8,
+    gLinkAdultSkel_eyes_down_ci8_png_001_ci8,
+    gLinkAdultSkel_eyes_wincing_ci8_png_001_ci8,
+ }
+{     gLinkAdultSkel_mouth_closed_ci8_png_001_ci8,
+    gLinkAdultSkel_mouth_half_ci8_png_001_ci8,
+    gLinkAdultSkel_mouth_open_ci8_png_001_ci8,
+    gLinkAdultSkel_mouth_smile_ci8_png_001_ci8,
+ }
+{     gLinkAdultSkel_eyes_open_ci8_png_001_ci8,
+    gLinkAdultSkel_eyes_half_ci8_png_001_ci8,
+    gLinkAdultSkel_eyes_closed_ci8_png_001_ci8,
+    gLinkAdultSkel_eyes_left_ci8_png_001_ci8,
+    gLinkAdultSkel_eyes_right_ci8_png_001_ci8,
+    gLinkAdultSkel_eyes_wide_ci8_png_001_ci8,
+    gLinkAdultSkel_eyes_down_ci8_png_001_ci8,
+    gLinkAdultSkel_eyes_wincing_ci8_png_001_ci8,
+ }
 
 #pragma increment_block_number "gc-eu:0 gc-eu-mq:0 gc-jp:128 gc-jp-ce:128 gc-jp-mq:128 gc-us:128 gc-us-mq:128" \
                                "pal-1.0:0 pal-1.1:0"
```

This PR fixes that issue:
```diff
diff --git a/src/code/z_player_lib.c b/src/code/z_player_lib.c
index 1ac27fdb6..563f42af9 100644
--- a/src/code/z_player_lib.c
+++ b/src/code/z_player_lib.c
@@ -1022,18 +1022,17 @@ void* sMouthTextures[PLAYER_MOUTH_MAX] = {
 };
 #else
 // Defining `AVOID_UB` will use a 2D array instead and properly use the child link pointers to allow for shifting.
-void* sEyeTextures[][PLAYER_EYES_MAX] = {
-    {
-        gLinkAdultEyesOpenTex,    // PLAYER_EYES_OPEN
-        gLinkAdultEyesHalfTex,    // PLAYER_EYES_HALF
-        gLinkAdultEyesClosedfTex, // PLAYER_EYES_CLOSED
-        gLinkAdultEyesLeftTex,    // PLAYER_EYES_LEFT
-        gLinkAdultEyesRightTex,   // PLAYER_EYES_RIGHT
-        gLinkAdultEyesWideTex,    // PLAYER_EYES_WIDE
-        gLinkAdultEyesDownTex,    // PLAYER_EYES_DOWN
-        gLinkAdultEyesWincingTex, // PLAYER_EYES_WINCING
-    },
-    {
+void* sEyeTextures[][PLAYER_EYES_MAX] = {{
+    gLinkAdultSkel_eyes_open_ci8_png_001_ci8,
+    gLinkAdultSkel_eyes_half_ci8_png_001_ci8,
+    gLinkAdultSkel_eyes_closed_ci8_png_001_ci8,
+    gLinkAdultSkel_eyes_left_ci8_png_001_ci8,
+    gLinkAdultSkel_eyes_right_ci8_png_001_ci8,
+    gLinkAdultSkel_eyes_wide_ci8_png_001_ci8,
+    gLinkAdultSkel_eyes_down_ci8_png_001_ci8,
+    gLinkAdultSkel_eyes_wincing_ci8_png_001_ci8,
+ },
+{
         gLinkChildEyesOpenTex,    // PLAYER_EYES_OPEN
         gLinkChildEyesHalfTex,    // PLAYER_EYES_HALF
         gLinkChildEyesClosedfTex, // PLAYER_EYES_CLOSED
@@ -1042,23 +1041,20 @@ void* sEyeTextures[][PLAYER_EYES_MAX] = {
         gLinkChildEyesWideTex,    // PLAYER_EYES_WIDE
         gLinkChildEyesDownTex,    // PLAYER_EYES_DOWN
         gLinkChildEyesWincingTex, // PLAYER_EYES_WINCING
-    },
-};
-
-void* sMouthTextures[][PLAYER_MOUTH_MAX] = {
-    {
-        gLinkAdultMouthClosedTex, // PLAYER_MOUTH_CLOSED
-        gLinkAdultMouthHalfTex,   // PLAYER_MOUTH_HALF
-        gLinkAdultMouthOpenTex,   // PLAYER_MOUTH_OPEN
-        gLinkAdultMouthSmileTex,  // PLAYER_MOUTH_SMILE
-    },
-    {
+    }};
+
+void* sMouthTextures[][PLAYER_MOUTH_MAX] = {{
+    gLinkAdultSkel_mouth_closed_ci8_png_001_ci8,
+    gLinkAdultSkel_mouth_half_ci8_png_001_ci8,
+    gLinkAdultSkel_mouth_open_ci8_png_001_ci8,
+    gLinkAdultSkel_mouth_smile_ci8_png_001_ci8,
+ },
+{
         gLinkChildMouthClosedTex, // PLAYER_MOUTH_CLOSED
         gLinkChildMouthHalfTex,   // PLAYER_MOUTH_HALF
         gLinkChildMouthOpenTex,   // PLAYER_MOUTH_OPEN
         gLinkChildMouthSmileTex,  // PLAYER_MOUTH_SMILE
-    },
-};
+    }};
 #endif
 
 Color_RGB8 sTunicColors[PLAYER_TUNIC_MAX] = {
```