### PR TITLE
[OoT] fix draw layer suffix always being present

### DIFF
--- a/fast64_internal/f3d/f3d_gbi.py
+++ b/fast64_internal/f3d/f3d_gbi.py
@@ -2335,7 +2335,7 @@ class FPaletteKey:
 
 
 class FMesh:
-    def __init__(self, name, DLFormat):
+    def __init__(self, name, DLFormat, drawLayer=None):
         self.name = name
         # GfxList
         self.draw = GfxList(name, GfxListTag.Draw, DLFormat)
@@ -2345,6 +2345,7 @@ class FMesh:
         self.cullVertexList = None
         self.draw_overrides: list[GfxList] = []
         self.DLFormat = DLFormat
+        self.drawLayer = drawLayer
 
         # Used to avoid consecutive calls to the same material if unnecessary
         self.currentFMaterial = None
@@ -2405,8 +2406,7 @@ class FMesh:
         for triGroup in self.triangleGroups:
             staticData.append(triGroup.to_c(f3d, gfxFormatter))
 
-        draw_layer = "Opaque" if "Opaque" in self.name else "Transparent" if "Transparent" in self.name else "Overlay"
-        dynamicData = gfxFormatter.drawToC(f3d, self.draw, layer=draw_layer)
+        dynamicData = gfxFormatter.drawToC(f3d, self.draw, layer=self.drawLayer)
 
         for cmd_list in self.draw_overrides:
             dynamicData.append(cmd_list.to_c(f3d))
@@ -2541,7 +2541,7 @@ class FModel:
                 if final_name in self.meshes:
                     final_name = f"{base_name}_{i:03}"
         checkUniqueBoneNames(self, final_name, name)
-        self.meshes[final_name] = mesh = meshOverride(final_name, self.DLFormat)
+        self.meshes[final_name] = mesh = meshOverride(final_name, self.DLFormat, drawLayer=drawLayer)
         self.onAddMesh(mesh, contextObj)
         return mesh
 

