### PR TITLE
Fix export of custom conveyorSpeed

### DIFF
--- a/fast64_internal/oot/exporter/collision/__init__.py
+++ b/fast64_internal/oot/exporter/collision/__init__.py
@@ -155,7 +155,9 @@ class CollisionUtility:
                         if colProp.conveyorSpeed == "Custom":
                             conveyorSpeed = colProp.conveyorSpeedCustom
                         else:
-                            conveyorSpeed = int(colProp.conveyorSpeed, base=16) + (4 if colProp.conveyorKeepMomentum else 0)
+                            conveyorSpeed = int(colProp.conveyorSpeed, base=16) + (
+                                4 if colProp.conveyorKeepMomentum else 0
+                            )
                     else:
                         conveyorSpeed = 0
 

--- a/fast64_internal/oot/exporter/collision/__init__.py
+++ b/fast64_internal/oot/exporter/collision/__init__.py
@@ -151,8 +151,14 @@ class CollisionUtility:
 
                     # get surface type and collision poly data
                     useConveyor = colProp.conveyorOption != "None"
-                    conveyorSpeed = int(Utility.getPropValue(colProp, "conveyorSpeed"), base=16) if useConveyor else 0
-                    shouldKeepMomentum = colProp.conveyorKeepMomentum if useConveyor else False
+                    if useConveyor:
+                        if colProp.conveyorSpeed == "Custom":
+                            conveyorSpeed = colProp.conveyorSpeedCustom
+                        else:
+                            conveyorSpeed = int(colProp.conveyorSpeed, base=16) + (4 if colProp.conveyorKeepMomentum else 0)
+                    else:
+                        conveyorSpeed = 0
+
                     surfaceType = SurfaceType(
                         colProp.cameraID,
                         colProp.exitID,
@@ -167,7 +173,7 @@ class CollisionUtility:
                         colProp.lightingSetting,
                         int(colProp.echo, base=16),
                         colProp.hookshotable,
-                        conveyorSpeed + (4 if shouldKeepMomentum else 0),
+                        conveyorSpeed,
                         int(colProp.conveyorRotation / (2 * math.pi) * 0x3F) if useConveyor else 0,
                         colProp.isWallDamage,
                         useMacros,

--- a/fast64_internal/oot/exporter/collision/surface.py
+++ b/fast64_internal/oot/exporter/collision/surface.py
@@ -22,7 +22,7 @@ class SurfaceType:
     lightSetting: int
     echo: int
     canHookshot: bool
-    conveyorSpeed: int
+    conveyorSpeed: int | str
     conveyorDirection: int
     isWallDamage: bool  # unk27
 


### PR DESCRIPTION
custom conveyor speeds can be strings, as returned by `Utility.getPropValue(colProp, "conveyorSpeed")`, but fast64:main always passes it to `int(*, base=16)` which fails on non-hex strings. this PR only uses `int()` on non-custom `conveyorSpeed`s