### PR TITLE
[OoT] Fix/workaround decomp extracting params macroified

### DIFF
--- a/fast64_internal/z64/exporter/scene/actors.py
+++ b/fast64_internal/z64/exporter/scene/actors.py
@@ -40,6 +40,24 @@ class TransitionActor(Actor):
             + ("\n" + indent + "},\n")
         )
 
+def split_c_on_commas(s: str):
+    parts: list[str] = []
+    part = ""
+    parens_depth = 0
+    for c in s:
+        if c == "(":
+            parens_depth += 1
+        if c == ")":
+            parens_depth -= 1
+            if parens_depth < 0:
+                parens_depth = 0
+        if c == "," and parens_depth == 0:
+            parts.append(part)
+            part = ""
+        else:
+            part += c
+    parts.append(part)
+    return parts
 
 @dataclass
 class SceneTransitionActors:
@@ -116,14 +134,14 @@ class SceneTransitionActors:
             if entry == "":
                 continue
 
-            params = entry.replace("{", "").replace("}", "").split(",")
+            params = split_c_on_commas(entry.replace("{", "").replace("}", ""))
 
             # trailing commas
             for p in params:
                 if p == "":
                     params.remove(p)
 
-            assert len(params) == 10
+            assert len(params) == 10, entry
             trans_actor = TransitionActor()
             trans_actor.name = "(unset)"
             trans_actor.id = params[4]

--- a/fast64_internal/z64/exporter/scene/actors.py
+++ b/fast64_internal/z64/exporter/scene/actors.py
@@ -40,6 +40,7 @@ class TransitionActor(Actor):
             + ("\n" + indent + "},\n")
         )
 
+
 def split_c_on_commas(s: str):
     parts: list[str] = []
     part = ""
@@ -58,6 +59,7 @@ def split_c_on_commas(s: str):
             part += c
     parts.append(part)
     return parts
+
 
 @dataclass
 class SceneTransitionActors:

--- a/fast64_internal/z64/importer/actor.py
+++ b/fast64_internal/z64/importer/actor.py
@@ -25,7 +25,7 @@ def set_actor_params(actorProp, actor_id, actor_params):
         try:
             actorProp.set_param_value(actor_params, "Params")
         except:
-            print("Failed to parse params " + actor.params + " for actor " + actor_id + ":")
+            print("Failed to parse params " + actor_params + " for actor " + actor_id + ":")
             traceback.print_exc()
             print("Defaulting to custom")
             actorProp.actor_id = "Custom"

--- a/fast64_internal/z64/importer/actor.py
+++ b/fast64_internal/z64/importer/actor.py
@@ -1,4 +1,5 @@
 import re
+import traceback
 import bpy
 
 from ...utility import parentObject, hexOrDecInt
@@ -17,6 +18,21 @@ from .utility import (
     handleActorWithRotAsParam,
     unsetAllHeadersExceptSpecified,
 )
+
+
+def set_actor_params(actorProp, actor_id, actor_params):
+    if actorProp.actor_id != "Custom":
+        try:
+            actorProp.set_param_value(actor_params, "Params")
+        except:
+            print("Failed to parse params " + actor.params + " for actor " + actor_id + ":")
+            traceback.print_exc()
+            print("Defaulting to custom")
+            actorProp.actor_id = "Custom"
+            actorProp.actor_id_custom = actor_id
+            actorProp.params_custom = actor_params
+    else:
+        actorProp.params_custom = actor_params
 
 
 def parseTransActorList(
@@ -66,10 +82,7 @@ def parseTransActorList(
 
             actorProp = transActorProp.actor
             setCustomProperty(actorProp, "actor_id", actor.id, game_data.z64.actors.ootEnumActorID)
-            if actorProp.actor_id != "Custom":
-                actorProp.params = actor.params
-            else:
-                actorProp.params_custom = actor.params
+            set_actor_params(actorProp, actor.id, actor.params)
             handleActorWithRotAsParam(actorProp, actor.id, rotation)
             unsetAllHeadersExceptSpecified(actorProp.headerSettings, headerIndex)
 
@@ -147,10 +160,7 @@ def parseSpawnList(
             spawnProp.customActor = actorID != "ACTOR_PLAYER"
             actorProp = spawnProp.actor
             setCustomProperty(actorProp, "actor_id", actorID, game_data.z64.actors.ootEnumActorID)
-            if actorProp.actor_id != "Custom":
-                actorProp.params = actorParam
-            else:
-                actorProp.params_custom = actorParam
+            set_actor_params(actorProp, actorID, actorParam)
             handleActorWithRotAsParam(actorProp, actorID, rotation)
             unsetAllHeadersExceptSpecified(actorProp.headerSettings, headerIndex)
 
@@ -188,10 +198,7 @@ def parseActorList(
             actorProp = actorObj.ootActorProperty
 
             setCustomProperty(actorProp, "actor_id", actorID, game_data.z64.actors.ootEnumActorID)
-            if actorProp.actor_id != "Custom":
-                actorProp.params = actorParam
-            else:
-                actorProp.params_custom = actorParam
+            set_actor_params(actorProp, actorID, actorParam)
             handleActorWithRotAsParam(actorProp, actorID, rotation)
             unsetAllHeadersExceptSpecified(actorProp.headerSettings, headerIndex)
 

--- a/fast64_internal/z64/utility.py
+++ b/fast64_internal/z64/utility.py
@@ -845,7 +845,9 @@ def getEvalParamsInt(input: str):
     try:
         return _eval(node.body)
     except:
-        print("WARNING: something wrong happened:", traceback.print_exc())
+        print("WARNING: something wrong happened:")
+        print("input:", input)
+        traceback.print_exc()
         return None
 
 


### PR DESCRIPTION
Decomp recently started extracting params macroified like `ENDOOR_PARAMS_NODATA(DOOR_ROOMLOAD, false)` instead of as just raw hex `0x003F`
for example this is an excerpt from `extracted/gc-eu-mq-dbg/assets/scenes/dungeons/Bmori1/Bmori1_scene_02000090_TransitionActorEntryList.inc.c`:
```c
    {
        {
            // { room, bgCamIndex }
            { 11, -1 },
            { 8, -1 },
        }, // sides
        ACTOR_EN_DOOR,
        {  -1502,    523,  -1864 }, // pos
        -0x8000, // rotY
        ENDOOR_PARAMS_NODATA(DOOR_ROOMLOAD, false) /* 0x003F */, // params
    }, // 4
```

This breaks fast64 importing for two unrelated reasons:
- fast64 does not expect additional commas in each entry, so I introduced `split_c_on_commas` which splits on commas but ignoring commas inside parentheses
- fast64 expects to be able to parse the params; this is worked around

The workaround for the second point is to try set the params value, and if it fails then fallback to using the actor as "custom", setting the custom actor id and custom params.