### PR TITLE
[Codebase] Restore original functionality to setOrigin

### DIFF
--- a/fast64_internal/utility.py
+++ b/fast64_internal/utility.py
@@ -722,6 +722,10 @@ def setOrigin(obj: bpy.types.Object, target_loc: mathutils.Vector):
         active_object=obj,
     ):
         obj.data.transform(mathutils.Matrix.Translation(-offset))
+        # Applying location puts the object origin at world origin
+        # (It is only needed to apply location to set the origin,
+        #  but historically this function has applied all transforms
+        #  so just keep doing that to not break anything)
         bpy.ops.object.transform_apply()
         obj.location = target_loc
 

--- a/fast64_internal/utility.py
+++ b/fast64_internal/utility.py
@@ -712,17 +712,16 @@ def checkIdentityRotation(obj, rotation, allowYaw):
 
 
 def setOrigin(obj: bpy.types.Object, target_loc: mathutils.Vector):
+    assert obj.type == "MESH", "Object is not a mesh"
+
     if not target_loc.is_frozen:
         target_loc = target_loc.copy()
+    offset = target_loc - obj.location
     with bpy.context.temp_override(
         selected_objects=[obj],
         active_object=obj,
     ):
-        obj.location += -target_loc
-        # Applying location puts the object origin at world origin
-        # (It is only needed to apply location to set the origin,
-        #  but historically this function has applied all transforms
-        #  so just keep doing that to not break anything)
+        obj.data.transform(mathutils.Matrix.Translation(-offset))
         bpy.ops.object.transform_apply()
         obj.location = target_loc
 


### PR DESCRIPTION
the remade version of set origin was not equivalent to the previous one, breaking SM64. we were applying -target_loc instead of the offset between target loc and the original location