### PR TITLE
[OoT] Fix custom-path OoT/MM DL import not reading object header

### DIFF
--- a/fast64_internal/z64/utility.py
+++ b/fast64_internal/z64/utility.py
@@ -493,7 +493,9 @@ def ootGetObjectPath(isCustomExport: bool, exportPath: str, folderName: str, inc
 def ootGetObjectHeaderPath(isCustomExport: bool, exportPath: str, folderName: str, include_extracted: bool) -> str:
     extracted = bpy.context.scene.fast64.oot.get_extracted_path() if include_extracted else "."
     if isCustomExport:
-        filepath = exportPath
+        # The custom .c references _WIDTH/_HEIGHT defines from its sibling .h, read that too.
+        root, ext = os.path.splitext(exportPath)
+        filepath = root + ".h" if ext == ".c" else exportPath
     else:
         filepath = os.path.join(
             ootGetPath(exportPath, isCustomExport, f"{extracted}/assets/objects/", folderName, False, False),


### PR DESCRIPTION
The custom-path import reads the given .c file but never reads the matching .h. 
OoT/MM objects define the texture width/height in the .h, so the import fails:

    AssertionError: match is null for object_toki_objects_Tex_000000_WIDTH

ootGetObjectHeaderPath returned the .c path unchanged for custom imports, so OOT_ImportDL read the .c twice and the header was never loaded. This derives the .h next to the .c instead.

Tested with object_toki_objects (DL object_toki_objects_DL_000880) from an ntsc-1.2 extract via custom path: errors as above before the change, imports correctly after.

The skeleton importer uses the same helper, so custom skeleton import is fixed too.