### PR TITLE
[OoT] Fix misplaced objects bug

### DIFF
--- a/fast64_internal/z64/utility.py
+++ b/fast64_internal/z64/utility.py
@@ -360,6 +360,7 @@ def clear_mesh_children(scene_obj: Object, scene_objs: list[Object]):
                 if obj in room_obj.children_recursive:
                     assign_new_parent(obj, room_obj)
                     assign_scene = False
+                    break
 
             if assign_scene:
                 assign_new_parent(obj, scene_obj)


### PR DESCRIPTION
probably a hacky fix but `setOrigin` now have the annoying side-effect of moving any child object the mesh got, I'm not sure how to fix that properly so I just made it so any object that is a child of a mesh is parented to whatever object the mesh is parented to, so basically moving it by one level in the hierarchy, shouldn't hurt anything

the issue specifically happens in `applyRotation` in `ootDuplicateHierarchy`, basically anything that runs `bpy.ops.object.transform_apply()` will move the objects, idk how to fix that but I think editing the tree of the duplicated objects is good enough, it won't change anything for users anyway since it's a temporary tree :shrug: 

Note: only tested with scenes but this change also affects DL, collision exporters, which are untested