### PR TITLE
[OoT] Add support for legacy decomp to SkinLimbs

### DIFF
--- a/fast64_internal/z64/animation/importer/functions.py
+++ b/fast64_internal/z64/animation/importer/functions.py
@@ -30,7 +30,7 @@ def binangToRadians(value):
 
 
 def getFrameData(filepath: str, animData: str, frameDataName: str):
-    matchResult = re.search(re.escape(frameDataName) + "\s*\[.*?\]\s*=\s*\{([^\}]*)\}", animData, re.DOTALL)
+    matchResult = re.search(re.escape(frameDataName) + r"\s*\[[^\;]*?\]\s*=\s*\{([^\}]*)\}", animData, re.DOTALL)
     if matchResult is None:
         raise PluginError("Cannot find animation frame data named " + frameDataName + " in " + filepath)
     data = matchResult.group(1)

--- a/fast64_internal/z64/model_classes.py
+++ b/fast64_internal/z64/model_classes.py
@@ -5,7 +5,7 @@ import re
 from bpy.types import MeshLoop, MeshLoopTriangle
 import mathutils
 
-from enum import Enum
+from enum import Enum, IntEnum
 from typing import Union, Optional, NamedTuple, Generic, TypeVar
 from collections import defaultdict
 from dataclasses import dataclass, field
@@ -801,15 +801,15 @@ class LimbType(str, Enum):
     SKIN = "Skin"
 
 
-class LimbSkinType(str, Enum):
+class LimbSkinType(IntEnum):
     # Contains no mesh data, segment is NULL
-    EMPTY = "0"
+    EMPTY = 0
     # Contains the smooth skinned mesh data, segment is SkinAnimatedLimbData
-    SKIN_LIMB_TYPE_ANIMATED = "SKIN_LIMB_TYPE_ANIMATED"
+    SKIN_LIMB_TYPE_ANIMATED = 4
     # Is a limb responsible for smooth skinned deformation, segment is NULL
-    SKINNED = "5"
+    SKINNED = 5
     # Functions like a StandardLimb, segment is DisplayList
-    SKIN_LIMB_TYPE_NORMAL = "SKIN_LIMB_TYPE_NORMAL"
+    SKIN_LIMB_TYPE_NORMAL = 11
 
 
 @dataclass(frozen=True)
@@ -960,7 +960,7 @@ class OOTF3DContext(F3DContext):
             if isinstance(bufferVert.groupIndex, int):
                 groupIndex = bufferVert.groupIndex
             else:
-                groupIndex = list(self.matrixData).index(bufferVert.groupIndex)
+                groupIndex = self.limbList.index(bufferVert.groupIndex)
             vert.addTransform(groupIndex, vert.position, 1.0)
 
         position = self.transformPosition(vert)

