### PR TITLE
[bugfix] Animation action names include actor name in variable

### DIFF
--- a/fast64_internal/sm64/animation/exporting.py
+++ b/fast64_internal/sm64/animation/exporting.py
@@ -281,7 +281,7 @@ def to_animation_class(
             values_reference, indice_reference = action_props.values_table, action_props.indices_table
     else:
         pairs = get_animation_pairs(blender_to_sm64_scale, [action], obj, quick_read)[action]
-        animation.data = to_data_class(pairs, action_props.get_name(action, dma), animation.file_name)
+        animation.data = to_data_class(pairs, action_props.get_name(actor_name, action, dma), animation.file_name)
         values_reference = animation.data.values_reference
         indice_reference = animation.data.indice_reference
     bone_count = len(get_anim_owners(obj))
@@ -360,7 +360,7 @@ def to_table_element_class(
         if action in action_pairs and action not in data_dict:
             data_dict[action] = to_data_class(
                 action_pairs[action],
-                action_props.get_name(action, dma),
+                action_props.get_name(actor_name, action, dma),
                 action_props.get_file_name(action, export_type, dma),
             )
         data = data_dict[action]

--- a/fast64_internal/sm64/animation/properties.py
+++ b/fast64_internal/sm64/animation/properties.py
@@ -429,10 +429,10 @@ class SM64_ActionAnimProperty(PropertyGroup):
     def dma_name(self):
         return get_dma_anim_name([header.table_index for header in self.headers])
 
-    def get_name(self, action: Action, dma=False) -> str:
+    def get_name(self, actor_name: str, action: Action, dma=False) -> str:
         if dma:
             return self.dma_name
-        return toAlnum(f"anim_{action.name}")
+        return toAlnum(f"{actor_name}_anim_{action.name}")
 
     def get_file_name(self, action: Action, export_type: str, dma=False) -> str:
         if not export_type in {"C", "Insertable Binary"}:


### PR DESCRIPTION
Bug with animation names only including name of the action lead to duplicate names, adding the actor name provides sufficient uniqueness for var naming.