### PR TITLE
[OoT] Some CS export fixes and improvements

### DIFF
--- a/fast64_internal/z64/__init__.py
+++ b/fast64_internal/z64/__init__.py
@@ -134,6 +134,9 @@ class OOT_Properties(bpy.types.PropertyGroup):
     hackeroot_settings: bpy.props.PointerProperty(type=HackerOoTSettings)
     anim_mats_export_settings: bpy.props.PointerProperty(type=Z64_AnimatedMaterialExportSettings)
     anim_mats_import_settings: bpy.props.PointerProperty(type=Z64_AnimatedMaterialImportSettings)
+    export_cutscene_obj: bpy.props.PointerProperty(
+        type=bpy.types.Object, poll=lambda self, obj: obj.type == "EMPTY" and obj.ootEmptyType == "Cutscene"
+    )
 
     def get_extracted_path(self):
         version = self.oot_version if game_data.z64.is_oot() else self.mm_version

--- a/fast64_internal/z64/cutscene/operators.py
+++ b/fast64_internal/z64/cutscene/operators.py
@@ -77,7 +77,10 @@ class OOT_ExportCutscene(Operator):
             if context.mode != "OBJECT":
                 object.mode_set(mode="OBJECT")
 
-            cs_obj = context.view_layer.objects.active
+            if context.scene.fast64.oot.export_cutscene_obj is not None:
+                cs_obj = context.scene.fast64.oot.export_cutscene_obj
+            else:
+                cs_obj = context.view_layer.objects.active
 
             if cs_obj is None or cs_obj.type != "EMPTY" or cs_obj.ootEmptyType != "Cutscene":
                 raise PluginError("You must select a cutscene object")

--- a/fast64_internal/z64/cutscene/panels.py
+++ b/fast64_internal/z64/cutscene/panels.py
@@ -23,37 +23,42 @@ class OOT_CutscenePanel(OOT_Panel):
     def draw(self, context):
         layout = self.layout
 
-        exportBox = layout.box()
-        exportBox.label(text="Cutscene Exporter")
+        export_box = layout.box().column()
+        export_box.label(text="Cutscene Exporter")
 
-        prop_split(exportBox, context.scene, "ootCutsceneExportPath", "Export To")
+        prop_split(export_box, context.scene, "ootCutsceneExportPath", "Export To")
+        prop_split(export_box, context.scene.fast64.oot, "export_cutscene_obj", "CS Object")
 
-        activeObj = context.view_layer.objects.active
+        cs_obj = context.scene.fast64.oot.export_cutscene_obj
+
+        if cs_obj is None:
+            cs_obj = context.view_layer.objects.active
+
         label = None
-        col = exportBox.column()
-        colcol = col.column()
-        if activeObj is None or activeObj.type != "EMPTY" or activeObj.ootEmptyType != "Cutscene":
+        if cs_obj is None or cs_obj.type != "EMPTY" or cs_obj.ootEmptyType != "Cutscene":
             label = "Select a cutscene object"
 
-        if activeObj is not None and activeObj.parent is not None:
+        if cs_obj is not None and cs_obj.parent is not None:
             label = "Cutscene object must not be parented to anything"
 
+        export_op_layout = export_box.column()
+
         if label is not None:
-            col.label(text=label)
-            colcol.enabled = False
+            export_box.label(text=label)
+            export_op_layout.enabled = False
 
-        colcol.operator(OOT_ExportCutscene.bl_idname)
-        col.operator(OOT_ExportAllCutscenes.bl_idname)
+        export_op_layout.operator(OOT_ExportCutscene.bl_idname)
+        export_box.operator(OOT_ExportAllCutscenes.bl_idname)
 
-        importBox = layout.box()
-        importBox.label(text="Cutscene Importer")
-        prop_split(importBox, context.scene, "ootCSImportName", "Import")
-        prop_split(importBox, context.scene, "ootCutsceneImportPath", "From")
+        import_box = layout.box().column()
+        import_box.label(text="Cutscene Importer")
+        prop_split(import_box, context.scene, "ootCSImportName", "Import")
+        prop_split(import_box, context.scene, "ootCutsceneImportPath", "From")
 
-        col = importBox.column()
         if len(context.scene.ootCSImportName) == 0:
-            col.label(text="All Cutscenes will be imported.")
-        col.operator(OOT_ImportCutscene.bl_idname)
+            import_box.label(text="All Cutscenes will be imported.")
+
+        import_box.operator(OOT_ImportCutscene.bl_idname)
 
 
 oot_cutscene_panel_classes = (

--- a/fast64_internal/z64/exporter/cutscene/__init__.py
+++ b/fast64_internal/z64/exporter/cutscene/__init__.py
@@ -145,7 +145,7 @@ class Cutscene:
                     '#include "command_macros_base.h"',
                     '#include "z64cutscene_commands.h"',
                 ]
-            else:
+            elif bpy.context.scene.fast64.oot.is_z64sceneh_present():
                 includes = [
                     '#include "ultra64.h"',
                     '#include "sequence.h"',
@@ -154,6 +154,16 @@ class Cutscene:
                     '#include "z64cutscene_commands.h"',
                     '#include "z64ocarina.h"',
                     '#include "z64player.h"',
+                ]
+            else:
+                includes = [
+                    '#include "ultra64.h"',
+                    '#include "sequence.h"',
+                    '#include "math.h"',
+                    '#include "cutscene.h"',
+                    '#include "cutscene_commands.h"',
+                    '#include "ocarina.h"',
+                    '#include "player.h"',
                 ]
 
             filedata.header = (


### PR DESCRIPTION
random changes related to the cs exporter, added a "cs object" picker to let you pick one cs and never need it to be the active object (just for convenience, you can still do an export based on the active object if that field is left empty), I fixed include issues also and improved a bit the panel (internally)