### PR TITLE
[OoT] Fixed object being added to the duplicated room object

### DIFF
--- a/fast64_internal/oot/exporter/__init__.py
+++ b/fast64_internal/oot/exporter/__init__.py
@@ -72,6 +72,7 @@ class SceneExport:
             sceneName = f"{toAlnum(exportInfo.name)}_scene"
             newScene = Scene.new(
                 sceneName,
+                originalSceneObj,
                 sceneObj,
                 transform,
                 exportInfo.useMacros,

--- a/fast64_internal/oot/exporter/room/__init__.py
+++ b/fast64_internal/oot/exporter/room/__init__.py
@@ -29,6 +29,7 @@ class Room:
         name: str,
         transform: Matrix,
         sceneObj: Object,
+        original_room_obj: Object,
         roomObj: Object,
         roomShapeType: str,
         model: OOTModel,
@@ -90,7 +91,7 @@ class Room:
             headers.extend([altHeader.childNight, altHeader.adultDay, altHeader.adultNight])
             if len(altHeader.cutscenes) > 0:
                 headers.extend(altHeader.cutscenes)
-        addMissingObjectsToAllRoomHeaders(roomObj, headers)
+        addMissingObjectsToAllRoomHeaders(original_room_obj, headers)
 
         roomShape = RoomShapeUtility.create_shape(
             sceneName, name, roomShapeType, model, transform, sceneObj, roomObj, saveTexturesAsPNG, mainHeaderProps

--- a/fast64_internal/oot/exporter/scene/__init__.py
+++ b/fast64_internal/oot/exporter/scene/__init__.py
@@ -28,10 +28,24 @@ class Scene:
     hasAlternateHeaders: bool
 
     @staticmethod
-    def new(name: str, sceneObj: Object, transform: Matrix, useMacros: bool, saveTexturesAsPNG: bool, model: OOTModel):
+    def new(
+        name: str,
+        original_scene_obj: Object,
+        sceneObj: Object,
+        transform: Matrix,
+        useMacros: bool,
+        saveTexturesAsPNG: bool,
+        model: OOTModel,
+    ):
         i = 0
         rooms = RoomEntries.new(
-            f"{name}_roomList", name.removesuffix("_scene"), model, sceneObj, transform, saveTexturesAsPNG
+            f"{name}_roomList",
+            name.removesuffix("_scene"),
+            model,
+            original_scene_obj,
+            sceneObj,
+            transform,
+            saveTexturesAsPNG,
         )
 
         colHeader = CollisionHeader.new(

--- a/fast64_internal/oot/exporter/scene/rooms.py
+++ b/fast64_internal/oot/exporter/scene/rooms.py
@@ -29,6 +29,9 @@ class RoomEntries:
         original_room_list = getObjectList(original_scene_obj.children_recursive, "EMPTY", "Room")
         assert len(original_room_list) == len(roomObjs)
 
+        roomObjs.sort(key=lambda obj: obj.ootRoomHeader.roomIndex)
+        original_room_list.sort(key=lambda obj: obj.ootRoomHeader.roomIndex)
+
         if len(roomObjs) == 0:
             raise PluginError("ERROR: The scene has no child empties with the 'Room' empty type.")
 

--- a/fast64_internal/oot/exporter/scene/rooms.py
+++ b/fast64_internal/oot/exporter/scene/rooms.py
@@ -13,16 +13,26 @@ class RoomEntries:
     entries: list[Room]
 
     @staticmethod
-    def new(name: str, sceneName: str, model: OOTModel, sceneObj: Object, transform: Matrix, saveTexturesAsPNG: bool):
+    def new(
+        name: str,
+        sceneName: str,
+        model: OOTModel,
+        original_scene_obj: Object,
+        sceneObj: Object,
+        transform: Matrix,
+        saveTexturesAsPNG: bool,
+    ):
         """Returns the room list from empty objects with the type 'Room'"""
 
         roomDict: dict[int, Room] = {}
         roomObjs = getObjectList(sceneObj.children_recursive, "EMPTY", "Room")
+        original_room_list = getObjectList(original_scene_obj.children_recursive, "EMPTY", "Room")
+        assert len(original_room_list) == len(roomObjs)
 
         if len(roomObjs) == 0:
             raise PluginError("ERROR: The scene has no child empties with the 'Room' empty type.")
 
-        for roomObj in roomObjs:
+        for original_room_obj, roomObj in zip(original_room_list, roomObjs):
             roomHeader = roomObj.ootRoomHeader
             roomIndex = roomHeader.roomIndex
 
@@ -34,6 +44,7 @@ class RoomEntries:
                 roomName,
                 transform,
                 sceneObj,
+                original_room_obj,
                 roomObj,
                 roomHeader.roomShape,
                 model.addSubModel(

--- a/fast64_internal/oot/oot_object.py
+++ b/fast64_internal/oot/oot_object.py
@@ -23,7 +23,7 @@ def addMissingObjectsToRoomHeader(roomObj: Object, curHeader: RoomHeader, header
                 for objKey in actor.tiedObjects:
                     if objKey not in ["obj_gameplay_keep", "obj_gameplay_field_keep", "obj_gameplay_dangeon_keep"]:
                         objID = ootData.objectData.objectsByKey[objKey].id
-                        if not (objID in curHeader.objects.objectList):
+                        if objID not in curHeader.objects.objectList:
                             curHeader.objects.objectList.append(objID)
                             addMissingObjectToProp(roomObj, headerIndex, objKey)
 


### PR DESCRIPTION
We missed a little bug with the exporter, when you export actors without their object dependencies, Fast64 will add it automatically, except since the new exporter it was being added to the duplicated room object instead of the original room object

This is addressed by passing the original scene object to `RoomEntries.new()` which will fetch the original room objects to use in `addMissingObjectsToAllRoomHeaders`, not sure if there's a better fix but this works