### PR TITLE
[Codebase] Fix setOrigin AGAIN

### DIFF
--- a/fast64_internal/utility.py
+++ b/fast64_internal/utility.py
@@ -722,10 +722,11 @@ def setOrigin(obj: bpy.types.Object, target_loc: mathutils.Vector):
     mesh: bpy.types.Mesh = obj.data
 
     original_mat = obj.matrix_world.copy()
-    target_mat = original_mat.copy()
+    mesh.transform(original_mat)
 
+    target_mat = original_mat.copy()
     target_mat.translation = target_loc
-    mesh.transform(target_mat.inverted() @ original_mat)
+    mesh.transform(target_mat.inverted())
     obj.matrix_world = target_mat
 
 


### PR DESCRIPTION
transform_apply was not neeeded, typehint was missing and offset was being affected by obj.location, we actually just zero it out now before applying the world matrix. also removed the temp_override cause transform already does that.