### PR TITLE
[SM64] Rework actor load exports for level scripts

### DIFF
--- a/fast64_internal/sm64/sm64_constants.py
+++ b/fast64_internal/sm64/sm64_constants.py
@@ -2117,6 +2117,12 @@ groupsSeg6 = [
     ("Custom", "Custom", "Custom"),
 ]
 
+groupsSeg8 = [
+    ("common0", "common0", "Generic course objects (Goomba, Bob-ombs, Cannon etc.)"),
+    ("Do Not Write", "Do Not Write", "Do Not Write"),
+    ("Custom", "Custom", "Custom"),
+]
+
 # groups you can use for the combined object export
 groups_obj_export = [
     ("common0", "common0", "chuckya, boxes, blue coin switch"),

--- a/fast64_internal/sm64/sm64_constants.py
+++ b/fast64_internal/sm64/sm64_constants.py
@@ -2101,7 +2101,7 @@ groupsSeg5 = [
     ("group9", "group9", "Haunted Objects (Boo, Mad Piano etc.)"),
     ("group10", "group10", "Peach/Yoshi"),
     ("group11", "group11", "THI Ojbects (Lakitu, Wiggler, Bubba)"),
-    ("Do Not Write", "Do Not Write", "Do Not Write"),
+    ("None", "None", "None"),
     ("Custom", "Custom", "Custom"),
 ]
 
@@ -2113,13 +2113,13 @@ groupsSeg6 = [
     ("group15", "group15", "Castle Objects (MIPS, Toad etc.)"),
     ("group16", "group16", "Ice Objects (Chill Bully, Moneybags)"),
     ("group17", "group17", "Cave Objects (Swoop, Scuttlebug, Dorrie etc.)"),
-    ("Do Not Write", "Do Not Write", "Do Not Write"),
+    ("None", "None", "None"),
     ("Custom", "Custom", "Custom"),
 ]
 
 groupsSeg8 = [
     ("common0", "common0", "Generic course objects (Goomba, Bob-ombs, Cannon etc.)"),
-    ("Do Not Write", "Do Not Write", "Do Not Write"),
+    ("None", "None", "None"),
     ("Custom", "Custom", "Custom"),
 ]
 

--- a/fast64_internal/sm64/sm64_level_writer.py
+++ b/fast64_internal/sm64/sm64_level_writer.py
@@ -467,9 +467,14 @@ def removeSegmentLoad(levelscript, removedSegment):
 
 def replaceScriptLoads(levelscript, obj):
     newFuncs = []
+    for jumpLink in levelscript.levelFunctions:
+        target = jumpLink.args[0]  # format is [macro, list[args], comment]
+        if "script_func_global_" not in target:
+            newFuncs.append(jumpLink)
+            continue
+
     group_seg_loads = obj.fast64.sm64.segment_loads
     scriptFuncs = (group_seg_loads.group8, group_seg_loads.group5, group_seg_loads.group6)
-
     for func in scriptFuncs:
         if func != "None":
             newFuncs.append(Macro("JUMP_LINK", [func], ""))

--- a/fast64_internal/sm64/sm64_level_writer.py
+++ b/fast64_internal/sm64/sm64_level_writer.py
@@ -468,8 +468,7 @@ def replaceScriptLoads(levelscript, obj):
         scriptNum = int(re.findall(r"\d+", target)[-1])
         # this is common0
         if scriptNum == 1:
-            newFuncs.append(jumpLink)
-            continue
+            newNum = obj.fast64.sm64.segment_loads.group8
         if scriptNum < 13:
             newNum = obj.fast64.sm64.segment_loads.group5
         else:
@@ -850,6 +849,14 @@ def export_level_script_c(obj, prev_level_script, level_name, level_data, level_
             0x06,
         )
         replaceSegmentLoad(prev_level_script, f"_{group_seg_loads.seg6}_geo", "LOAD_RAW", 0x0D)
+    if group_seg_loads.seg8_enum != "Do Not Write":
+        replaceSegmentLoad(
+            prev_level_script,
+            f"_{group_seg_loads.seg8}_{compressionFmt}",
+            f"LOAD_{compressionFmt.upper()}",
+            0x08,
+        )
+        replaceSegmentLoad(prev_level_script, f"_{group_seg_loads.seg8}_geo", "LOAD_RAW", 0x0F)
 
     # write data
     replaceScriptLoads(prev_level_script, obj)

--- a/fast64_internal/sm64/sm64_level_writer.py
+++ b/fast64_internal/sm64/sm64_level_writer.py
@@ -457,6 +457,7 @@ def replaceSegmentLoad(levelscript, segmentName, command, changedSegment):
     changedLoad[1][1] = segmentName + "SegmentRomStart"
     changedLoad[1][2] = segmentName + "SegmentRomEnd"
 
+
 def removeSegmentLoad(levelscript, removedSegment):
     for segmentLoad in levelscript.segmentLoads:
         segmentString = segmentLoad[1][0].lower()
@@ -464,6 +465,7 @@ def removeSegmentLoad(levelscript, removedSegment):
         if segment == removedSegment:
             levelscript.segmentLoads.remove(segmentLoad)
             return
+
 
 def replaceScriptLoads(levelscript, obj):
     newFuncs = []
@@ -478,7 +480,7 @@ def replaceScriptLoads(levelscript, obj):
     for func in scriptFuncs:
         if func != "None":
             newFuncs.append(Macro("JUMP_LINK", [func], ""))
-        
+
     levelscript.levelFunctions = newFuncs
 
 

--- a/fast64_internal/sm64/sm64_objects.py
+++ b/fast64_internal/sm64/sm64_objects.py
@@ -1255,7 +1255,7 @@ class SM64ObjectPanel(bpy.types.Panel):
                 # box.box().label(text = 'Background IDs defined in include/geo_commands.h.')
             box.prop(obj, "actSelectorIgnore")
             box.prop(obj, "setAsStartLevel")
-            grid = box.grid_flow(columns=2)
+            grid = box.grid_flow(columns=1)
             obj.fast64.sm64.segment_loads.draw(grid)
             prop_split(box, obj, "acousticReach", "Acoustic Reach")
             obj.starGetCutscenes.draw(box)

--- a/fast64_internal/sm64/sm64_objects.py
+++ b/fast64_internal/sm64/sm64_objects.py
@@ -1255,8 +1255,10 @@ class SM64ObjectPanel(bpy.types.Panel):
                 # box.box().label(text = 'Background IDs defined in include/geo_commands.h.')
             box.prop(obj, "actSelectorIgnore")
             box.prop(obj, "setAsStartLevel")
-            grid = box.grid_flow(columns=1)
-            obj.fast64.sm64.segment_loads.draw(grid)
+            box.prop(obj, "writeActorLoads")
+            if obj.writeActorLoads:
+                grid = box.grid_flow(columns=1)
+                obj.fast64.sm64.segment_loads.draw(grid)
             prop_split(box, obj, "acousticReach", "Acoustic Reach")
             obj.starGetCutscenes.draw(box)
 
@@ -2783,9 +2785,9 @@ class SM64_SegmentProperties(bpy.types.PropertyGroup):
     seg6_group_custom: bpy.props.StringProperty(name="Segment 6 Group")
     seg8_load_custom: bpy.props.StringProperty(name="Segment 8 Seg")
     seg8_group_custom: bpy.props.StringProperty(name="Segment 8 Group")
-    seg5_enum: bpy.props.EnumProperty(name="Segment 5 Group", default="Do Not Write", items=groupsSeg5)
-    seg6_enum: bpy.props.EnumProperty(name="Segment 6 Group", default="Do Not Write", items=groupsSeg6)
-    seg8_enum: bpy.props.EnumProperty(name="Segment 8 Group", default="Do Not Write", items=groupsSeg8)
+    seg5_enum: bpy.props.EnumProperty(name="Segment 5 Group", default="None", items=groupsSeg5)
+    seg6_enum: bpy.props.EnumProperty(name="Segment 6 Group", default="None", items=groupsSeg6)
+    seg8_enum: bpy.props.EnumProperty(name="Segment 8 Group", default="None", items=groupsSeg8)
 
     def draw(self, layout):
         col = layout.column()
@@ -2805,7 +2807,7 @@ class SM64_SegmentProperties(bpy.types.PropertyGroup):
             prop_split(col, self, "seg8_group_custom", "Segment 8 Group")
 
     def jump_link_from_enum(self, grp):
-        if grp == "Do Not Write":
+        if grp == "None":
             return grp
         elif grp == "common0":
             return f"script_func_global_1"
@@ -3072,6 +3074,7 @@ def sm64_obj_register():
     bpy.types.Object.startDialog = bpy.props.StringProperty(name="Start Dialog", default="DIALOG_000")
     bpy.types.Object.actSelectorIgnore = bpy.props.BoolProperty(name="Skip Act Selector")
     bpy.types.Object.setAsStartLevel = bpy.props.BoolProperty(name="Set As Start Level")
+    bpy.types.Object.writeActorLoads = bpy.props.BoolProperty(name="Write Actor Loads")
 
     bpy.types.Object.switchFunc = bpy.props.StringProperty(
         name="Function", default="", description="Name of function for C, hex address for binary."
@@ -3164,6 +3167,7 @@ def sm64_obj_unregister():
     del bpy.types.Object.startDialog
     del bpy.types.Object.actSelectorIgnore
     del bpy.types.Object.setAsStartLevel
+    del bpy.types.Object.writeActorLoads
     del bpy.types.Object.switchFunc
     del bpy.types.Object.switchParam
     del bpy.types.Object.enableRoomSwitch

--- a/fast64_internal/sm64/sm64_objects.py
+++ b/fast64_internal/sm64/sm64_objects.py
@@ -2827,7 +2827,7 @@ class SM64_SegmentProperties(bpy.types.PropertyGroup):
             return self.seg6_load_custom
         else:
             return self.seg6_enum
-        
+
     @property
     def seg8(self):
         if self.seg8_enum == "Custom":
@@ -2848,7 +2848,7 @@ class SM64_SegmentProperties(bpy.types.PropertyGroup):
             return self.seg6_group_custom
         else:
             return self.jump_link_from_enum(self.seg6_enum)
-        
+
     @property
     def group8(self):
         if self.seg8_enum == "Custom":

--- a/fast64_internal/sm64/sm64_objects.py
+++ b/fast64_internal/sm64/sm64_objects.py
@@ -46,6 +46,7 @@ from .sm64_constants import (
     obj_group_enums,
     groupsSeg5,
     groupsSeg6,
+    groupsSeg8,
     groups_obj_export,
 )
 from .sm64_utility import convert_addr_to_func
@@ -2780,8 +2781,11 @@ class SM64_SegmentProperties(bpy.types.PropertyGroup):
     seg5_group_custom: bpy.props.StringProperty(name="Segment 5 Group")
     seg6_load_custom: bpy.props.StringProperty(name="Segment 6 Seg")
     seg6_group_custom: bpy.props.StringProperty(name="Segment 6 Group")
+    seg8_load_custom: bpy.props.StringProperty(name="Segment 8 Seg")
+    seg8_group_custom: bpy.props.StringProperty(name="Segment 8 Group")
     seg5_enum: bpy.props.EnumProperty(name="Segment 5 Group", default="Do Not Write", items=groupsSeg5)
     seg6_enum: bpy.props.EnumProperty(name="Segment 6 Group", default="Do Not Write", items=groupsSeg6)
+    seg8_enum: bpy.props.EnumProperty(name="Segment 8 Group", default="Do Not Write", items=groupsSeg8)
 
     def draw(self, layout):
         col = layout.column()
@@ -2794,10 +2798,17 @@ class SM64_SegmentProperties(bpy.types.PropertyGroup):
         if self.seg6_enum == "Custom":
             prop_split(col, self, "seg6_load_custom", "Segment 6 Seg")
             prop_split(col, self, "seg6_group_custom", "Segment 6 Group")
+        col = layout.column()
+        prop_split(col, self, "seg8_enum", "Segment 8 Select")
+        if self.seg8_enum == "Custom":
+            prop_split(col, self, "seg8_load_custom", "Segment 8 Seg")
+            prop_split(col, self, "seg8_group_custom", "Segment 8 Group")
 
     def jump_link_from_enum(self, grp):
         if grp == "Do Not Write":
             return grp
+        elif grp == "common0":
+            return f"script_func_global_1"
         num = int(grp.removeprefix("group")) + 1
         return f"script_func_global_{num}"
 
@@ -2814,6 +2825,13 @@ class SM64_SegmentProperties(bpy.types.PropertyGroup):
             return self.seg6_load_custom
         else:
             return self.seg6_enum
+        
+    @property
+    def seg8(self):
+        if self.seg8_enum == "Custom":
+            return self.seg8_load_custom
+        else:
+            return self.seg8_enum
 
     @property
     def group5(self):
@@ -2828,6 +2846,13 @@ class SM64_SegmentProperties(bpy.types.PropertyGroup):
             return self.seg6_group_custom
         else:
             return self.jump_link_from_enum(self.seg6_enum)
+        
+    @property
+    def group8(self):
+        if self.seg8_enum == "Custom":
+            return self.seg8_group_custom
+        else:
+            return self.jump_link_from_enum(self.seg8_enum)
 
 
 class SM64_ObjectProperties(bpy.types.PropertyGroup):


### PR DESCRIPTION
- Adds segment 8 group loads (common0)
- Global "Write Actor Loads" checkbox instead of individual "Do Not Write" options for each segment. If disabled (default) it will export the same exact loads that are already present in the script. If enabled, it will replace the loads with the groups that are selected in Fast 64.
- "Do not write" is replaced with a "None" option for each segment load. If set to none, will remove any existing loads for this segment that are already present in the script.
	
One of the issues with how actor loads are handled in the current system is that it will only ever replace the actor load `JUMP_LINK` commands that already exist. So for instance if a segment 6 group isn't loaded in the original level script, Fast 64 will not add the correct `JUMP_LINK` command because it will have nothing to replace (even though it will still add the segment load itself). This new system lets Fast 64 export all of the necessary commands to load an actor group without needing to specifically overwrite the existing commands.

Making write/don't write a global toggle will allow a user to either handle their actor loads entirely through Fast 64 or by modifying the level script by hand, meaning that additional commands can be written by Fast 64 if necessary without breaking anything for users who do not want Fast 64 to handle this. This should also let Fast 64 play nicer with custom groups, since it will no longer have to guess which segment each `JUMP_LINK` command is meant to be for by looking at the number in the script name, instead it will simply export the three scripts that are specified (or less if any of them are set to "None").