--- a/fast64_internal/z64/skeleton/importer/skinLimb_parser.py
+++ b/fast64_internal/z64/skeleton/importer/skinLimb_parser.py
@@ -21,13 +21,14 @@ def getSkinLimbRestPose(
 
 
 def parseSkinVertex(includeData: str, skinVertexName: str, vertexData: list[OOTVert]):
-    pattern = r"SkinVertex\s+?" + re.escape(skinVertexName) + r"\[\]\s+=\s+?{\s*#include (.*?)};"
+    pattern = r"SkinVertex\s+?" + re.escape(skinVertexName) + r"\[\]\s+=\s+?{\s*?(.*?)};"
     skinVertexData = re.search(pattern, includeData, re.DOTALL)
 
     if skinVertexData is None:
         raise PluginError("Cannot find SkinVertex named: " + skinVertexName)
-
-    data = get_include_data(skinVertexData.group(1), strip=True)
+    data = skinVertexData.group(1).replace("\n", "").replace(" ", "")
+    if "#include" in data:
+        data = get_include_data(skinVertexData.group(1), strip=True)
 
     verts: list[OOTVert] = []
     for skinVert in re.finditer(r"{(.*?)}", data, re.DOTALL):
@@ -50,13 +51,15 @@ def parseSkinVertex(includeData: str, skinVertexName: str, vertexData: list[OOTV
 def parseSkinTransformation(
     includeData: str, skinTransformName: str
 ) -> tuple[list[VertexTransform], list[VertexWeight[int]]]:
-    pattern = r"SkinTransformation\s+?" + re.escape(skinTransformName) + r"\[\]\s+=\s+?{\s*#include (.*?)};"
+    pattern = r"SkinTransformation\s+?" + re.escape(skinTransformName) + r"\[\]\s+=\s+?{\s*?(.*?)};"
     skinTransformData = re.search(pattern, includeData, re.DOTALL)
 
     if skinTransformData is None:
         raise PluginError("Cannot find SkinTransformation named: " + skinTransformName)
 
-    data = get_include_data(skinTransformData.group(1), strip=True)
+    data = skinTransformData.group(1).replace("\n", "").replace(" ", "")
+    if "#include" in data:
+        data = get_include_data(skinTransformData.group(1), strip=True)
     transforms: list[VertexTransform] = []
     weights: list[VertexWeight[int]] = []
 
@@ -73,33 +76,40 @@ def parseSkinTransformation(
 
 
 def parseSkinLimbModifs(includeData: str, modifName: str, vertexData: list[OOTVert]) -> None:
-    pattern = r"SkinLimbModif\s+?" + re.escape(modifName) + r"\[\]\s+=\s+?{\s*#include (.*?)};"
+    pattern = r"SkinLimbModif\s+?" + re.escape(modifName) + r"\[\]\s+=\s+?{\s*?(.*?)};"
     verts: list[OOTVert] = []
     modifData = re.search(pattern, includeData, re.DOTALL)
 
     if modifData is None:
         raise PluginError("Cannot find SkinLimbModif named: " + modifName)
 
-    data = get_include_data(modifData.group(1), strip=True)  # .split(",")
+    data = modifData.group(1).replace("\n", "").replace(" ", "")
+    if "#include" in data:
+        data = get_include_data(modifData.group(1), strip=True)  # .split(",")
 
-    for modif in re.finditer(r"{.*?}", data, re.DOTALL):
-        value = modif.group(0).split(",")
-        limbTransformations, groups = parseSkinTransformation(includeData, value[4])
-        verts = parseSkinVertex(includeData, value[3], vertexData)
+    for modif in re.finditer(r"{(.*?)}", data, re.DOTALL):
+        values = modif.group(1).split(",")
+        limbTransformations, groups = parseSkinTransformation(includeData, values[4])
+        verts = parseSkinVertex(includeData, values[3], vertexData)
 
         for vert in verts:
             vert.transforms = limbTransformations
 
 
 def parseSkinAnimatedLimbData(includeData: str, dataName: str) -> SkinAnimatedLimbData:
-    pattern = r"SkinAnimatedLimbData\s*?" + re.escape(dataName[1:]) + r"\s*?=\s*?{\s*?#include (.*?)};"
+    pattern = r"SkinAnimatedLimbData\s*?" + re.escape(dataName[1:]) + r"\s*?=\s*?{\s*?(.*?)};"
 
     animatedLimbText = re.search(pattern, includeData, re.DOTALL)
 
     if animatedLimbText is None:
         raise PluginError(f"Cannot find SkinAnimatedLimbData named: {dataName}")
 
-    data = get_include_data(animatedLimbText.group(1), strip=True).split(",")
+    if "#include" in animatedLimbText.group(0):
+        data = get_include_data(animatedLimbText.group(1), strip=True)
+    else:
+        data = animatedLimbText.group(1)
+
+    data = data.replace("\n", "").replace(" ", "").split(",")
 
     totalVtxCount = int(data[0])
     vertexData = [

--- a/fast64_internal/z64/skeleton/importer/skinLimb_parser.py
+++ b/fast64_internal/z64/skeleton/importer/skinLimb_parser.py
@@ -85,7 +85,7 @@ def parseSkinLimbModifs(includeData: str, modifName: str, vertexData: list[OOTVe
 
     data = modifData.group(1).replace("\n", "").replace(" ", "")
     if "#include" in data:
-        data = get_include_data(modifData.group(1), strip=True)  # .split(",")
+        data = get_include_data(modifData.group(1), strip=True)
 
     for modif in re.finditer(r"{(.*?)}", data, re.DOTALL):
         values = modif.group(1).split(",")

--- a/fast64_internal/z64/skeleton/utility.py
+++ b/fast64_internal/z64/skeleton/utility.py
@@ -3,8 +3,7 @@ import mathutils, bpy, os, re
 from typing import Optional
 from ...utility_anim import armatureApplyWithMesh
 from ..model_classes import OOTVertexGroupInfo, SkinLimbGroup, VertexWeight, LimbType, LimbSkinType
-from ..utility import checkForStartBone, getStartBone, getNextBone, ootStripComments, getSortedChildren
-from ...f3d.f3d_writer import MeshInfo
+from ..utility import checkForStartBone, getStartBone, getNextBone, ootStripComments, hexOrDecInt
 
 from ...utility import (
     PluginError,
@@ -171,7 +170,10 @@ def ootGetLimb(skeletonData, limbName, continueOnError):
         far_dl_name = matchResult.group(7)
     elif limbType == LimbType.SKIN:
         try:
-            skin_type = LimbSkinType(matchResult.group(6))
+            if matchResult.group(6) in LimbSkinType._member_names_:
+                skin_type = LimbSkinType[matchResult.group(6)]
+            else:
+                skin_type = LimbSkinType(hexOrDecInt(matchResult.group(6)))
         except ValueError:
             if continueOnError:
                 return None


### PR DESCRIPTION
Adds support for importing SkinLimbs from older versions of decomp. Mostly to allow importing Epona from MM decomp.

Tested:
- [x] Blender 4.5 deku tree import
- [x] Blender 4.5 temple of time import-export
- [x] Blender 4.5 `gGerudoRedSkel`, `gGerudoRedSpinAttackAnim` import-export
- [x] Blender 4.5 `gLinkAdultSkel` import-export
- [x] Blender 4.5 `gEponaSkel`, `gEponaWalkingAnim` import-export
- [x] Blender 4.5 `gBoulderFragmentsDL` import-export