### PR TITLE
f3d_parser: fix ast.Str, ast.Num deprecated

### DIFF
--- a/fast64_internal/f3d/f3d_parser.py
+++ b/fast64_internal/f3d/f3d_parser.py
@@ -371,13 +371,16 @@ def math_eval(s, f3d):
     def _eval(node):
         if isinstance(node, ast.Expression):
             return _eval(node.body)
-        elif isinstance(node, ast.Str):
-            return node.s
+        elif isinstance(node, ast.Constant):
+            if isinstance(node.value, str):
+                return node.value
+            elif isinstance(node.value, int):
+                return int(node.value)
+            else:
+                raise Exception("Unsupported constant type {}".format(type(node.value)))
         elif isinstance(node, ast.Name):
             if hasattr(f3d, node.id):
                 return getattr(f3d, node.id)
-        elif isinstance(node, ast.Num):
-            return node.n
         elif isinstance(node, ast.UnaryOp):
             if isinstance(node.op, ast.USub):
                 return -1 * _eval(node.operand)


### PR DESCRIPTION
Those are deprecated since python 3.8 and removed in python 3.14

ast.Constant is used for all constants since python 3.8, and the earliest blender version we support (3.2) ships python 3.10