### PR TITLE
[Draft] Changes related to running Blender in background mode

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -219,6 +219,11 @@ class Fast64Settings_Properties(bpy.types.PropertyGroup):
 
     internal_game_update_ver: bpy.props.IntProperty(default=0)
 
+    internal_background_mode: bpy.props.BoolProperty(
+        default=False,
+        description="Used to disable certain parts of the codebase when Fast64 is ran with Blender in CLI mode",
+    )
+
     def to_repo_settings(self):
         data = {}
         data["autoLoad"] = self.auto_repo_load_settings

--- a/fast64_internal/utility.py
+++ b/fast64_internal/utility.py
@@ -155,7 +155,10 @@ def unhideAllAndGetHiddenState(scene):
 
     if bpy.context.mode != "OBJECT":
         bpy.ops.object.mode_set(mode="OBJECT")
-    bpy.ops.object.hide_view_clear()
+
+    if not scene.fast64.settings.internal_background_mode:
+        # the viewport is disabled when blender is ran in background mode, so we need to disable this to avoid errors
+        bpy.ops.object.hide_view_clear()
 
     hiddenLayerCols = []
 


### PR DESCRIPTION
I'm making [a tool](https://github.com/Yanis002/HackerTestSuite) that can export any scene/level with Fast64 and build automatically decomp with the necessary changes (mainly focused on OoT but can be for any game), to do that I need to make changes to fix some issues (well, one so far, `blender --background` disables the viewport and that's causing an issue when exporting because of `bpy.ops.object.hide_view_clear()` in `unhideAllAndGetHiddenState`)

Making this a draft for now because I'm not sure what's actually necessary, I only did exporting stuff but I have to try imports at some point