### PR TITLE
[SM64] Don't use room export logic for switch nodes in object exports

### DIFF
--- a/fast64_internal/sm64/sm64_geolayout_writer.py
+++ b/fast64_internal/sm64/sm64_geolayout_writer.py
@@ -1347,7 +1347,7 @@ def processMesh(
         alphabeticalChildren = getSwitchChildren(obj)
         for i in range(len(alphabeticalChildren)):
             childObj = alphabeticalChildren[i]
-            if i == 0:  # Outside room system
+            if i == 0 and addRooms:  # Outside room system
                 # TODO: Allow users to specify whether this should be rendered before or after rooms (currently, it is after)
                 processMesh(
                     fModel,


### PR DESCRIPTION
Fixes switch nodes in object exports to be consistent with how armature exports behave. The normal room logic (first child always renders) still applies to level exports using the room system.