### PR TITLE
[OoT] Fix cutscene export issues

### DIFF
--- a/fast64_internal/z64/exporter/cutscene/__init__.py
+++ b/fast64_internal/z64/exporter/cutscene/__init__.py
@@ -178,7 +178,7 @@ class SceneCutscene:
     @staticmethod
     def new(props: OOTSceneHeaderProperty, headerIndex: int, useMacros: bool):
         csObj: Object = props.csWriteObject
-        cutsceneObjects: list[Object] = [csObj for csObj in props.extraCutscenes]
+        cutsceneObjects: list[Object] = [extraCS.csObject for extraCS in props.extraCutscenes]
         entries: list[Cutscene] = []
 
         if headerIndex > 0 and len(cutsceneObjects) > 0:


### PR DESCRIPTION
- fixes an issue where extra cutscenes couldn't be exported
- ~~added a check to check if the path exists for the standalone exporter, for some reasons relative paths are broken for me but it makes no sense at all, I don't see why it wouldn't work but absolute paths works properly~~ actually no forget about that I'm dumb