### PR TITLE
[OoT] Fix animation exporter expecting an object name with custom paths

### DIFF
--- a/fast64_internal/oot/animation/operators.py
+++ b/fast64_internal/oot/animation/operators.py
@@ -18,10 +18,17 @@ from ..oot_utility import (
 
 
 def exportAnimationC(armatureObj: bpy.types.Object, settings: OOTAnimExportSettingsProperty):
+    if settings.isCustom:
+        checkEmptyName(settings.customPath)
+    else:
+        checkEmptyName(settings.folderName)
+
+    if settings.isCustomFilename:
+        checkEmptyName(settings.filename)
+
     path = bpy.path.abspath(settings.customPath)
     exportPath = ootGetObjectPath(settings.isCustom, path, settings.folderName, False)
 
-    checkEmptyName(settings.folderName)
     checkEmptyName(armatureObj.name)
     name = toAlnum(armatureObj.name)
     filename = settings.filename if settings.isCustomFilename else name


### PR DESCRIPTION
Currently the animation exporter assumes you never use a custom path, which can raise an error with `No name entered for the exporter.` if the object name happens to be empty, this PR addresses that issue