### PR TITLE
Fixup after_load handler

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -392,7 +392,7 @@ def after_load(_a, _b):
     # Doing some operations immediately on file load can crash blender in specific situations,
     # so delay the post-load code execution.
     # (note if register() is called without a delay the function just runs immediately, so we need any non-zero delay)
-    bpy.app.timers.register(after_load_impl, 0.001)
+    bpy.app.timers.register(after_load_impl, first_interval=0.001)
 
 
 def after_load_impl():


### PR DESCRIPTION
Fixes bug introduced in #689
apparently the delay passed to `bpy.app.timers.register` needs to be a keyword argument, at least in Blender 4.5.9.
I tested this in 3.2.2, 4.5.9 and 5.1.0