### PR TITLE
Update black-lint GHA

### DIFF
--- a/.github/workflows/black-lint.yml
+++ b/.github/workflows/black-lint.yml
@@ -9,5 +9,5 @@ jobs:
     permissions: {} # Remove all permissions
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: psf/black@23.12.1


### PR DESCRIPTION
For details see the warning at e.g. https://github.com/Fast-64/fast64/actions/runs/22946825360/job/66601186553#step:7:2
TLDR we must update actions/checkout