### PR TITLE
[OoT] Fix room shape image imports

### DIFF
--- a/fast64_internal/z64/importer/room_shape.py
+++ b/fast64_internal/z64/importer/room_shape.py
@@ -49,6 +49,7 @@ def parseBGImage(roomHeader: OOTRoomHeaderProperty, params: list[str], sharedSce
     bgImage = roomHeader.bgImageList.add()
     bgImage.otherModeFlags = params[10]
     bgName = f"{params[3]}.jpg"
+    bgName = bgName.removeprefix("&")
     image = bpy.data.images.load(os.path.join(bpy.path.abspath(sharedSceneData.scenePath), f"{bgName}"))
     bgImage.image = image
 
@@ -66,6 +67,7 @@ def parseBGImageList(
         bgImage.otherModeFlags = params[9]
 
         bgName = params[2]
+        bgName = bgName.removeprefix("&")
         image = bpy.data.images.load(os.path.join(bpy.path.abspath(sharedSceneData.scenePath), f"{bgName}.jpg"))
         bgImage.image = image
 


### PR DESCRIPTION
New assets system tm has an unnecessary `&` in front of the jfif symbol, which these changes strip.