### PR TITLE
[SM64] Fix bad FModel names

### DIFF
--- a/fast64_internal/f3d/f3d_gbi.py
+++ b/fast64_internal/f3d/f3d_gbi.py
@@ -2341,7 +2341,7 @@ class FModel:
         DLFormat: "DLFormat",
         matWriteMethod: GfxMatWriteMethod,
     ):
-        self.name = name  # used for texture prefixing
+        self.name = toAlnum(name)  # used for texture prefixing
         # dict of light name : Lights
         self.lights: dict[str, Lights] = {}
         # dict of (texture, (texture format, palette format)) : FImage

--- a/fast64_internal/sm64/sm64_geolayout_writer.py
+++ b/fast64_internal/sm64/sm64_geolayout_writer.py
@@ -628,7 +628,7 @@ def exportGeolayoutArmatureC(
     DLFormat,
 ):
     geolayoutGraph, fModel = convertArmatureToGeolayout(
-        armatureObj, obj, convertTransformMatrix, camera, dirName, DLFormat, not savePNG
+        armatureObj, obj, convertTransformMatrix, camera, toAlnum(dirName), DLFormat, not savePNG
     )
 
     return saveGeolayoutC(
@@ -664,7 +664,7 @@ def exportGeolayoutObjectC(
     DLFormat,
 ):
     geolayoutGraph, fModel = convertObjectToGeolayout(
-        obj, convertTransformMatrix, True, dirName, None, None, DLFormat, not savePNG
+        obj, convertTransformMatrix, True, toAlnum(dirName), None, None, DLFormat, not savePNG
     )
 
     return saveGeolayoutC(


### PR DESCRIPTION
Normalize names before passing them to convert geolayout, but also normalize in the fmodel class like geolayout does.