### PR TITLE
[SM64] Concept: Use desgraph updates to set current versions at runtime

### DIFF
--- a/fast64_internal/sm64/animation/properties.py
+++ b/fast64_internal/sm64/animation/properties.py
@@ -883,7 +883,7 @@ class SM64_AnimProperties(PropertyGroup):
 
     importing: PointerProperty(type=SM64_AnimImportProperties)
 
-    def upgrade_old_props(self, scene: Scene):
+    def upgrade_version_0(self, scene: Scene):
         self.importing.upgrade_old_props(scene)
 
         # Export
@@ -931,10 +931,13 @@ class SM64_AnimProperties(PropertyGroup):
 
         self.version = 1
 
-    def upgrade_changed_props(self, scene):
-        if self.version != self.cur_version:
-            self.upgrade_old_props(scene)
-            self.version = SM64_AnimProperties.cur_version
+    def upgrade_scene(self, scene: Scene):
+        if self.version < self.cur_version:
+            self.upgrade_version_0(scene)
+            self.set_to_newest_version()
+
+    def set_to_newest_version(self):
+        self.version = self.cur_version
 
 
 class SM64_ArmatureAnimProperties(PropertyGroup):

--- a/fast64_internal/sm64/custom_cmd/properties.py
+++ b/fast64_internal/sm64/custom_cmd/properties.py
@@ -735,6 +735,7 @@ def custom_cmd_change_preset(self: "SM64_CustomCmdProperties", context: Context)
 
 class SM64_CustomCmdProperties(PropertyGroup):
     version: IntProperty(name="SM64_CustomCmdProperties Version", default=0)
+    cur_version = 1
 
     tab: BoolProperty(default=False)
     preset: EnumProperty(items=get_custom_cmd_preset_enum, update=custom_cmd_change_preset)
@@ -826,8 +827,11 @@ class SM64_CustomCmdProperties(PropertyGroup):
     def preset_hash(self):
         return str(hash(str(self.to_dict("PRESET_EDIT", include_defaults=False).items())))
 
+    def set_to_newest_version(self):
+        self.version = self.cur_version
+
     def upgrade_object(self, obj: Object):
-        if self.version != 0:
+        if self.version == self.cur_version:
             return
         found_cmd, arg = upgrade_old_prop(self, "str_cmd", obj, "customGeoCommand"), get_first_set_prop(
             obj, "customGeoCommandArgs"
@@ -840,7 +844,7 @@ class SM64_CustomCmdProperties(PropertyGroup):
             self.args[-1].parameter = arg
 
     def upgrade_bone(self, bone: Bone):
-        if self.version != 0:
+        if self.version == self.cur_version:
             return
         upgrade_old_prop(self, "str_cmd", self, "custom_geo_cmd_macro")
         args = get_first_set_prop(self, "custom_geo_cmd_args")

--- a/fast64_internal/sm64/tools/properties.py
+++ b/fast64_internal/sm64/tools/properties.py
@@ -21,10 +21,15 @@ class SM64_AddrConvProperties(PropertyGroup):
     level: EnumProperty(items=enumLevelNames, name="Level", default="castle_inside")
     clipboard: BoolProperty(name="Copy to Clipboard", default=True)
 
-    def upgrade_changed_props(self, scene: Scene):
+    def upgrade_scene(self, scene: Scene):
+        if self.version >= self.cur_version:
+            return
         upgrade_old_prop(self, "address", scene, "convertibleAddr", fix_forced_base_16=True)
         upgrade_old_prop(self, "level", scene, "level")
-        self.version = SM64_AddrConvProperties.cur_version
+        self.set_to_newest_version()
+
+    def set_to_newest_version(self):
+        self.version = self.cur_version
 
     def draw_props(self, layout: UILayout, import_rom: PathLike = None):
         col = layout.column()


### PR DESCRIPTION
Instead of always running upgrade code on new objects/bones/scenes on file load, we make sure they get the new version as soon as possible. This is ideal considering we are gathering properties from keys that could be very likely exist in another addon.

That said, I feel like there has to be a better approach to this? I can´t really figure out one. This does work it just feels hacky I guess, even if this is how materials work.

Related to [#vversionersion](https://github.com/Fast-64/fast64/issues/179)

@Yanis002 Would this work for oot too? Is it even worth it considering oot at least uses oot as a prefix in old names aha.