### PR TITLE
Fix #688 crash

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -389,6 +389,13 @@ def upgrade_scene_props_node():
 
 @bpy.app.handlers.persistent
 def after_load(_a, _b):
+    # Doing some operations immediately on file load can crash blender in specific situations,
+    # so delay the post-load code execution.
+    # (note if register() is called without a delay the function just runs immediately, so we need any non-zero delay)
+    bpy.app.timers.register(after_load_impl, 0.001)
+
+
+def after_load_impl():
     game_data.update(bpy.context.scene.gameEditorMode)
 
     settings = bpy.context.scene.fast64.settings


### PR DESCRIPTION
Fixes #688 

Blender fails this assert here
https://projects.blender.org/blender/blender/src/tag/v4.5.8/source/blender/blenkernel/intern/node.cc#L451
which makes it seem like the data is inconsistent. It gave me the idea that since fast64 is running this code on file load, maybe the data is not fully loaded or upgraded yet by blender. So I tried delaying the code slightly (the exact delay doesn't matter, it just needs to be past the `wm_file_read_post` context I suppose), and it fixed the crash