### PR TITLE
[SM64] Bug fix for animation rework table logic

### DIFF
--- a/fast64_internal/sm64/animation/classes.py
+++ b/fast64_internal/sm64/animation/classes.py
@@ -906,7 +906,7 @@ class SM64_AnimTable:
                         i,
                     )
             element_start, element_end = adjust_start_end(
-                table_start + element_match.start(), table_start + element_match.end(), comment_map
+                start + element_match.start(), start + element_match.end(), comment_map
             )
             self.elements.append(
                 SM64_AnimTableElement(

--- a/fast64_internal/sm64/animation/exporting.py
+++ b/fast64_internal/sm64/animation/exporting.py
@@ -517,16 +517,17 @@ def update_table_file(
 ):
     assert isinstance(table.reference, str) and table.reference, "Invalid table reference"
 
-    text, comment_less, enum_text, comment_map = "", "", "", []
+    text, enum_text = "", ""
     existing_file = table_path.exists() and not override_files
     if existing_file:
         text = table_path.read_text()
-        comment_less, comment_map = get_comment_map(text)
+    comment_less, comment_map = get_comment_map(text)
 
     # add include if not already there
     descriptor = to_include_descriptor(Path("table_enum.h"))
     if gen_enums and len(find_descriptor_in_text(descriptor, comment_less, comment_map)) == 0:
         text = '#include "table_enum.h"\n' + text
+        comment_less, comment_map = get_comment_map(text)
 
     # First, find existing tables
     tables = import_tables(comment_less, table_path, comment_map, table.reference)


### PR DESCRIPTION
Along the development cycle of animation rework, I made some relevant comment handling changes, admittedly i missed two small details, that we need to adjust from start (commentless) instead of table_start (comment adjusted pos). And that we need to rerun the comment map function after adding the enum include