--- a/fast64_internal/sm64/sm64_geolayout_writer.py
+++ b/fast64_internal/sm64/sm64_geolayout_writer.py
@@ -2764,7 +2764,7 @@ def saveSkinnedMeshByMaterial(
     lastMaterialName = None
 
     # Load parent group vertices
-    fSkinnedMesh = FMesh(skinnedMeshName, fModel.DLFormat)
+    fSkinnedMesh = FMesh(skinnedMeshName, fModel.DLFormat, drawLayer=drawLayer)
 
     # Load verts into buffer by material.
     # It seems like material setup must be done BEFORE triangles are drawn.
@@ -2808,7 +2808,7 @@ def saveSkinnedMeshByMaterial(
     # End skinned mesh vertices.
     fSkinnedMesh.draw.commands.append(SPEndDisplayList())
 
-    fMesh = FMesh(meshName, fModel.DLFormat)
+    fMesh = FMesh(meshName, fModel.DLFormat, drawLayer=drawLayer)
 
     # Load current group vertices, then draw commands by material
     existingVertData, matRegionDict = convertVertDictToArray(notInGroupVertArray)

--- a/fast64_internal/z64/exporter/skeleton/functions.py
+++ b/fast64_internal/z64/exporter/skeleton/functions.py
@@ -100,7 +100,7 @@ def ootProcessBone(
             )
         else:
             # Dummy data, only used so that name is set correctly
-            mesh = FMesh(bone.ootBone.customDLName, DLFormat.Static)
+            mesh = FMesh(bone.ootBone.customDLName, DLFormat.Static, drawLayer=drawLayer)
 
     DL = None
     if mesh is not None:

--- a/fast64_internal/z64/f3d/operators.py
+++ b/fast64_internal/z64/f3d/operators.py
@@ -32,12 +32,16 @@ from ..utility import (
 
 
 class OOTF3DGfxFormatter(OOTGfxFormatter):
-    def __init__(self, scrollMethod):
+    def __init__(self, scrollMethod, use_draw_layer_suffix=True):
         OOTGfxFormatter.__init__(self, scrollMethod)
+        self.use_draw_layer_suffix = use_draw_layer_suffix
 
     # override the function to give a custom name to the DL array
     def drawToC(self, f3d, gfxList, layer: Optional[str] = None):
-        return gfxList.to_c(f3d, name_override=f"{gfxList.name}_{layer.lower()}_dl")
+        name_override = None
+        if self.use_draw_layer_suffix and layer is not None:
+            name_override = f"{gfxList.name}_{layer.lower()}_dl"
+        return gfxList.to_c(f3d, name_override=name_override)
 
 
 def ootConvertMeshToC(
@@ -71,7 +75,11 @@ def ootConvertMeshToC(
             triConverterInfo, fModel, obj, finalTransform, fModel.name, not saveTextures, False, "oot"
         )
 
-        # Since we provide a draw layer override, there should only be one fMesh.
+        # fMeshes is a dict where keys are draw layer names and values are the mesh for that draw layer.
+        # If there is more than one mesh we need to append a draw layer suffix on export to the original mesh name,
+        # to avoid exporting the same name twice.
+        use_draw_layer_suffix = len(fMeshes) > 1
+
         for fMesh in fMeshes.values():
             fMesh.draw.name = obj_name
 
@@ -96,7 +104,8 @@ def ootConvertMeshToC(
     path = ootGetPath(exportPath, isCustomExport, "assets/objects/", folderName, False, True)
     includeDir = settings.customAssetIncludeDir if settings.isCustom else f"assets/objects/{folderName}"
     exportData = fModel.to_c(
-        TextureExportSettings(False, saveTextures, includeDir, path), OOTF3DGfxFormatter(ScrollMethod.Vertex)
+        TextureExportSettings(False, saveTextures, includeDir, path),
+        OOTF3DGfxFormatter(ScrollMethod.Vertex, use_draw_layer_suffix=use_draw_layer_suffix),
     )
 
     data.append(exportData.all())

--- a/fast64_internal/z64/model_classes.py
+++ b/fast64_internal/z64/model_classes.py
@@ -378,7 +378,7 @@ class OOTVtxList(VtxList):
 class SkinAnimData(FMesh):
     """subclass of FMesh for exporting SkinAnimatedLimbData"""
 
-    def __init__(self, name: str, DLFormat: DLFormat, drawLayer = None) -> None:
+    def __init__(self, name: str, DLFormat: DLFormat, drawLayer=None) -> None:
         super().__init__(name, DLFormat, drawLayer=drawLayer)
         self.namePrefix = name.partition("mesh")[0]
         self.name = self.namePrefix + "SkinAnimatedLimbData"

--- a/fast64_internal/z64/model_classes.py
+++ b/fast64_internal/z64/model_classes.py
@@ -378,8 +378,8 @@ class OOTVtxList(VtxList):
 class SkinAnimData(FMesh):
     """subclass of FMesh for exporting SkinAnimatedLimbData"""
 
-    def __init__(self, name: str, DLFormat: DLFormat) -> None:
-        super().__init__(name, DLFormat)
+    def __init__(self, name: str, DLFormat: DLFormat, drawLayer = None) -> None:
+        super().__init__(name, DLFormat, drawLayer=drawLayer)
         self.namePrefix = name.partition("mesh")[0]
         self.name = self.namePrefix + "SkinAnimatedLimbData"
         self.vtxList: OOTVtxList = OOTVtxList("(Vtx*)0x08000000")


### PR DESCRIPTION
# Context

OoT DList exporter

Fast64 allows setting draw layers by material. This splits the mesh by material on export, between opaque/translucent/overlay draw layers, writing out different display lists.

It was reported last year https://github.com/Fast-64/fast64/issues/602 that fast64 however was writing those different display lists using the same name, obviously causing errors on compile due to the duplicate symbol name.

The issue was fixed in https://github.com/Fast-64/fast64/pull/605 by appending a "_drawlayer_dl" suffix to the written draw layer display list

However there have been complaints since then about this behavior since you can't name a single-draw-layer-using mesh properly (like `gMyCubeDL`) and have it be exported under that name, it would export as eg `gMyCubeDL_opaque_dl`

# This PR

This PR makes the suffix be omitted when a mesh is composed of a single draw layer. When several draw layers are present, it uses the draw layer suffixes.

# Testing

I tested:

- DL export with a single draw layer
- DL export with two draw layers
- deku tree import-export
- gerudo skeleton import-export
- epona skinskeleton import-export