### PR TITLE
[OoT] Fix include reading for DL imports

### DIFF
--- a/fast64_internal/z64/animation/importer/functions.py
+++ b/fast64_internal/z64/animation/importer/functions.py
@@ -69,7 +69,7 @@ def ootImportNonLinkAnimationC(armatureObj, filepath, animName, actorScale, isCu
     animData = getImportData([filepath])
     if not isCustomImport:
         basePath = bpy.path.abspath(bpy.context.scene.ootDecompPath)
-        animData = ootGetIncludedAssetData(basePath, [filepath], animData) + animData
+        animData = ootGetIncludedAssetData([basePath], [filepath], animData) + animData
 
     matchResult = re.search(re.escape(animName) + r"\s*=\s*\{(.*?)\}\s*;", animData, re.DOTALL | re.MULTILINE)
 
@@ -195,8 +195,8 @@ def ootImportLinkAnimationC(
     animData = getImportData([animFilepath])
     if not isCustomImport:
         basePath = bpy.path.abspath(bpy.context.scene.ootDecompPath)
-        animHeaderData = ootGetIncludedAssetData(basePath, [animHeaderFilepath], animHeaderData) + animHeaderData
-        animData = ootGetIncludedAssetData(basePath, [animFilepath], animData) + animData
+        animHeaderData = ootGetIncludedAssetData([basePath], [animHeaderFilepath], animHeaderData) + animHeaderData
+        animData = ootGetIncludedAssetData([basePath], [animFilepath], animData) + animData
 
     matchResult = re.search(
         re.escape(animHeaderName) + r"\s*=\s*\{(.*?)\}\s*;", animHeaderData, re.DOTALL | re.MULTILINE

--- a/fast64_internal/z64/f3d/operators.py
+++ b/fast64_internal/z64/f3d/operators.py
@@ -172,7 +172,17 @@ class OOT_ImportDL(Operator):
 
             scale = None
             if not isCustomImport:
-                filedata = ootGetIncludedAssetData(basePath, paths, filedata) + filedata
+                filedata = (
+                    ootGetIncludedAssetData(
+                        [
+                            basePath,
+                            str(Path(basePath) / context.scene.fast64.oot.get_extracted_path()),
+                        ],
+                        paths,
+                        filedata,
+                    )
+                    + filedata
+                )
 
                 if overlayName is not None:
                     ootReadTextureArrays(basePath, overlayName, name, f3dContext, False, flipbookArrayIndex2D)

--- a/fast64_internal/z64/model_classes.py
+++ b/fast64_internal/z64/model_classes.py
@@ -42,7 +42,7 @@ from .utility import is_hackeroot
 
 
 # read included asset data
-def ootGetIncludedAssetData(basePath: str, currentPaths: list[str], data: str) -> str:
+def ootGetIncludedAssetData(basePaths: list[str], currentPaths: list[str], data: str) -> str:
     includeData = ""
     searchedPaths = currentPaths[:]
 
@@ -50,7 +50,15 @@ def ootGetIncludedAssetData(basePath: str, currentPaths: list[str], data: str) -
 
     # search assets
     for includeMatch in re.finditer(r"\#include\s*\"(assets/objects/(.*?)\.h)\"", data):
-        h_p = Path(basePath) / includeMatch.group(1)
+        h_p = None
+        for basePath in basePaths:
+            candidate_h_p = Path(basePath) / includeMatch.group(1)
+            if candidate_h_p.exists():
+                h_p = candidate_h_p
+                break
+        if h_p is None:
+            print("Could not find included file:", includeMatch.group(1))
+            continue
         print("", str(h_p))
         includeData += getImportData([str(h_p)]) + "\n"
         for path_p in h_p.parent.glob("*.c"):

--- a/fast64_internal/z64/skeleton/importer/functions.py
+++ b/fast64_internal/z64/skeleton/importer/functions.py
@@ -316,7 +316,7 @@ def ootImportSkeletonC(basePath: str, importSettings: OOTSkeletonImportSettings)
 
     skeletonData = getImportData(filepaths)
     if overlayName is not None or isLink:
-        skeletonData = ootGetIncludedAssetData(basePath, filepaths, skeletonData) + skeletonData
+        skeletonData = ootGetIncludedAssetData([basePath], filepaths, skeletonData) + skeletonData
 
     skel_info = ootGetSkeleton(skeletonData, skeletonName, False)
     assert skel_info is not None

--- a/fast64_internal/z64/texture_array.py
+++ b/fast64_internal/z64/texture_array.py
@@ -29,7 +29,7 @@ def ootReadTextureArrays(
     else:
         actorData = ootGetLinkData(basePath)
         currentPaths = [os.path.join(basePath, f"src/code/z_player_lib.c")]
-    actorData = ootGetIncludedAssetData(basePath, currentPaths, actorData) + actorData
+    actorData = ootGetIncludedAssetData([basePath], currentPaths, actorData) + actorData
 
     actorData = removeComments(actorData)
 


### PR DESCRIPTION
fast64 was not looking in extracted/VERSION/ for DL imports, causing e.g. imports of Link DLs like `gLinkAdultLeftHandHoldingMasterSwordNearDL` to fail due to not finding eg `gHilite1Tex_WIDTH`

The fix is to pass a list to `ootGetIncludedAssetData` as `basePaths` instead of the previously singular `basePath` which basically corresponds to the repo include path

This fix could be applied to other import things too (like anim and skeleton import) but it's not necessary at the moment so I'd rather not touch anything there :^)

I did not test this super thoroughly, I'm just assuming it didn't break anything