### PR TITLE
Blender 5.1 support: fix vertex colors import and bump max version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Fast64
 
-This requires Blender 3.2 - 5.0.1. Blender 4.0+ is recommended.
+This requires Blender 3.2 - 5.1.2. Blender 4.0+ is recommended.
 
 Forked from [kurethedead/fast64 on BitBucket](https://bitbucket.org/kurethedead/fast64/src).
 

--- a/fast64_internal/f3d/f3d_parser.py
+++ b/fast64_internal/f3d/f3d_parser.py
@@ -1902,10 +1902,10 @@ class F3DContext:
             # There will be one loop for every vertex
             uv_layer[i].uv = self.verts[i].uv
 
-        # The mesh.vertex_colors is deprecated since a long time,
+        # The mesh.vertex_colors API is deprecated since Blender 3.2,
         # and its usage by fast64 here breaks in Blender 5.1 somehow.
         # (can't replicate in simple cases)
-        if bpy.app.version < (5, 1, 0):
+        if bpy.app.version < (3, 2, 0):
             color_layer = mesh.vertex_colors.new(name="Col").data
             for i in range(len(mesh.loops)):
                 color_layer[i].color = self.verts[i].rgb.to_4d()

--- a/fast64_internal/f3d/f3d_parser.py
+++ b/fast64_internal/f3d/f3d_parser.py
@@ -1864,7 +1864,7 @@ class F3DContext:
             raise PluginError("Attempting to delete material context that is None.")
 
     # if deleteMaterialContext is False, then manually call self.deleteMaterialContext() later.
-    def createMesh(self, obj, removeDoubles, importNormals, callDeleteMaterialContext: bool):
+    def createMesh(self, obj: bpy.types.Object, removeDoubles, importNormals, callDeleteMaterialContext: bool):
         mesh = obj.data
         if len(self.verts) % 3 != 0:
             print(len(self.verts))
@@ -1902,13 +1902,26 @@ class F3DContext:
             # There will be one loop for every vertex
             uv_layer[i].uv = self.verts[i].uv
 
-        color_layer = mesh.vertex_colors.new(name="Col").data
-        for i in range(len(mesh.loops)):
-            color_layer[i].color = self.verts[i].rgb.to_4d()
+        # The mesh.vertex_colors is deprecated since a long time,
+        # and its usage by fast64 here breaks in Blender 5.1 somehow.
+        # (can't replicate in simple cases)
+        if bpy.app.version < (5, 1, 0):
+            color_layer = mesh.vertex_colors.new(name="Col").data
+            for i in range(len(mesh.loops)):
+                color_layer[i].color = self.verts[i].rgb.to_4d()
 
-        alpha_layer = mesh.vertex_colors.new(name="Alpha").data
-        for i in range(len(mesh.loops)):
-            alpha_layer[i].color = [self.verts[i].alpha] * 3 + [1]
+            alpha_layer = mesh.vertex_colors.new(name="Alpha").data
+            for i in range(len(mesh.loops)):
+                alpha_layer[i].color = [self.verts[i].alpha] * 3 + [1]
+        else:
+            col_attr = mesh.color_attributes.new("Col", "BYTE_COLOR", "CORNER")
+            for i in range(len(mesh.loops)):
+                col_attr.data[i].color = (*self.verts[i].rgb, 1)
+
+            alpha_attr = mesh.color_attributes.new("Alpha", "BYTE_COLOR", "CORNER")
+            for i in range(len(mesh.loops)):
+                a = self.verts[i].alpha
+                alpha_attr.data[i].color = (a, a, a, 1)
 
         if bpy.context.mode != "OBJECT":
             bpy.ops.object.mode_set(mode="OBJECT")


### PR DESCRIPTION
While testing 5.1.2 I found out that for some reason vertex colors were no longer imported correctly. I still don't know why the deprecated vertex_colors API breaks in how fast64 uses it (I can't replicate it with simpler code)

With that fix oot seems to be working fine on all fronts so bumping the recommended blender version range max to 5.1.2 (the last of the 5.1 releases it seems for now). Testing for other games welcome.